### PR TITLE
Use promises rather than callbacks for lazy data

### DIFF
--- a/src/CreatesObjects.php
+++ b/src/CreatesObjects.php
@@ -7,6 +7,7 @@ use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\ImageSize;
 use eLife\ApiSdk\Model\Subject;
+use GuzzleHttp\Promise\PromiseInterface;
 
 trait CreatesObjects
 {
@@ -20,8 +21,11 @@ trait CreatesObjects
         return new Image($image['alt'], $sizes);
     }
 
-    private function createBlogArticle(array $data, callable $full, callable $subjects = null) : BlogArticle
-    {
+    private function createBlogArticle(
+        array $data,
+        PromiseInterface $full,
+        PromiseInterface $subjects = null
+    ) : BlogArticle {
         return new BlogArticle(
             $data['id'],
             $data['title'],

--- a/src/Promise/CallbackPromise.php
+++ b/src/Promise/CallbackPromise.php
@@ -32,7 +32,7 @@ final class CallbackPromise implements PromiseInterface
 
         if ($onFulfilled) {
             $clone->callback = function () use ($onFulfilled) {
-                return call_user_func($onFulfilled, call_user_func($this->callback));
+                return call_user_func($onFulfilled, $this->wait());
             };
         }
 

--- a/src/Promise/CallbackPromise.php
+++ b/src/Promise/CallbackPromise.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace eLife\ApiSdk\Promise;
+
+use Exception;
+use GuzzleHttp\Promise\CancellationException;
+use GuzzleHttp\Promise\PromiseInterface;
+use LogicException;
+use RuntimeException;
+use function GuzzleHttp\Promise\exception_for;
+
+/**
+ * @internal
+ */
+final class CallbackPromise implements PromiseInterface
+{
+    private $callback;
+    private $callbackOnRejected;
+    private $result;
+
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+        $this->callbackOnRejected = function (Exception $e) {
+            throw $e;
+        };
+    }
+
+    public function then(callable $onFulfilled = null, callable $onRejected = null)
+    {
+        $clone = clone $this;
+
+        if ($onFulfilled) {
+            $clone->callback = function () use ($onFulfilled) {
+                return call_user_func($onFulfilled, call_user_func($this->callback));
+            };
+        }
+
+        if ($onRejected) {
+            $clone->callbackOnRejected = function (Exception $e) use ($onRejected) {
+                try {
+                    return call_user_func($this->callbackOnRejected, $e);
+                } catch (Exception $e) {
+                    return call_user_func($onRejected, $e);
+                }
+            };
+        }
+
+        return $clone;
+    }
+
+    public function otherwise(callable $onRejected)
+    {
+        return $this->then(null, $onRejected);
+    }
+
+    public function getState()
+    {
+        if ($this->result instanceof Exception) {
+            return PromiseInterface::REJECTED;
+        } elseif ($this->result) {
+            return PromiseInterface::FULFILLED;
+        }
+
+        return PromiseInterface::PENDING;
+    }
+
+    public function resolve($value)
+    {
+        throw new LogicException('Cannot resolve a callback promise');
+    }
+
+    public function reject($reason)
+    {
+        if (PromiseInterface::PENDING !== $this->getState()) {
+            throw new RuntimeException('Promise is already resolved');
+        }
+
+        $this->result = exception_for($reason);
+    }
+
+    public function cancel()
+    {
+        $this->result = new CancellationException('Promise has been cancelled');
+    }
+
+    public function wait($unwrap = true)
+    {
+        $this->run();
+
+        if (false === $unwrap) {
+            return null;
+        }
+
+        if ($this->result instanceof Exception) {
+            throw $this->result;
+        }
+
+        return $this->result;
+    }
+
+    private function run()
+    {
+        if (PromiseInterface::PENDING !== $this->getState()) {
+            return;
+        }
+
+        try {
+            $this->result = call_user_func($this->callback);
+        } catch (Exception $e) {
+            try {
+                $this->result = call_user_func($this->callbackOnRejected, $e);
+            } catch (Exception $e) {
+                $this->result = $e;
+            }
+        }
+
+        $this->callback = null;
+    }
+}

--- a/test/Model/BlogArticleTest.php
+++ b/test/Model/BlogArticleTest.php
@@ -10,9 +10,10 @@ use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\ImageSize;
 use eLife\ApiSdk\Model\Subject;
-use Exception;
+use GuzzleHttp\Promise\PromiseInterface;
 use PHPUnit_Framework_TestCase;
 use function GuzzleHttp\Promise\promise_for;
+use function GuzzleHttp\Promise\rejection_for;
 
 final class BlogArticleTest extends PHPUnit_Framework_TestCase
 {
@@ -21,11 +22,10 @@ final class BlogArticleTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_an_id()
     {
-        $blogArticle = new BlogArticle('id', 'title', new DateTimeImmutable(), null, function () {
-            throw new Exception('Full blog article should not be unwrapped');
-        }, function () {
-            throw new Exception('Subjects should not be unwrapped');
-        });
+        $blogArticle = new BlogArticle('id', 'title', new DateTimeImmutable(), null,
+            rejection_for('Full blog article should not be unwrapped'),
+            rejection_for('Subjects should not be unwrapped')
+        );
 
         $this->assertSame('id', $blogArticle->getId());
     }
@@ -35,11 +35,10 @@ final class BlogArticleTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_a_title()
     {
-        $blogArticle = new BlogArticle('id', 'title', new DateTimeImmutable(), null, function () {
-            throw new Exception('Full blog article should not be unwrapped');
-        }, function () {
-            throw new Exception('Subjects should not be unwrapped');
-        });
+        $blogArticle = new BlogArticle('id', 'title', new DateTimeImmutable(), null,
+            rejection_for('Full blog article should not be unwrapped'),
+            rejection_for('Subjects should not be unwrapped')
+        );
 
         $this->assertSame('title', $blogArticle->getTitle());
     }
@@ -49,16 +48,14 @@ final class BlogArticleTest extends PHPUnit_Framework_TestCase
      */
     public function it_may_have_an_impact_statement()
     {
-        $with = new BlogArticle('id', 'title', new DateTimeImmutable(), 'impact statement', function () {
-            throw new Exception('Full blog article should not be unwrapped');
-        }, function () {
-            throw new Exception('Subjects should not be unwrapped');
-        });
-        $withOut = new BlogArticle('id', 'title', new DateTimeImmutable(), null, function () {
-            throw new Exception('Full blog article should not be unwrapped');
-        }, function () {
-            throw new Exception('Subjects should not be unwrapped');
-        });
+        $with = new BlogArticle('id', 'title', new DateTimeImmutable(), 'impact statement',
+            rejection_for('Full blog article should not be unwrapped'),
+            rejection_for('Subjects should not be unwrapped')
+        );
+        $withOut = new BlogArticle('id', 'title', new DateTimeImmutable(), null,
+            rejection_for('Full blog article should not be unwrapped'),
+            rejection_for('Subjects should not be unwrapped')
+        );
 
         $this->assertSame('impact statement', $with->getImpactStatement());
         $this->assertNull($withOut->getImpactStatement());
@@ -69,11 +66,10 @@ final class BlogArticleTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_a_published_date()
     {
-        $blogArticle = new BlogArticle('id', 'title', $date = new DateTimeImmutable(), null, function () {
-            throw new Exception('Full blog article should not be unwrapped');
-        }, function () {
-            throw new Exception('Subjects should not be unwrapped');
-        });
+        $blogArticle = new BlogArticle('id', 'title', $date = new DateTimeImmutable(), null,
+            rejection_for('Full blog article should not be unwrapped'),
+            rejection_for('Subjects should not be unwrapped')
+        );
 
         $this->assertEquals($date, $blogArticle->getPublishedDate());
     }
@@ -82,11 +78,11 @@ final class BlogArticleTest extends PHPUnit_Framework_TestCase
      * @test
      * @dataProvider subjectsProvider
      */
-    public function it_may_have_subjects(callable $subjects = null, bool $hasSubjects, array $expected)
+    public function it_may_have_subjects(PromiseInterface $subjects = null, bool $hasSubjects, array $expected)
     {
-        $blogArticle = new BlogArticle('id', 'title', new DateTimeImmutable(), null, function () {
-            throw new Exception('Full blog article should not be unwrapped');
-        }, $subjects);
+        $blogArticle = new BlogArticle('id', 'title', new DateTimeImmutable(), null,
+            rejection_for('Full blog article should not be unwrapped'), $subjects
+        );
 
         $this->assertSame($hasSubjects, $blogArticle->hasSubjects());
         $this->assertEquals($expected, $blogArticle->getSubjects());
@@ -107,17 +103,8 @@ final class BlogArticleTest extends PHPUnit_Framework_TestCase
                 false,
                 [],
             ],
-            'raw' => [
-                function () use ($subjects) {
-                    return $subjects;
-                },
-                true,
-                $subjects,
-            ],
             'promise' => [
-                function () use ($subjects) {
-                    return promise_for($subjects);
-                },
+                promise_for($subjects),
                 true,
                 $subjects,
             ],
@@ -129,11 +116,10 @@ final class BlogArticleTest extends PHPUnit_Framework_TestCase
      */
     public function it_does_not_unwrap_subjects_when_checking_if_it_has_any()
     {
-        $blogArticle = new BlogArticle('id', 'title', new DateTimeImmutable(), null, function () {
-            throw new Exception('Full blog article should not be unwrapped');
-        }, function () {
-            throw new Exception('Subjects should not be unwrapped');
-        });
+        $blogArticle = new BlogArticle('id', 'title', new DateTimeImmutable(), null,
+            rejection_for('Full blog article should not be unwrapped'),
+            rejection_for('Subjects should not be unwrapped')
+        );
 
         $this->assertTrue($blogArticle->hasSubjects());
     }
@@ -174,11 +160,9 @@ final class BlogArticleTest extends PHPUnit_Framework_TestCase
             new YouTube('foo', 300, 200),
         ];
 
-        $blogArticle = new BlogArticle('id', 'title', new DateTimeImmutable(), null, function () use ($contentJson) {
-            return ['content' => $contentJson];
-        }, function () {
-            throw new Exception('Subjects should not be unwrapped');
-        });
+        $blogArticle = new BlogArticle('id', 'title', new DateTimeImmutable(), null, promise_for($contentJson),
+            rejection_for('Subjects should not be unwrapped')
+        );
 
         $this->assertEquals($contentBlocks, $blogArticle->getContent());
     }

--- a/test/Promise/CallbackPromiseTest.php
+++ b/test/Promise/CallbackPromiseTest.php
@@ -73,15 +73,24 @@ final class CallbackPromiseTest extends PHPUnit_Framework_TestCase
      */
     public function it_chains_callbacks()
     {
-        $promise = new CallbackPromise(function () {
-            return 'foo';
+        $i = 0;
+
+        $promise = new CallbackPromise(function () use (&$i) {
+            $i++;
+
+            return $i;
         });
 
-        $promise = $promise->then(function (string $string) {
-            return $string.'bar';
+        $promise1 = $promise->then(function (int $count) {
+            return $count.' foo';
         });
 
-        $this->assertSame('foobar', $promise->wait());
+        $promise2 = $promise->then(function (int $count) {
+            return $count.' bar';
+        });
+
+        $this->assertSame('1 foo', $promise1->wait());
+        $this->assertSame('1 bar', $promise2->wait());
     }
 
     /**

--- a/test/Promise/CallbackPromiseTest.php
+++ b/test/Promise/CallbackPromiseTest.php
@@ -76,7 +76,7 @@ final class CallbackPromiseTest extends PHPUnit_Framework_TestCase
         $i = 0;
 
         $promise = new CallbackPromise(function () use (&$i) {
-            $i++;
+            ++$i;
 
             return $i;
         });

--- a/test/Promise/CallbackPromiseTest.php
+++ b/test/Promise/CallbackPromiseTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace test\eLife\ApiSdk\Promise;
+
+use eLife\ApiSdk\Promise\CallbackPromise;
+use Exception;
+use GuzzleHttp\Promise\CancellationException;
+use GuzzleHttp\Promise\PromiseInterface;
+use LogicException;
+use PHPUnit_Framework_TestCase;
+
+final class CallbackPromiseTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_a_callback()
+    {
+        $promise = new CallbackPromise(function () {
+            return 'foo';
+        });
+
+        $this->assertSame('foo', $promise->wait());
+    }
+
+    /**
+     * @test
+     * @dataProvider stateProvider
+     */
+    public function it_has_a_state(callable $callback, string $outcome)
+    {
+        $promise = new CallbackPromise($callback);
+
+        $this->assertSame(PromiseInterface::PENDING, $promise->getState());
+
+        $promise->wait(false);
+
+        $this->assertSame($outcome, $promise->getState());
+    }
+
+    public function stateProvider() : array
+    {
+        return [
+            'fulfilled' => [
+                function () {
+                    return 'foo';
+                },
+                PromiseInterface::FULFILLED,
+            ],
+            'rejected' => [
+                function () {
+                    throw new Exception();
+                },
+                PromiseInterface::REJECTED,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_nothing_when_not_unwrapping()
+    {
+        $promise = new CallbackPromise(function () {
+            throw new Exception();
+        });
+
+        $promise->wait(false);
+    }
+
+    /**
+     * @test
+     */
+    public function it_chains_callbacks()
+    {
+        $promise = new CallbackPromise(function () {
+            return 'foo';
+        });
+
+        $promise = $promise->then(function (string $string) {
+            return $string.'bar';
+        });
+
+        $this->assertSame('foobar', $promise->wait());
+    }
+
+    /**
+     * @test
+     */
+    public function it_runs_a_callbacks_on_failure()
+    {
+        $promise = new CallbackPromise(function () {
+            throw new Exception('Should not be thrown');
+        });
+
+        $promise = $promise->then(function () {
+            return 'foo';
+        }, function () {
+            return 'bar';
+        });
+
+        $this->assertSame('bar', $promise->wait());
+    }
+
+    /**
+     * @test
+     */
+    public function it_runs_a_callbacks_on_failure_2()
+    {
+        $promise = new CallbackPromise(function () {
+            throw new Exception('Should not be thrown');
+        });
+
+        $promise = $promise->otherwise(function () {
+            return 'foo';
+        });
+
+        $this->assertSame('foo', $promise->wait());
+    }
+
+    /**
+     * @test
+     */
+    public function it_cannot_be_resolved()
+    {
+        $promise = new CallbackPromise(function () {
+            throw new Exception('Should not be thrown');
+        });
+
+        $this->expectException(LogicException::class);
+
+        $promise->resolve('foo');
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_cancelled()
+    {
+        $promise = new CallbackPromise(function () {
+            throw new Exception('Should not be thrown');
+        });
+
+        $this->expectException(CancellationException::class);
+
+        $promise->cancel();
+
+        $promise->wait();
+    }
+}


### PR DESCRIPTION
Brings a bit more consistency, and simplifies a few parts.

I had to introduce `CallbackPromise` though, as a promise that is completely separate from Guzzle's promise queue. Not doing so causes request to happen early.
