### PR TITLE
Allow custom headers rather than trying to set a specific version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Usage
 
 The `eLife\ApiSdk\ApiClient` namespace provides separate clients for each part of the eLife API.
 
-Each method on an API client represents an endpoint. The method arguments are the arguments that the endpoint accepts, though the first argument is *always* the version of the JSON response that you will accept.
+Each method on an API client represents an endpoint.
+
+You can pass default headers to an API client, and/or to each API client method. You should provide an `Accept` header stating which versions you support.
 
 API clients always return instances of `GuzzleHttp\Promise\PromiseInterface`, which wrap instances of `eLife\ApiSdk\Result`, which in turn wrap the JSON response.
 
@@ -35,13 +37,14 @@ To list the Labs Experiment numbers that appear on the first page of the endpoin
 ```php
 use eLife\ApiSdk\ApiClient\LabsClient;
 use eLife\ApiSdk\HttpClient\Guzzle6HttpClient;
+use eLife\ApiSdk\MediaType;
 use GuzzleHttp\Client as Guzzle;
 
 $guzzle = new Guzzle(['base_uri' => 'https://api.elifesciences.org/']);
 $httpClient = new Guzzle6HttpClient($guzzle);
 $labsClient = new LabsClient($httpClient);
 
-var_dump($labsClient->listExperiments(1)->wait()->search('items[*].number'));
+var_dump($labsClient->listExperiments(['Accept' => new MediaType(LabsClient::TYPE_EXPERIMENT_LIST, 1)])->wait()->search('items[*].number'));
 ```
 
 ### Deprecation warnings

--- a/spec/ApiClient/BlogClientSpec.php
+++ b/spec/ApiClient/BlogClientSpec.php
@@ -17,30 +17,35 @@ final class BlogClientSpec extends ObjectBehavior
     {
         $this->httpClient = $httpClient;
 
-        $this->beConstructedWith($httpClient);
+        $this->beConstructedWith($httpClient, ['X-Foo' => 'bar']);
     }
 
     public function it_gets_an_article()
     {
         $request = new Request('GET', 'blog-articles/3',
-            ['Accept' => 'application/vnd.elife.blog-article+json; version=2']);
+            ['X-Foo' => 'bar', 'Accept' => 'application/vnd.elife.blog-article+json; version=2']);
         $response = new FulfilledPromise(new ArrayResult(new MediaType('application/vnd.elife.blog-article+json',
             2), ['foo' => ['bar', 'baz']]));
 
         $this->httpClient->send($request)->willReturn($response);
 
-        $this->getArticle(2, '3')->shouldBeLike($response);
+        $this->getArticle(['Accept' => 'application/vnd.elife.blog-article+json; version=2'], '3')
+            ->shouldBeLike($response)
+        ;
     }
 
     public function it_lists_articles()
     {
         $request = new Request('GET', 'blog-articles?page=1&per-page=20&order=desc&subject=cell-biology',
-            ['Accept' => 'application/vnd.elife.blog-article-list+json; version=2']);
+            ['X-Foo' => 'bar', 'Accept' => 'application/vnd.elife.blog-article-list+json; version=2']);
         $response = new FulfilledPromise(new ArrayResult(new MediaType('application/vnd.elife.blog-article-list+json',
             2), ['foo' => ['bar', 'baz']]));
 
         $this->httpClient->send($request)->willReturn($response);
 
-        $this->listArticles(2, 1, 20, true, 'cell-biology')->shouldBeLike($response);
+        $this->listArticles(['Accept' => 'application/vnd.elife.blog-article-list+json; version=2'],
+            1, 20, true,
+            'cell-biology')->shouldBeLike($response)
+        ;
     }
 }

--- a/spec/ApiClient/LabsClientSpec.php
+++ b/spec/ApiClient/LabsClientSpec.php
@@ -17,30 +17,34 @@ final class LabsClientSpec extends ObjectBehavior
     {
         $this->httpClient = $httpClient;
 
-        $this->beConstructedWith($httpClient);
+        $this->beConstructedWith($httpClient, ['X-Foo' => 'bar']);
     }
 
     public function it_gets_an_experiment()
     {
         $request = new Request('GET', 'labs-experiments/3',
-            ['Accept' => 'application/vnd.elife.labs-experiment+json; version=2']);
+            ['X-Foo' => 'bar', 'Accept' => 'application/vnd.elife.labs-experiment+json; version=2']);
         $response = new FulfilledPromise(new ArrayResult(new MediaType('application/vnd.elife.labs-experiment+json',
             2), ['foo' => ['bar', 'baz']]));
 
         $this->httpClient->send($request)->willReturn($response);
 
