### PR TITLE
Better error message for PHPSpec failure

### DIFF
--- a/project_tests.sh
+++ b/project_tests.sh
@@ -3,5 +3,5 @@ set -e
 
 : "${dependencies:?Need to set dependencies environment variable}"
 if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --no-interaction; else composer update --no-interaction; fi;
-(vendor/bin/phpspec run --format=junit > build/${dependencies}-phpspec.xml) && echo "PHPSpec tests passed - see build/phpspec.xml log"
+(vendor/bin/phpspec run --format=junit | tee build/${dependencies}-phpspec.xml) && echo "PHPSpec tests passed - see build/phpspec.xml log"
 vendor/bin/phpunit --log-junit="build/${dependencies}-phpunit.xml"


### PR DESCRIPTION
The failure was caused by the missing `build/` dir, but in this way we can see the output. PHPSpec cannot produce both XML and a readable output at the same time, so in this build we stick to the XML