-        $this->getExperiment(2, 3)->shouldBeLike($response);
+        $this->getExperiment(['Accept' => 'application/vnd.elife.labs-experiment+json; version=2'], 3)
+            ->shouldBeLike($response)
+        ;
     }
 
     public function it_lists_experiments()
     {
         $request = new Request('GET', 'labs-experiments?page=1&per-page=20&order=desc',
-            ['Accept' => 'application/vnd.elife.labs-experiment-list+json; version=2']);
+            ['X-Foo' => 'bar', 'Accept' => 'application/vnd.elife.labs-experiment-list+json; version=2']);
         $response = new FulfilledPromise(new ArrayResult(new MediaType('application/vnd.elife.labs-experiment-list+json',
             2), ['foo' => ['bar', 'baz']]));
 
         $this->httpClient->send($request)->willReturn($response);
 
-        $this->listExperiments(2)->shouldBeLike($response);
+        $this->listExperiments(['Accept' => 'application/vnd.elife.labs-experiment-list+json; version=2'])
+            ->shouldBeLike($response)
+        ;
     }
 }

--- a/spec/ApiClient/MediumClientSpec.php
+++ b/spec/ApiClient/MediumClientSpec.php
@@ -17,18 +17,20 @@ final class MediumClientSpec extends ObjectBehavior
     {
         $this->httpClient = $httpClient;
 
-        $this->beConstructedWith($httpClient);
+        $this->beConstructedWith($httpClient, ['X-Foo' => 'bar']);
     }
 
     public function it_lists_medium_articles()
     {
         $request = new Request('GET', 'medium-articles',
-            ['Accept' => 'application/vnd.elife.medium-article-list+json; version=2']);
+            ['X-Foo' => 'bar', 'Accept' => 'application/vnd.elife.medium-article-list+json; version=2']);
         $response = new FulfilledPromise(new ArrayResult(new MediaType('application/vnd.elife.medium-article-list+json',
             2), ['foo' => ['bar', 'baz']]));
 
         $this->httpClient->send($request)->willReturn($response);
 
-        $this->listArticles(2)->shouldBeLike($response);
+        $this->listArticles(['Accept' => 'application/vnd.elife.medium-article-list+json; version=2'])
+            ->shouldBeLike($response)
+        ;
     }
 }

--- a/spec/ApiClient/PeopleClientSpec.php
+++ b/spec/ApiClient/PeopleClientSpec.php
@@ -17,30 +17,34 @@ final class PeopleClientSpec extends ObjectBehavior
     {
         $this->httpClient = $httpClient;
 
-        $this->beConstructedWith($httpClient);
+        $this->beConstructedWith($httpClient, ['X-Foo' => 'bar']);
     }
 
     public function it_gets_a_person()
     {
         $request = new Request('GET', 'people/fbloggs',
-            ['Accept' => 'application/vnd.elife.person+json; version=2']);
+            ['X-Foo' => 'bar', 'Accept' => 'application/vnd.elife.person+json; version=2']);
         $response = new FulfilledPromise(new ArrayResult(new MediaType('application/vnd.elife.person+json',
             2), ['foo' => ['bar', 'baz']]));
 
         $this->httpClient->send($request)->willReturn($response);
 
-        $this->getPerson(2, 'fbloggs')->shouldBeLike($response);
+        $this->getPerson(['Accept' => 'application/vnd.elife.person+json; version=2'], 'fbloggs')
+            ->shouldBeLike($response)
+        ;
     }
 
     public function it_lists_people()
     {
         $request = new Request('GET', 'people?page=1&per-page=20&order=desc&subject=cell-biology&type=senior-editor',
-            ['Accept' => 'application/vnd.elife.person-list+json; version=2']);
+            ['X-Foo' => 'bar', 'Accept' => 'application/vnd.elife.person-list+json; version=2']);
         $response = new FulfilledPromise(new ArrayResult(new MediaType('application/vnd.elife.person-list+json',
             2), ['foo' => ['bar', 'baz']]));
 
         $this->httpClient->send($request)->willReturn($response);
 
-        $this->listPeople(2, 1, 20, true, 'cell-biology', 'senior-editor')->shouldBeLike($response);
+        $this->listPeople(['Accept' => 'application/vnd.elife.person-list+json; version=2'], 1, 20, true,
+            'cell-biology', 'senior-editor')->shouldBeLike($response)
+        ;
     }
 }

--- a/spec/ApiClient/PodcastClientSpec.php
+++ b/spec/ApiClient/PodcastClientSpec.php
@@ -17,30 +17,34 @@ final class PodcastClientSpec extends ObjectBehavior
     {
         $this->httpClient = $httpClient;
 
-        $this->beConstructedWith($httpClient);
+        $this->beConstructedWith($httpClient, ['X-Foo' => 'bar']);
     }
 
     public function it_gets_a_podcast_episode()
     {
         $request = new Request('GET', 'podcast-episodes/3',
-            ['Accept' => 'application/vnd.elife.podcast-episode+json; version=2']);
+            ['X-Foo' => 'bar', 'Accept' => 'application/vnd.elife.podcast-episode+json; version=2']);
         $response = new FulfilledPromise(new ArrayResult(new MediaType('application/vnd.elife.podcast-episode+json',
             2), ['foo' => ['bar', 'baz']]));
 
         $this->httpClient->send($request)->willReturn($response);
 
-        $this->getEpisode(2, 3)->shouldBeLike($response);
+        $this->getEpisode(['Accept' => 'application/vnd.elife.podcast-episode+json; version=2'], 3)
+            ->shouldBeLike($response)
+        ;
     }
 
     public function it_lists_episodes()
     {
         $request = new Request('GET', 'podcast-episodes?page=1&per-page=20&order=desc&subject=cell-biology',
-            ['Accept' => 'application/vnd.elife.podcast-episode-list+json; version=2']);
+            ['X-Foo' => 'bar', 'Accept' => 'application/vnd.elife.podcast-episode-list+json; version=2']);
         $response = new FulfilledPromise(new ArrayResult(new MediaType('application/vnd.elife.podcast-episode-list+json',
             2), ['foo' => ['bar', 'baz']]));
 
         $this->httpClient->send($request)->willReturn($response);
 
-        $this->listEpisodes(2, 1, 20, true, 'cell-biology')->shouldBeLike($response);
+        $this->listEpisodes(['Accept' => 'application/vnd.elife.podcast-episode-list+json; version=2'], 1, 20, true,
+            'cell-biology')->shouldBeLike($response)
+        ;
     }
 }

--- a/spec/ApiClient/SearchClientSpec.php
+++ b/spec/ApiClient/SearchClientSpec.php
@@ -17,19 +17,22 @@ final class SearchClientSpec extends ObjectBehavior
     {
         $this->httpClient = $httpClient;
 
-        $this->beConstructedWith($httpClient);
+        $this->beConstructedWith($httpClient, ['X-Foo' => 'bar']);
     }
 
     public function it_queries()
     {
         $request = new Request('GET',
             'search?for=foo&page=1&per-page=20&sort=date&order=desc&subject[]=cell-biology&type[]=research-article',
-            ['Accept' => 'application/vnd.elife.search+json; version=2']);
+            ['X-Foo' => 'bar', 'Accept' => 'application/vnd.elife.search+json; version=2']);
         $response = new FulfilledPromise(new ArrayResult(new MediaType('application/vnd.elife.search+json',
             2), ['foo' => ['bar', 'baz']]));
 
         $this->httpClient->send($request)->willReturn($response);
 
-        $this->query(2, 'foo', 1, 20, 'date', true, ['cell-biology'], ['research-article'])->shouldBeLike($response);
+        $this->query((['Accept' => 'application/vnd.elife.search+json; version=2']), 'foo', 1, 20, 'date', true,
+            ['cell-biology'], ['research-article'])
+            ->shouldBeLike($response)
+        ;
     }
 }

--- a/spec/ApiClient/SubjectsClientSpec.php
+++ b/spec/ApiClient/SubjectsClientSpec.php
@@ -17,30 +17,34 @@ final class SubjectsClientSpec extends ObjectBehavior
     {
         $this->httpClient = $httpClient;
 
-        $this->beConstructedWith($httpClient);
+        $this->beConstructedWith($httpClient, ['X-Foo' => 'bar']);
     }
 
     public function it_gets_an_experiment()
     {
         $request = new Request('GET', 'subjects/cell-biology',
-            ['Accept' => 'application/vnd.elife.subject+json; version=2']);
+            ['X-Foo' => 'bar', 'Accept' => 'application/vnd.elife.subject+json; version=2']);
         $response = new FulfilledPromise(new ArrayResult(new MediaType('application/vnd.elife.subject+json',
             2), ['foo' => ['bar', 'baz']]));
 
         $this->httpClient->send($request)->willReturn($response);
 
-        $this->getSubject(2, 'cell-biology')->shouldBeLike($response);
+        $this->getSubject(['Accept' => 'application/vnd.elife.subject+json; version=2'], 'cell-biology')
+            ->shouldBeLike($response)
+        ;
     }
 
     public function it_lists_subjects()
     {
         $request = new Request('GET', 'subjects?page=1&per-page=20&order=desc',
-            ['Accept' => 'application/vnd.elife.subject-list+json; version=2']);
+            ['X-Foo' => 'bar', 'Accept' => 'application/vnd.elife.subject-list+json; version=2']);
         $response = new FulfilledPromise(new ArrayResult(new MediaType('application/vnd.elife.subject-list+json',
             2), ['foo' => ['bar', 'baz']]));
 
         $this->httpClient->send($request)->willReturn($response);
 
-        $this->listSubjects(2)->shouldBeLike($response);
+        $this->listSubjects(['Accept' => 'application/vnd.elife.subject-list+json; version=2'])
+            ->shouldBeLike($response)
+        ;
     }
 }

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -9,44 +9,50 @@ use Psr\Http\Message\StreamInterface;
 trait ApiClient
 {
     private $httpClient;
+    private $headers;
 
-    public function __construct(HttpClient $httpClient)
+    public function __construct(HttpClient $httpClient, array $headers = [])
     {
         $this->httpClient = $httpClient;
+        $this->headers = $headers;
     }
 
-    final protected function deleteRequest(string $uri, MediaType $accept) : PromiseInterface
+    final protected function deleteRequest(string $uri, array $headers) : PromiseInterface
     {
-        $request = new Request('DELETE', $uri, ['Accept' => $accept]);
+        $request = new Request('DELETE', $uri, array_merge($this->headers, $headers));
 
         return $this->httpClient->send($request);
     }
 
-    final protected function getRequest(string $uri, MediaType $accept) : PromiseInterface
+    final protected function getRequest(string $uri, array $headers) : PromiseInterface
     {
-        $request = new Request('GET', $uri, ['Accept' => $accept]);
+        $request = new Request('GET', $uri, array_merge($this->headers, $headers));
 
         return $this->httpClient->send($request);
     }
 
     final protected function postRequest(
         string $uri,
-        MediaType $accept,
+        array $headers,
         MediaType $contentType,
         StreamInterface $content
     ) : PromiseInterface {
-        $request = new Request('DELETE', $uri, ['Accept' => $accept, 'Content-Type' => $contentType], $content);
+        $headers = array_merge($this->headers, $headers, ['Content-Type' => $contentType]);
+
+        $request = new Request('DELETE', $uri, $headers, $content);
 
         return $this->httpClient->send($request);
     }
 
     final protected function putRequest(
         string $uri,
-        MediaType $accept,
+        array $headers,
         MediaType $contentType,
         StreamInterface $content
     ) : PromiseInterface {
-        $request = new Request('PUT', $uri, ['Accept' => $accept, 'Content-Type' => $contentType], $content);
+        $headers = array_merge($this->headers, $headers, ['Content-Type' => $contentType]);
+
+        $request = new Request('PUT', $uri, $headers, $content);
 
         return $this->httpClient->send($request);
     }

--- a/src/ApiClient/BlogClient.php
+++ b/src/ApiClient/BlogClient.php
@@ -3,23 +3,22 @@
 namespace eLife\ApiSdk\ApiClient;
 
 use eLife\ApiSdk\ApiClient;
-use eLife\ApiSdk\MediaType;
 use GuzzleHttp\Promise\PromiseInterface;
 
 final class BlogClient
 {
+    const TYPE_BLOG_ARTICLE = 'application/vnd.elife.blog-article+json';
+    const TYPE_BLOG_ARTICLE_LIST = 'application/vnd.elife.blog-article-list+json';
+
     use ApiClient;
 
-    public function getArticle(int $version, string $id) : PromiseInterface
+    public function getArticle(array $headers, string $id) : PromiseInterface
     {
-        return $this->getRequest(
-            'blog-articles/'.$id,
-            new MediaType('application/vnd.elife.blog-article+json', $version)
-        );
+        return $this->getRequest('blog-articles/'.$id, $headers);
     }
 
     public function listArticles(
-        int $version,
+        array $headers = [],
         int $page = 1,
         int $perPage = 20,
         bool $descendingOrder = true,
@@ -29,7 +28,7 @@ final class BlogClient
 
         return $this->getRequest(
             'blog-articles?page='.$page.'&per-page='.$perPage.'&order='.($descendingOrder ? 'desc' : 'asc').$subjectQuery,
-            new MediaType('application/vnd.elife.blog-article-list+json', $version)
+            $headers
         );
     }
 }

--- a/src/ApiClient/LabsClient.php
+++ b/src/ApiClient/LabsClient.php
@@ -3,30 +3,32 @@
 namespace eLife\ApiSdk\ApiClient;
 
 use eLife\ApiSdk\ApiClient;
-use eLife\ApiSdk\MediaType;
 use GuzzleHttp\Promise\PromiseInterface;
 
 final class LabsClient
 {
+    const TYPE_EXPERIMENT = 'application/vnd.elife.labs-experiment+json';
+    const TYPE_EXPERIMENT_LIST = 'application/vnd.elife.labs-experiment-list+json';
+
     use ApiClient;
 
-    public function getExperiment(int $version, int $number) : PromiseInterface
+    public function getExperiment(array $headers, int $number) : PromiseInterface
     {
         return $this->getRequest(
             'labs-experiments/'.$number,
-            new MediaType('application/vnd.elife.labs-experiment+json', $version)
+            $headers
         );
     }
 
     public function listExperiments(
-        int $version,
+        array $headers = [],
         int $page = 1,
         int $perPage = 20,
         bool $descendingOrder = true
     ) : PromiseInterface {
         return $this->getRequest(
             'labs-experiments?page='.$page.'&per-page='.$perPage.'&order='.($descendingOrder ? 'desc' : 'asc'),
-            new MediaType('application/vnd.elife.labs-experiment-list+json', $version)
+            $headers
         );
     }
 }

--- a/src/ApiClient/MediumClient.php
+++ b/src/ApiClient/MediumClient.php
@@ -3,18 +3,17 @@
 namespace eLife\ApiSdk\ApiClient;
 
 use eLife\ApiSdk\ApiClient;
-use eLife\ApiSdk\MediaType;
 use GuzzleHttp\Promise\PromiseInterface;
 
 final class MediumClient
 {
+    const TYPE_MEDIUM_ARTICLE = 'application/vnd.elife.medium-article+json';
+    const TYPE_MEDIUM_ARTICLE_LIST = 'application/vnd.elife.medium-article-list+json';
+
     use ApiClient;
 
-    public function listArticles(int $version) : PromiseInterface
+    public function listArticles(array $headers = []) : PromiseInterface
     {
-        return $this->getRequest(
-            'medium-articles',
-            new MediaType('application/vnd.elife.medium-article-list+json', $version)
-        );
+        return $this->getRequest('medium-articles', $headers);
     }
 }

--- a/src/ApiClient/PeopleClient.php
+++ b/src/ApiClient/PeopleClient.php
@@ -3,23 +3,22 @@
 namespace eLife\ApiSdk\ApiClient;
 
 use eLife\ApiSdk\ApiClient;
-use eLife\ApiSdk\MediaType;
 use GuzzleHttp\Promise\PromiseInterface;
 
 final class PeopleClient
 {
+    const TYPE_PERSON = 'application/vnd.elife.person+json';
+    const TYPE_PERSON_LIST = 'application/vnd.elife.person-list+json';
+
     use ApiClient;
 
-    public function getPerson(int $version, string $id) : PromiseInterface
+    public function getPerson(array $headers, string $id) : PromiseInterface
     {
-        return $this->getRequest(
-            'people/'.$id,
-            new MediaType('application/vnd.elife.person+json', $version)
-        );
+        return $this->getRequest('people/'.$id, $headers);
     }
 
     public function listPeople(
-        int $version,
+        array $headers = [],
         int $page = 1,
         int $perPage = 20,
         bool $descendingOrder = true,
@@ -31,7 +30,7 @@ final class PeopleClient
 
         return $this->getRequest(
             'people?page='.$page.'&per-page='.$perPage.'&order='.($descendingOrder ? 'desc' : 'asc').$subjectQuery.$typeQuery,
-            new MediaType('application/vnd.elife.person-list+json', $version)
+            $headers
         );
     }
 }

--- a/src/ApiClient/PodcastClient.php
+++ b/src/ApiClient/PodcastClient.php
@@ -3,23 +3,22 @@
 namespace eLife\ApiSdk\ApiClient;
 
 use eLife\ApiSdk\ApiClient;
-use eLife\ApiSdk\MediaType;
 use GuzzleHttp\Promise\PromiseInterface;
 
 final class PodcastClient
 {
+    const TYPE_PODCAST_EPISODE = 'application/vnd.elife.podcast-episode+json';
+    const TYPE_PODCAST_EPISODE_LIST = 'application/vnd.elife.podcast-episode-list+json';
+
     use ApiClient;
 
-    public function getEpisode(int $version, int $number) : PromiseInterface
+    public function getEpisode(array $headers, int $number) : PromiseInterface
     {
-        return $this->getRequest(
-            'podcast-episodes/'.$number,
-            new MediaType('application/vnd.elife.podcast-episode+json', $version)
-        );
+        return $this->getRequest('podcast-episodes/'.$number, $headers);
     }
 
     public function listEpisodes(
-        int $version,
+        array $headers = [],
         int $page = 1,
         int $perPage = 20,
         bool $descendingOrder = true,
@@ -29,7 +28,7 @@ final class PodcastClient
 
         return $this->getRequest(
             'podcast-episodes?page='.$page.'&per-page='.$perPage.'&order='.($descendingOrder ? 'desc' : 'asc').$subjectQuery,
-            new MediaType('application/vnd.elife.podcast-episode-list+json', $version)
+            $headers
         );
     }
 }

--- a/src/ApiClient/SearchClient.php
+++ b/src/ApiClient/SearchClient.php
@@ -3,7 +3,6 @@
 namespace eLife\ApiSdk\ApiClient;
 
 use eLife\ApiSdk\ApiClient;
-use eLife\ApiSdk\MediaType;
 use GuzzleHttp\Promise\PromiseInterface;
 
 final class SearchClient
@@ -11,7 +10,7 @@ final class SearchClient
     use ApiClient;
 
     public function query(
-        int $version,
+        array $headers = [],
         string $query = '',
         int $page = 1,
         int $perPage = 20,
@@ -31,7 +30,7 @@ final class SearchClient
 
         return $this->getRequest(
             'search?for='.$query.'&page='.$page.'&per-page='.$perPage.'&sort='.$sort.'&order='.($descendingOrder ? 'desc' : 'asc').$subjectQuery.$typeQuery,
-            new MediaType('application/vnd.elife.search+json', $version)
+            $headers
         );
     }
 }

--- a/src/ApiClient/SubjectsClient.php
+++ b/src/ApiClient/SubjectsClient.php
@@ -3,30 +3,29 @@
 namespace eLife\ApiSdk\ApiClient;
 
 use eLife\ApiSdk\ApiClient;
-use eLife\ApiSdk\MediaType;
 use GuzzleHttp\Promise\PromiseInterface;
 
 final class SubjectsClient
 {
+    const TYPE_SUBJECT = 'application/vnd.elife.subject+json';
+    const TYPE_SUBJECT_LIST = 'application/vnd.elife.subject-list+json';
+
     use ApiClient;
 
-    public function getSubject(int $version, string $id) : PromiseInterface
+    public function getSubject(array $headers, string $id) : PromiseInterface
     {
-        return $this->getRequest(
-            'subjects/'.$id,
-            new MediaType('application/vnd.elife.subject+json', $version)
-        );
+        return $this->getRequest('subjects/'.$id, $headers);
     }
 
     public function listSubjects(
-        int $version,
+        array $headers = [],
         int $page = 1,
         int $perPage = 20,
         bool $descendingOrder = true
     ) : PromiseInterface {
         return $this->getRequest(
             'subjects?page='.$page.'&per-page='.$perPage.'&order='.($descendingOrder ? 'desc' : 'asc'),
-            new MediaType('application/vnd.elife.subject-list+json', $version)
+            $headers
         );
     }
 }


### PR DESCRIPTION
Currently there's a `version` argument on all methods, which is quite simple. Some endpoints (eg articles) will need multiple media types, however, and this method doesn't allow for multiple versions (though I'm not sure that's needed).

Instead it might be better to allow headers to be set (either at the client or endpoint level).