### PR TITLE
Add sequences

### DIFF
--- a/src/ArrayFromIterator.php
+++ b/src/ArrayFromIterator.php
@@ -2,14 +2,15 @@
 
 namespace eLife\ApiSdk;
 
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
+use eLife\ApiSdk\Collection\Sequence;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 
 trait ArrayFromIterator
 {
-    final public function map(callable $callback) : Collection
+    final public function map(callable $callback) : Sequence
     {
         return $this->all()->map($callback);
     }
@@ -24,7 +25,7 @@ trait ArrayFromIterator
         return $this->all()->reduce($callback, $initial);
     }
 
-    final public function sort(callable $callback) : Collection
+    final public function sort(callable $callback) : Sequence
     {
         return $this->all()->sort($callback);
     }
@@ -40,12 +41,12 @@ trait ArrayFromIterator
         return $array;
     }
 
-    final private function all() : PromiseCollection
+    final private function all() : PromiseSequence
     {
-        return new PromiseCollection(
+        return new PromiseSequence(
             $promise = new Promise(
                 function () use (&$promise) {
-                    $promise->resolve(new ArrayCollection($this->toArray()));
+                    $promise->resolve(new ArraySequence($this->toArray()));
                 }
             )
         );

--- a/src/CanBeSliced.php
+++ b/src/CanBeSliced.php
@@ -2,6 +2,7 @@
 
 namespace eLife\ApiSdk;
 
+use eLife\ApiSdk\Collection\Sequence;
 use LogicException;
 
 trait CanBeSliced
@@ -9,7 +10,7 @@ trait CanBeSliced
     private $pages = [];
     private $pageBatch = 100;
 
-    abstract public function slice(int $offset, int $length = null) : Collection;
+    abstract public function slice(int $offset, int $length = null) : Sequence;
 
     abstract public function count() : int;
 

--- a/src/Client/AnnualReports.php
+++ b/src/Client/AnnualReports.php
@@ -7,9 +7,9 @@ use eLife\ApiClient\ApiClient\AnnualReportsClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\ApiSdk\ArrayFromIterator;
-use eLife\ApiSdk\Collection;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
+use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\AnnualReport;
 use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -17,7 +17,7 @@ use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use function GuzzleHttp\Promise\promise_for;
 
-final class AnnualReports implements Iterator, Collection
+final class AnnualReports implements Iterator, Sequence
 {
     use ArrayFromIterator;
     use SlicedIterator;
@@ -56,17 +56,17 @@ final class AnnualReports implements Iterator, Collection
             });
     }
 
-    public function slice(int $offset, int $length = null) : Collection
+    public function slice(int $offset, int $length = null) : Sequence
     {
         if (null === $length) {
-            return new PromiseCollection($this->all()
-                ->then(function (Collection $collection) use ($offset) {
-                    return $collection->slice($offset);
+            return new PromiseSequence($this->all()
+                ->then(function (Sequence $sequence) use ($offset) {
+                    return $sequence->slice($offset);
                 })
             );
         }
 
-        return new PromiseCollection($this->annualReportsClient
+        return new PromiseSequence($this->annualReportsClient
             ->listReports(
                 ['Accept' => new MediaType(AnnualReportsClient::TYPE_ANNUAL_REPORT_LIST, 1)],
                 ($offset / $length) + 1,
@@ -90,12 +90,12 @@ final class AnnualReports implements Iterator, Collection
                     }
                 }
 
-                return new ArrayCollection($reports);
+                return new ArraySequence($reports);
             })
         );
     }
 
-    public function reverse() : Collection
+    public function reverse() : Sequence
     {
         $clone = clone $this;
 

--- a/src/Client/Articles.php
+++ b/src/Client/Articles.php
@@ -7,9 +7,9 @@ use eLife\ApiClient\ApiClient\ArticlesClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\ApiSdk\ArrayFromIterator;
-use eLife\ApiSdk\Collection;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
+use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\ArticleVersion;
 use eLife\ApiSdk\Promise\CallbackPromise;
 use eLife\ApiSdk\SlicedIterator;
@@ -18,7 +18,7 @@ use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use function GuzzleHttp\Promise\promise_for;
 
-final class Articles implements Iterator, Collection
+final class Articles implements Iterator, Sequence
 {
     use ArrayFromIterator;
     use SlicedIterator;
@@ -99,17 +99,17 @@ final class Articles implements Iterator, Collection
             });
     }
 
-    public function slice(int $offset, int $length = null) : Collection
+    public function slice(int $offset, int $length = null) : Sequence
     {
         if (null === $length) {
-            return new PromiseCollection($this->all()
-                ->then(function (Collection $collection) use ($offset) {
-                    return $collection->slice($offset);
+            return new PromiseSequence($this->all()
+                ->then(function (Sequence $sequence) use ($offset) {
+                    return $sequence->slice($offset);
                 })
             );
         }
 
-        return new PromiseCollection($this->articlesClient
+        return new PromiseSequence($this->articlesClient
             ->listArticles(
                 ['Accept' => new MediaType(ArticlesClient::TYPE_ARTICLE_LIST, 1)],
                 ($offset / $length) + 1,
@@ -186,12 +186,12 @@ final class Articles implements Iterator, Collection
                     }
                 }
 
-                return new ArrayCollection($articles);
+                return new ArraySequence($articles);
             })
         );
     }
 
-    public function reverse() : Collection
+    public function reverse() : Sequence
     {
         $clone = clone $this;
 

--- a/src/Client/BlogArticles.php
+++ b/src/Client/BlogArticles.php
@@ -7,9 +7,9 @@ use eLife\ApiClient\ApiClient\BlogClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\ApiSdk\ArrayFromIterator;
-use eLife\ApiSdk\Collection;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
+use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Promise\CallbackPromise;
 use eLife\ApiSdk\SlicedIterator;
@@ -18,7 +18,7 @@ use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use function GuzzleHttp\Promise\promise_for;
 
-final class BlogArticles implements Iterator, Collection
+final class BlogArticles implements Iterator, Sequence
 {
     use ArrayFromIterator;
     use SlicedIterator;
@@ -71,17 +71,17 @@ final class BlogArticles implements Iterator, Collection
         return $clone;
     }
 
-    public function slice(int $offset, int $length = null) : Collection
+    public function slice(int $offset, int $length = null) : Sequence
     {
         if (null === $length) {
-            return new PromiseCollection($this->all()
-                ->then(function (Collection $collection) use ($offset) {
-                    return $collection->slice($offset);
+            return new PromiseSequence($this->all()
+                ->then(function (Sequence $sequence) use ($offset) {
+                    return $sequence->slice($offset);
                 })
             );
         }
 
-        return new PromiseCollection($this->blogClient
+        return new PromiseSequence($this->blogClient
             ->listArticles(
                 ['Accept' => new MediaType(BlogClient::TYPE_BLOG_ARTICLE_LIST, 1)],
                 ($offset / $length) + 1,
@@ -123,12 +123,12 @@ final class BlogArticles implements Iterator, Collection
                     }
                 }
 
-                return new ArrayCollection($articles);
+                return new ArraySequence($articles);
             })
         );
     }
 
-    public function reverse() : Collection
+    public function reverse() : Sequence
     {
         $clone = clone $this;
 

--- a/src/Client/Events.php
+++ b/src/Client/Events.php
@@ -7,9 +7,9 @@ use eLife\ApiClient\ApiClient\EventsClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\ApiSdk\ArrayFromIterator;
-use eLife\ApiSdk\Collection;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
+use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Event;
 use eLife\ApiSdk\Promise\CallbackPromise;
 use eLife\ApiSdk\SlicedIterator;
@@ -18,7 +18,7 @@ use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use function GuzzleHttp\Promise\promise_for;
 
-final class Events implements Iterator, Collection
+final class Events implements Iterator, Sequence
 {
     use ArrayFromIterator;
     use SlicedIterator;
@@ -71,17 +71,17 @@ final class Events implements Iterator, Collection
         return $clone;
     }
 
-    public function slice(int $offset, int $length = null) : Collection
+    public function slice(int $offset, int $length = null) : Sequence
     {
         if (null === $length) {
-            return new PromiseCollection($this->all()
-                ->then(function (Collection $collection) use ($offset) {
-                    return $collection->slice($offset);
+            return new PromiseSequence($this->all()
+                ->then(function (Sequence $sequence) use ($offset) {
+                    return $sequence->slice($offset);
                 })
             );
         }
 
-        return new PromiseCollection($this->eventsClient
+        return new PromiseSequence($this->eventsClient
             ->listEvents(
                 ['Accept' => new MediaType(EventsClient::TYPE_EVENT_LIST, 1)],
                 ($offset / $length) + 1,
@@ -123,12 +123,12 @@ final class Events implements Iterator, Collection
                     }
                 }
 
-                return new ArrayCollection($events);
+                return new ArraySequence($events);
             })
         );
     }
 
-    public function reverse() : Collection
+    public function reverse() : Sequence
     {
         $clone = clone $this;
 

--- a/src/Client/Interviews.php
+++ b/src/Client/Interviews.php
@@ -7,9 +7,9 @@ use eLife\ApiClient\ApiClient\InterviewsClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\ApiSdk\ArrayFromIterator;
-use eLife\ApiSdk\Collection;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
+use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Interview;
 use eLife\ApiSdk\Promise\CallbackPromise;
 use eLife\ApiSdk\SlicedIterator;
@@ -18,7 +18,7 @@ use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use function GuzzleHttp\Promise\promise_for;
 
-final class Interviews implements Iterator, Collection
+final class Interviews implements Iterator, Sequence
 {
     use ArrayFromIterator;
     use SlicedIterator;
@@ -57,17 +57,17 @@ final class Interviews implements Iterator, Collection
             });
     }
 
-    public function slice(int $offset, int $length = null) : Collection
+    public function slice(int $offset, int $length = null) : Sequence
     {
         if (null === $length) {
-            return new PromiseCollection($this->all()
-                ->then(function (Collection $collection) use ($offset) {
-                    return $collection->slice($offset);
+            return new PromiseSequence($this->all()
+                ->then(function (Sequence $sequence) use ($offset) {
+                    return $sequence->slice($offset);
                 })
             );
         }
 
-        return new PromiseCollection($this->interviewsClient
+        return new PromiseSequence($this->interviewsClient
             ->listInterviews(
                 ['Accept' => new MediaType(InterviewsClient::TYPE_INTERVIEW_LIST, 1)],
                 ($offset / $length) + 1,
@@ -118,12 +118,12 @@ final class Interviews implements Iterator, Collection
                     }
                 }
 
-                return new ArrayCollection($interviews);
+                return new ArraySequence($interviews);
             })
         );
     }
 
-    public function reverse() : Collection
+    public function reverse() : Sequence
     {
         $clone = clone $this;
 

--- a/src/Client/LabsExperiments.php
+++ b/src/Client/LabsExperiments.php
@@ -7,9 +7,9 @@ use eLife\ApiClient\ApiClient\LabsClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\ApiSdk\ArrayFromIterator;
-use eLife\ApiSdk\Collection;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
+use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\LabsExperiment;
 use eLife\ApiSdk\Promise\CallbackPromise;
 use eLife\ApiSdk\SlicedIterator;
@@ -18,7 +18,7 @@ use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use function GuzzleHttp\Promise\promise_for;
 
-final class LabsExperiments implements Iterator, Collection
+final class LabsExperiments implements Iterator, Sequence
 {
     use ArrayFromIterator;
     use SlicedIterator;
@@ -57,17 +57,17 @@ final class LabsExperiments implements Iterator, Collection
             });
     }
 
-    public function slice(int $offset, int $length = null) : Collection
+    public function slice(int $offset, int $length = null) : Sequence
     {
         if (null === $length) {
-            return new PromiseCollection($this->all()
-                ->then(function (Collection $collection) use ($offset) {
-                    return $collection->slice($offset);
+            return new PromiseSequence($this->all()
+                ->then(function (Sequence $sequence) use ($offset) {
+                    return $sequence->slice($offset);
                 })
             );
         }
 
-        return new PromiseCollection($this->labsClient
+        return new PromiseSequence($this->labsClient
             ->listExperiments(
                 ['Accept' => new MediaType(LabsClient::TYPE_EXPERIMENT_LIST, 1)],
                 ($offset / $length) + 1,
@@ -109,12 +109,12 @@ final class LabsExperiments implements Iterator, Collection
                     }
                 }
 
-                return new ArrayCollection($experiments);
+                return new ArraySequence($experiments);
             })
         );
     }
 
-    public function reverse() : Collection
+    public function reverse() : Sequence
     {
         $clone = clone $this;
 

--- a/src/Client/MediumArticles.php
+++ b/src/Client/MediumArticles.php
@@ -7,16 +7,16 @@ use eLife\ApiClient\ApiClient\MediumClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\ApiSdk\ArrayFromIterator;
-use eLife\ApiSdk\Collection;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
+use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\MediumArticle;
 use eLife\ApiSdk\SlicedIterator;
 use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use function GuzzleHttp\Promise\promise_for;
 
-final class MediumArticles implements Iterator, Collection
+final class MediumArticles implements Iterator, Sequence
 {
     use ArrayFromIterator;
     use SlicedIterator;
@@ -39,17 +39,17 @@ final class MediumArticles implements Iterator, Collection
         $this->resetIterator();
     }
 
-    public function slice(int $offset, int $length = null) : Collection
+    public function slice(int $offset, int $length = null) : Sequence
     {
         if (null === $length) {
-            return new PromiseCollection($this->all()
-                ->then(function (Collection $collection) use ($offset) {
-                    return $collection->slice($offset);
+            return new PromiseSequence($this->all()
+                ->then(function (Sequence $sequence) use ($offset) {
+                    return $sequence->slice($offset);
                 })
             );
         }
 
-        return new PromiseCollection($this->mediumArticlesClient
+        return new PromiseSequence($this->mediumArticlesClient
             ->listArticles(
                 ['Accept' => new MediaType(MediumClient::TYPE_MEDIUM_ARTICLE_LIST, 1)],
                 ($offset / $length) + 1,
@@ -74,12 +74,12 @@ final class MediumArticles implements Iterator, Collection
                     }
                 }
 
-                return new ArrayCollection($mediumArticles);
+                return new ArraySequence($mediumArticles);
             })
         );
     }
 
-    public function reverse() : Collection
+    public function reverse() : Sequence
     {
         $clone = clone $this;
 

--- a/src/Client/Subjects.php
+++ b/src/Client/Subjects.php
@@ -7,9 +7,9 @@ use eLife\ApiClient\ApiClient\SubjectsClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\ApiSdk\ArrayFromIterator;
-use eLife\ApiSdk\Collection;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
+use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Subject;
 use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -17,7 +17,7 @@ use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use function GuzzleHttp\Promise\promise_for;
 
-final class Subjects implements Iterator, Collection
+final class Subjects implements Iterator, Sequence
 {
     use ArrayFromIterator;
     use SlicedIterator;
@@ -56,17 +56,17 @@ final class Subjects implements Iterator, Collection
             });
     }
 
-    public function slice(int $offset, int $length = null) : Collection
+    public function slice(int $offset, int $length = null) : Sequence
     {
         if (null === $length) {
-            return new PromiseCollection($this->all()
-                ->then(function (Collection $collection) use ($offset) {
-                    return $collection->slice($offset);
+            return new PromiseSequence($this->all()
+                ->then(function (Sequence $sequence) use ($offset) {
+                    return $sequence->slice($offset);
                 })
             );
         }
 
-        return new PromiseCollection($this->subjectsClient
+        return new PromiseSequence($this->subjectsClient
             ->listSubjects(
                 ['Accept' => new MediaType(SubjectsClient::TYPE_SUBJECT_LIST, 1)],
                 ($offset / $length) + 1,
@@ -90,12 +90,12 @@ final class Subjects implements Iterator, Collection
                     }
                 }
 
-                return new ArrayCollection($subjects);
+                return new ArraySequence($subjects);
             })
         );
     }
 
-    public function reverse() : Collection
+    public function reverse() : Sequence
     {
         $clone = clone $this;
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -3,22 +3,11 @@
 namespace eLife\ApiSdk;
 
 use Countable;
-use GuzzleHttp\Promise\PromiseInterface;
 use Traversable;
 
 interface Collection extends Countable, Traversable
 {
-    public function slice(int $offset, int $length = null) : Collection;
-
-    public function map(callable $callback) : Collection;
-
     public function filter(callable $callback) : Collection;
-
-    public function reduce(callable $callback, $initial = null) : PromiseInterface;
-
-    public function sort(callable $callback) : Collection;
-
-    public function reverse() : Collection;
 
     public function toArray() : array;
 }

--- a/src/Collection/ArraySequence.php
+++ b/src/Collection/ArraySequence.php
@@ -9,7 +9,7 @@ use IteratorAggregate;
 use Traversable;
 use function GuzzleHttp\Promise\promise_for;
 
-final class ArrayCollection implements IteratorAggregate, Collection
+final class ArraySequence implements IteratorAggregate, Sequence
 {
     private $array;
 
@@ -33,12 +33,12 @@ final class ArrayCollection implements IteratorAggregate, Collection
         return $this->array;
     }
 
-    public function slice(int $offset, int $length = null) : Collection
+    public function slice(int $offset, int $length = null) : Sequence
     {
         return new self(array_slice($this->array, $offset, $length));
     }
 
-    public function map(callable $callback) : Collection
+    public function map(callable $callback) : Sequence
     {
         return new self(array_map($callback, $this->array));
     }
@@ -53,7 +53,7 @@ final class ArrayCollection implements IteratorAggregate, Collection
         return promise_for(array_reduce($this->array, $callback, $initial));
     }
 
-    public function sort(callable $callback) : Collection
+    public function sort(callable $callback) : Sequence
     {
         $clone = clone $this;
 
@@ -62,7 +62,7 @@ final class ArrayCollection implements IteratorAggregate, Collection
         return $clone;
     }
 
-    public function reverse() : Collection
+    public function reverse() : Sequence
     {
         return new self(array_reverse($this->array));
     }

--- a/src/Collection/PromiseSequence.php
+++ b/src/Collection/PromiseSequence.php
@@ -8,14 +8,14 @@ use IteratorAggregate;
 use LogicException;
 use Traversable;
 
-final class PromiseCollection implements IteratorAggregate, Collection, PromiseInterface
+final class PromiseSequence implements IteratorAggregate, Sequence, PromiseInterface
 {
     private $promise;
 
     public function __construct(PromiseInterface $promise)
     {
         $this->promise = $promise->then(function ($value) {
-            if ($value instanceof Collection) {
+            if ($value instanceof Sequence) {
                 return $value;
             }
 
@@ -23,7 +23,7 @@ final class PromiseCollection implements IteratorAggregate, Collection, PromiseI
                 $value = iterator_to_array($value);
             }
 
-            return new ArrayCollection((array) $value);
+            return new ArraySequence((array) $value);
         });
     }
 
@@ -42,19 +42,19 @@ final class PromiseCollection implements IteratorAggregate, Collection, PromiseI
         return $this->wait()->toArray();
     }
 
-    public function slice(int $offset, int $length = null) : Collection
+    public function slice(int $offset, int $length = null) : Sequence
     {
         return new self(
-            $this->then(function (Collection $collection) use ($offset, $length) {
+            $this->then(function (Sequence $collection) use ($offset, $length) {
                 return $collection->slice($offset, $length);
             })
         );
     }
 
-    public function map(callable $callback) : Collection
+    public function map(callable $callback) : Sequence
     {
         return new self(
-            $this->then(function (Collection $collection) use ($callback) {
+            $this->then(function (Sequence $collection) use ($callback) {
                 return $collection->map($callback);
             })
         );
@@ -63,7 +63,7 @@ final class PromiseCollection implements IteratorAggregate, Collection, PromiseI
     public function filter(callable $callback) : Collection
     {
         return new self(
-            $this->then(function (Collection $collection) use ($callback) {
+            $this->then(function (Sequence $collection) use ($callback) {
                 return $collection->filter($callback);
             })
         );
@@ -71,24 +71,24 @@ final class PromiseCollection implements IteratorAggregate, Collection, PromiseI
 
     public function reduce(callable $callback, $initial = null) : PromiseInterface
     {
-        return $this->then(function (Collection $collection) use ($callback, $initial) {
+        return $this->then(function (Sequence $collection) use ($callback, $initial) {
             return $collection->reduce($callback, $initial);
         });
     }
 
-    public function sort(callable $callback) : Collection
+    public function sort(callable $callback) : Sequence
     {
         return new self(
-            $this->then(function (Collection $collection) use ($callback) {
+            $this->then(function (Sequence $collection) use ($callback) {
                 return $collection->sort($callback);
             })
         );
     }
 
-    public function reverse() : Collection
+    public function reverse() : Sequence
     {
         return new self(
-            $this->then(function (Collection $collection) {
+            $this->then(function (Sequence $collection) {
                 return $collection->reverse();
             })
         );
@@ -111,17 +111,17 @@ final class PromiseCollection implements IteratorAggregate, Collection, PromiseI
 
     public function resolve($value)
     {
-        throw new LogicException('Cannot resolve a PromiseCollection');
+        throw new LogicException('Cannot resolve a PromiseSequence');
     }
 
     public function reject($reason)
     {
-        throw new LogicException('Cannot reject a PromiseCollection');
+        throw new LogicException('Cannot reject a PromiseSequence');
     }
 
     public function cancel()
     {
-        throw new LogicException('Cannot cancel a PromiseCollection');
+        throw new LogicException('Cannot cancel a PromiseSequence');
     }
 
     public function wait($unwrap = true)

--- a/src/Collection/Sequence.php
+++ b/src/Collection/Sequence.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace eLife\ApiSdk\Collection;
+
+use eLife\ApiSdk\Collection;
+use GuzzleHttp\Promise\PromiseInterface;
+
+interface Sequence extends Collection
+{
+    public function map(callable $callback) : Sequence;
+
+    public function slice(int $offset, int $length = null) : Sequence;
+
+    /**
+     * @return Sequence
+     */
+    public function filter(callable $callback) : Collection;
+
+    public function reduce(callable $callback, $initial = null) : PromiseInterface;
+
+    public function sort(callable $callback) : Sequence;
+
+    public function reverse() : Sequence;
+}

--- a/src/Model/ArticleSection.php
+++ b/src/Model/ArticleSection.php
@@ -2,7 +2,7 @@
 
 namespace eLife\ApiSdk\Model;
 
-use eLife\ApiSdk\Collection;
+use eLife\ApiSdk\Collection\Sequence;
 
 final class ArticleSection
 {
@@ -12,16 +12,16 @@ final class ArticleSection
     /**
      * @internal
      */
-    public function __construct(Collection $content, string $doi = null)
+    public function __construct(Sequence $content, string $doi = null)
     {
         $this->content = $content;
         $this->doi = $doi;
     }
 
     /**
-     * @return Collection|Block[]
+     * @return Sequence|Block[]
      */
-    public function getContent() : Collection
+    public function getContent() : Sequence
     {
         return $this->content;
     }

--- a/src/Model/ArticleVersion.php
+++ b/src/Model/ArticleVersion.php
@@ -3,8 +3,8 @@
 namespace eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
-use eLife\ApiSdk\Collection;
-use eLife\ApiSdk\Collection\ArrayCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\Sequence;
 use GuzzleHttp\Promise\PromiseInterface;
 
 abstract class ArticleVersion
@@ -44,12 +44,12 @@ abstract class ArticleVersion
         int $volume,
         string $elocationId,
         string $pdf = null,
-        Collection $subjects = null,
+        Sequence $subjects = null,
         array $researchOrganisms,
         PromiseInterface $abstract,
         PromiseInterface $issue,
         PromiseInterface $copyright,
-        Collection $authors
+        Sequence $authors
     ) {
         $this->id = $id;
         $this->version = $version;
@@ -148,12 +148,12 @@ abstract class ArticleVersion
     }
 
     /**
-     * @return Collection|Subject[]
+     * @return Sequence|Subject[]
      */
-    final public function getSubjects() : Collection
+    final public function getSubjects() : Sequence
     {
         if (is_array($this->subjects)) {
-            return new ArrayCollection($this->subjects);
+            return new ArraySequence($this->subjects);
         }
 
         return $this->subjects;
@@ -188,7 +188,7 @@ abstract class ArticleVersion
         return $this->copyright->wait();
     }
 
-    final public function getAuthors(): Collection
+    final public function getAuthors(): Sequence
     {
         return $this->authors;
     }

--- a/src/Model/ArticleVoR.php
+++ b/src/Model/ArticleVoR.php
@@ -3,7 +3,7 @@
 namespace eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
-use eLife\ApiSdk\Collection;
+use eLife\ApiSdk\Collection\Sequence;
 use GuzzleHttp\Promise\PromiseInterface;
 
 final class ArticleVoR extends ArticleVersion
@@ -34,20 +34,20 @@ final class ArticleVoR extends ArticleVersion
         int $volume,
         string $elocationId,
         string $pdf = null,
-        Collection $subjects = null,
+        Sequence $subjects = null,
         array $researchOrganisms,
         PromiseInterface $abstract,
         PromiseInterface $issue,
         PromiseInterface $copyright,
-        Collection $authors,
+        Sequence $authors,
         string $impactStatement = null,
         Image $image = null,
-        Collection $keywords,
+        Sequence $keywords,
         PromiseInterface $digest,
-        Collection $content,
-        Collection $references,
+        Sequence $content,
+        Sequence $references,
         PromiseInterface $decisionLetter,
-        Collection $decisionLetterDescription,
+        Sequence $decisionLetterDescription,
         PromiseInterface $authorResponse
     ) {
         parent::__construct($id, $version, $type, $doi, $authorLine, $titlePrefix, $title, $published, $statusDate,
@@ -80,7 +80,7 @@ final class ArticleVoR extends ArticleVersion
         return $this->image;
     }
 
-    public function getKeywords() : Collection
+    public function getKeywords() : Sequence
     {
         return $this->keywords;
     }
@@ -93,15 +93,15 @@ final class ArticleVoR extends ArticleVersion
         return $this->digest->wait();
     }
 
-    public function getContent() : Collection
+    public function getContent() : Sequence
     {
         return $this->content;
     }
 
     /**
-     * @return Collection|Reference[]
+     * @return Sequence|Reference[]
      */
-    public function getReferences() : Collection
+    public function getReferences() : Sequence
     {
         return $this->references;
     }
@@ -115,9 +115,9 @@ final class ArticleVoR extends ArticleVersion
     }
 
     /**
-     * @return Collection|Block[]
+     * @return Sequence|Block[]
      */
-    public function getDecisionLetterDescription() : Collection
+    public function getDecisionLetterDescription() : Sequence
     {
         return $this->decisionLetterDescription;
     }

--- a/src/Model/BlogArticle.php
+++ b/src/Model/BlogArticle.php
@@ -3,8 +3,8 @@
 namespace eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
-use eLife\ApiSdk\Collection;
-use eLife\ApiSdk\Collection\ArrayCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\Sequence;
 
 final class BlogArticle
 {
@@ -23,8 +23,8 @@ final class BlogArticle
         string $title,
         DateTimeImmutable $published,
         string $impactStatement = null,
-        Collection $content,
-        Collection $subjects = null
+        Sequence $content,
+        Sequence $subjects = null
     ) {
         $this->id = $id;
         $this->title = $title;
@@ -67,21 +67,21 @@ final class BlogArticle
     }
 
     /**
-     * @return Collection|Subject[]
+     * @return Sequence|Subject[]
      */
-    public function getSubjects() : Collection
+    public function getSubjects() : Sequence
     {
         if (is_array($this->subjects)) {
-            return new ArrayCollection($this->subjects);
+            return new ArraySequence($this->subjects);
         }
 
         return $this->subjects;
     }
 
     /**
-     * @return Collection|Block[]
+     * @return Sequence|Block[]
      */
-    public function getContent() : Collection
+    public function getContent() : Sequence
     {
         return $this->content;
     }

--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -4,7 +4,7 @@ namespace eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
 use DateTimeZone;
-use eLife\ApiSdk\Collection;
+use eLife\ApiSdk\Collection\Sequence;
 use GuzzleHttp\Promise\PromiseInterface;
 use function GuzzleHttp\Promise\promise_for;
 
@@ -29,7 +29,7 @@ final class Event
         DateTimeImmutable $starts,
         DateTimeImmutable $ends,
         DateTimeZone $timeZone = null,
-        Collection $content,
+        Sequence $content,
         PromiseInterface $venue = null
     ) {
         $this->id = $id;
@@ -78,7 +78,7 @@ final class Event
         return $this->timeZone;
     }
 
-    public function getContent(): Collection
+    public function getContent(): Sequence
     {
         return $this->content;
     }

--- a/src/Model/GroupAuthor.php
+++ b/src/Model/GroupAuthor.php
@@ -2,7 +2,7 @@
 
 namespace eLife\ApiSdk\Model;
 
-use eLife\ApiSdk\Collection;
+use eLife\ApiSdk\Collection\Sequence;
 
 final class GroupAuthor extends Author
 {
@@ -15,7 +15,7 @@ final class GroupAuthor extends Author
      */
     public function __construct(
         string $name,
-        Collection $people,
+        Sequence $people,
         array $groups = [],
         array $affiliations = [],
         string $competingInterests = null,
@@ -38,7 +38,7 @@ final class GroupAuthor extends Author
         return $this->name;
     }
 
-    public function getPeople() : Collection
+    public function getPeople() : Sequence
     {
         return $this->people;
     }

--- a/src/Model/Interview.php
+++ b/src/Model/Interview.php
@@ -3,7 +3,7 @@
 namespace eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
-use eLife\ApiSdk\Collection;
+use eLife\ApiSdk\Collection\Sequence;
 
 final class Interview
 {
@@ -23,7 +23,7 @@ final class Interview
         string $title,
         DateTimeImmutable $published,
         string $impactStatement = null,
-        Collection $content
+        Sequence $content
     ) {
         $this->id = $id;
         $this->interviewee = $interviewee;
@@ -62,9 +62,9 @@ final class Interview
     }
 
     /**
-     * @return Collection|Block[]
+     * @return Sequence|Block[]
      */
-    public function getContent() : Collection
+    public function getContent() : Sequence
     {
         return $this->content;
     }

--- a/src/Model/Interviewee.php
+++ b/src/Model/Interviewee.php
@@ -2,15 +2,15 @@
 
 namespace eLife\ApiSdk\Model;
 
-use eLife\ApiSdk\Collection;
-use eLife\ApiSdk\Collection\ArrayCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\Sequence;
 
 final class Interviewee
 {
     private $person;
     private $cvLines;
 
-    public function __construct(Person $person, Collection $cvLines = null)
+    public function __construct(Person $person, Sequence $cvLines = null)
     {
         $this->person = $person;
         $this->cvLines = $cvLines;
@@ -27,12 +27,12 @@ final class Interviewee
     }
 
     /**
-     * @return Collection|IntervieweeCvLine[]
+     * @return Sequence|IntervieweeCvLine[]
      */
-    public function getCvLines() : Collection
+    public function getCvLines() : Sequence
     {
         if (empty($this->cvLines)) {
-            return new ArrayCollection([]);
+            return new ArraySequence([]);
         }
 
         return $this->cvLines;

--- a/src/Model/LabsExperiment.php
+++ b/src/Model/LabsExperiment.php
@@ -3,7 +3,7 @@
 namespace eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
-use eLife\ApiSdk\Collection;
+use eLife\ApiSdk\Collection\Sequence;
 
 final class LabsExperiment
 {
@@ -23,7 +23,7 @@ final class LabsExperiment
         DateTimeImmutable $published,
         string $impactStatement = null,
         Image $image,
-        Collection $content
+        Sequence $content
     ) {
         $this->number = $number;
         $this->title = $title;
@@ -62,9 +62,9 @@ final class LabsExperiment
     }
 
     /**
-     * @return Collection|Block[]
+     * @return Sequence|Block[]
      */
-    public function getContent() : Collection
+    public function getContent() : Sequence
     {
         return $this->content;
     }

--- a/src/Serializer/ArticleVersionNormalizer.php
+++ b/src/Serializer/ArticleVersionNormalizer.php
@@ -2,8 +2,8 @@
 
 namespace eLife\ApiSdk\Serializer;
 
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\ArticleSection;
 use eLife\ApiSdk\Model\ArticleVersion;
 use eLife\ApiSdk\Model\AuthorEntry;
@@ -33,14 +33,14 @@ abstract class ArticleVersionNormalizer implements NormalizerInterface, Denormal
                 }
 
                 return new ArticleSection(
-                    new ArrayCollection(array_map(function (array $block) use ($format, $context) {
+                    new ArraySequence(array_map(function (array $block) use ($format, $context) {
                         return $this->denormalizer->denormalize($block, Block::class, $format, $context);
                     }, $abstract['content'])),
                     $abstract['doi'] ?? null
                 );
             });
 
-        $data['authors'] = new PromiseCollection(promise_for($data['authors'])
+        $data['authors'] = new PromiseSequence(promise_for($data['authors'])
             ->then(function (array $authors) use ($format, $context) {
                 return array_map(function (array $author) use ($format, $context) {
                     return $this->denormalizer->denormalize($author, AuthorEntry::class, $format, $context);

--- a/src/Serializer/ArticleVoRNormalizer.php
+++ b/src/Serializer/ArticleVoRNormalizer.php
@@ -3,8 +3,8 @@
 namespace eLife\ApiSdk\Serializer;
 
 use DateTimeImmutable;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\ArticleSection;
 use eLife\ApiSdk\Model\ArticleVersion;
 use eLife\ApiSdk\Model\ArticleVoR;
@@ -27,7 +27,7 @@ final class ArticleVoRNormalizer extends ArticleVersionNormalizer
                     }
 
                     return new ArticleSection(
-                        new ArrayCollection(array_map(function (array $block) use ($format, $context) {
+                        new ArraySequence(array_map(function (array $block) use ($format, $context) {
                             return $this->denormalizer->denormalize($block, Block::class, $format, $context);
                         }, $authorResponse['content'])),
                         $authorResponse['doi']
@@ -35,7 +35,7 @@ final class ArticleVoRNormalizer extends ArticleVersionNormalizer
                 });
         }
 
-        $data['body'] = new PromiseCollection(promise_for($data['body'])
+        $data['body'] = new PromiseSequence(promise_for($data['body'])
             ->then(function (array $blocks) use ($format, $context) {
                 return array_map(function (array $block) use ($format, $context) {
                     return $this->denormalizer->denormalize($block, Block::class, $format, $context);
@@ -44,9 +44,9 @@ final class ArticleVoRNormalizer extends ArticleVersionNormalizer
 
         if (empty($data['decisionLetter'])) {
             $data['decisionLetter'] = promise_for(null);
-            $decisionLetterDescription = new ArrayCollection([]);
+            $decisionLetterDescription = new ArraySequence([]);
         } else {
-            $decisionLetterDescription = new PromiseCollection(promise_for($data['decisionLetter'])
+            $decisionLetterDescription = new PromiseSequence(promise_for($data['decisionLetter'])
                 ->then(function (array $decisionLetter) use ($format, $context) {
                     return array_map(function (array $block) use ($format, $context) {
                         return $this->denormalizer->denormalize($block, Block::class, $format, $context);
@@ -59,7 +59,7 @@ final class ArticleVoRNormalizer extends ArticleVersionNormalizer
                     }
 
                     return new ArticleSection(
-                        new ArrayCollection(array_map(function (array $block) use ($format, $context) {
+                        new ArraySequence(array_map(function (array $block) use ($format, $context) {
                             return $this->denormalizer->denormalize($block, Block::class, $format, $context);
                         }, $decisionLetter['content'])),
                         $decisionLetter['doi']
@@ -77,7 +77,7 @@ final class ArticleVoRNormalizer extends ArticleVersionNormalizer
                     }
 
                     return new ArticleSection(
-                        new ArrayCollection(array_map(function (array $block) use ($format, $context) {
+                        new ArraySequence(array_map(function (array $block) use ($format, $context) {
                             return $this->denormalizer->denormalize($block, Block::class, $format, $context);
                         }, $digest['content'])),
                         $digest['doi']
@@ -89,9 +89,9 @@ final class ArticleVoRNormalizer extends ArticleVersionNormalizer
             $data['image'] = $this->denormalizer->denormalize($data['image'], Image::class, $format, $context);
         }
 
-        $data['keywords'] = new PromiseCollection(promise_for($data['keywords'] ?? []));
+        $data['keywords'] = new PromiseSequence(promise_for($data['keywords'] ?? []));
 
-        $data['references'] = new PromiseCollection(promise_for($data['references'] ?? [])
+        $data['references'] = new PromiseSequence(promise_for($data['references'] ?? [])
             ->then(function (array $blocks) use ($format, $context) {
                 return array_map(function (array $block) use ($format, $context) {
                     return $this->denormalizer->denormalize($block, Reference::class, $format, $context);

--- a/src/Serializer/BlogArticleNormalizer.php
+++ b/src/Serializer/BlogArticleNormalizer.php
@@ -3,7 +3,7 @@
 namespace eLife\ApiSdk\Serializer;
 
 use DateTimeImmutable;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Block;
 use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Subject;
@@ -23,7 +23,7 @@ final class BlogArticleNormalizer implements NormalizerInterface, DenormalizerIn
 
     public function denormalize($data, $class, $format = null, array $context = []) : BlogArticle
     {
-        $data['content'] = new PromiseCollection(promise_for($data['content'])
+        $data['content'] = new PromiseSequence(promise_for($data['content'])
             ->then(function (array $blocks) use ($format, $context) {
                 return array_map(function (array $block) use ($format, $context) {
                     return $this->denormalizer->denormalize($block, Block::class, $format, $context);

--- a/src/Serializer/EventNormalizer.php
+++ b/src/Serializer/EventNormalizer.php
@@ -4,7 +4,7 @@ namespace eLife\ApiSdk\Serializer;
 
 use DateTimeImmutable;
 use DateTimeZone;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Block;
 use eLife\ApiSdk\Model\Event;
 use eLife\ApiSdk\Model\Place;
@@ -24,7 +24,7 @@ final class EventNormalizer implements NormalizerInterface, DenormalizerInterfac
 
     public function denormalize($data, $class, $format = null, array $context = []) : Event
     {
-        $data['content'] = new PromiseCollection(promise_for($data['content'])
+        $data['content'] = new PromiseSequence(promise_for($data['content'])
             ->then(function (array $blocks) use ($format, $context) {
                 return array_map(function (array $block) use ($format, $context) {
                     return $this->denormalizer->denormalize($block, Block::class, $format, $context);

--- a/src/Serializer/GroupAuthorNormalizer.php
+++ b/src/Serializer/GroupAuthorNormalizer.php
@@ -2,7 +2,7 @@
 
 namespace eLife\ApiSdk\Serializer;
 
-use eLife\ApiSdk\Collection\ArrayCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Model\Author;
 use eLife\ApiSdk\Model\AuthorEntry;
 use eLife\ApiSdk\Model\GroupAuthor;
@@ -25,7 +25,7 @@ final class GroupAuthorNormalizer extends AuthorNormalizer
 
         return new GroupAuthor(
             $data['name'],
-            new ArrayCollection(array_map(function (array $person) use ($format, $context) {
+            new ArraySequence(array_map(function (array $person) use ($format, $context) {
                 return $this->denormalizer->denormalize($person, PersonAuthor::class, $format, $context);
             }, $data['people'] ?? [])),
             $data['groups'] ?? [],

--- a/src/Serializer/InterviewNormalizer.php
+++ b/src/Serializer/InterviewNormalizer.php
@@ -3,7 +3,7 @@
 namespace eLife\ApiSdk\Serializer;
 
 use DateTimeImmutable;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Block;
 use eLife\ApiSdk\Model\Interview;
 use eLife\ApiSdk\Model\Interviewee;
@@ -24,7 +24,7 @@ final class InterviewNormalizer implements NormalizerInterface, DenormalizerInte
 
     public function denormalize($data, $class, $format = null, array $context = []) : Interview
     {
-        $data['content'] = new PromiseCollection(promise_for($data['content'])
+        $data['content'] = new PromiseSequence(promise_for($data['content'])
             ->then(function (array $blocks) use ($format, $context) {
                 return array_map(function (array $block) use ($format, $context) {
                     return $this->denormalizer->denormalize($block, Block::class, $format, $context);
@@ -32,7 +32,7 @@ final class InterviewNormalizer implements NormalizerInterface, DenormalizerInte
             }));
 
         if (!empty($data['interviewee']['cv'])) {
-            $data['interviewee']['cv'] = new PromiseCollection(promise_for($data['interviewee']['cv'])
+            $data['interviewee']['cv'] = new PromiseSequence(promise_for($data['interviewee']['cv'])
                 ->then(function (array $cvLines) {
                     return array_map(function (array $cvLine) {
                         return new IntervieweeCvLine($cvLine['date'], $cvLine['text']);

--- a/src/Serializer/LabsExperimentNormalizer.php
+++ b/src/Serializer/LabsExperimentNormalizer.php
@@ -3,7 +3,7 @@
 namespace eLife\ApiSdk\Serializer;
 
 use DateTimeImmutable;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Block;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\LabsExperiment;
@@ -22,7 +22,7 @@ final class LabsExperimentNormalizer implements NormalizerInterface, Denormalize
 
     public function denormalize($data, $class, $format = null, array $context = []) : LabsExperiment
     {
-        $data['content'] = new PromiseCollection(promise_for($data['content'])
+        $data['content'] = new PromiseSequence(promise_for($data['content'])
             ->then(function (array $blocks) use ($format, $context) {
                 return array_map(function (array $block) use ($format, $context) {
                     return $this->denormalizer->denormalize($block, Block::class, $format, $context);

--- a/src/Serializer/SubjectsAware.php
+++ b/src/Serializer/SubjectsAware.php
@@ -3,7 +3,7 @@
 namespace eLife\ApiSdk\Serializer;
 
 use eLife\ApiSdk\Client\Subjects;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Promise\CallbackPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use function GuzzleHttp\Promise\all;
@@ -36,7 +36,7 @@ trait SubjectsAware
             });
         }
 
-        return new PromiseCollection($this->globalSubjectsCallback
+        return new PromiseSequence($this->globalSubjectsCallback
             ->then(function (array $foundSubjects) use ($subjects) {
                 return array_intersect_key($foundSubjects, array_flip($subjects));
             })

--- a/test/Collection/ArraySequenceTest.php
+++ b/test/Collection/ArraySequenceTest.php
@@ -2,20 +2,20 @@
 
 namespace test\eLife\ApiSdk\Collection;
 
-use eLife\ApiSdk\Collection;
-use eLife\ApiSdk\Collection\ArrayCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\Sequence;
 use PHPUnit_Framework_TestCase;
 
-final class ArrayCollectionTest extends PHPUnit_Framework_TestCase
+final class ArraySequenceTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @test
      */
-    public function it_is_a_collection()
+    public function it_is_a_sequence()
     {
-        $collection = new ArrayCollection([]);
+        $collection = new ArraySequence([]);
 
-        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertInstanceOf(Sequence::class, $collection);
     }
 
     /**
@@ -23,7 +23,7 @@ final class ArrayCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_be_traversed()
     {
-        $collection = new ArrayCollection([1, 2, 3, 4, 5]);
+        $collection = new ArraySequence([1, 2, 3, 4, 5]);
 
         foreach ($collection as $i => $element) {
             $this->assertSame($i + 1, $element);
@@ -35,7 +35,7 @@ final class ArrayCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_be_counted()
     {
-        $collection = new ArrayCollection([1, 2, 3, 4, 5]);
+        $collection = new ArraySequence([1, 2, 3, 4, 5]);
 
         $this->assertSame(5, $collection->count());
     }
@@ -47,7 +47,7 @@ final class ArrayCollectionTest extends PHPUnit_Framework_TestCase
     {
         $array = [1, 2, 3, 4, 5];
 
-        $collection = new ArrayCollection($array);
+        $collection = new ArraySequence($array);
 
         $this->assertSame($array, $collection->toArray());
     }
@@ -58,7 +58,7 @@ final class ArrayCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_be_sliced(int $offset, int $length = null, array $expected)
     {
-        $collection = new ArrayCollection([1, 2, 3, 4, 5]);
+        $collection = new ArraySequence([1, 2, 3, 4, 5]);
 
         $this->assertSame($expected, $collection->slice($offset, $length)->toArray());
     }
@@ -78,7 +78,7 @@ final class ArrayCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_be_mapped()
     {
-        $collection = new ArrayCollection([1, 2, 3, 4, 5]);
+        $collection = new ArraySequence([1, 2, 3, 4, 5]);
 
         $map = function (int $number) {
             return $number * 100;
@@ -92,7 +92,7 @@ final class ArrayCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_be_filtered()
     {
-        $collection = new ArrayCollection([1, 2, 3, 4, 5]);
+        $collection = new ArraySequence([1, 2, 3, 4, 5]);
 
         $filter = function (int $number) {
             return $number > 3;
@@ -106,7 +106,7 @@ final class ArrayCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_be_reduced()
     {
-        $collection = new ArrayCollection([1, 2, 3, 4, 5]);
+        $collection = new ArraySequence([1, 2, 3, 4, 5]);
 
         $reduce = function (int $carry = null, int $number) {
             return $carry + $number;
@@ -120,7 +120,7 @@ final class ArrayCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_be_sorted()
     {
-        $collection = new ArrayCollection([1, 2, 3, 4, 5]);
+        $collection = new ArraySequence([1, 2, 3, 4, 5]);
 
         $sort = function (int $a, int $b) {
             return $b <=> $a;
@@ -134,7 +134,7 @@ final class ArrayCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_be_reversed()
     {
-        $collection = new ArrayCollection([1, 2, 3, 4, 5]);
+        $collection = new ArraySequence([1, 2, 3, 4, 5]);
 
         $this->assertSame([5, 4, 3, 2, 1], $collection->reverse()->toArray());
     }

--- a/test/Collection/PromiseSequenceTest.php
+++ b/test/Collection/PromiseSequenceTest.php
@@ -3,9 +3,9 @@
 namespace test\eLife\ApiSdk\Collection;
 
 use ArrayObject;
-use eLife\ApiSdk\Collection;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
+use eLife\ApiSdk\Collection\Sequence;
 use Exception;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -14,16 +14,16 @@ use PHPUnit_Framework_TestCase;
 use function GuzzleHttp\Promise\promise_for;
 use function GuzzleHttp\Promise\rejection_for;
 
-final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
+final class PromiseSequenceTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @test
      */
-    public function it_is_a_collection()
+    public function it_is_a_sequence()
     {
-        $collection = new PromiseCollection(promise_for([]));
+        $collection = new PromiseSequence(promise_for([]));
 
-        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertInstanceOf(Sequence::class, $collection);
     }
 
     /**
@@ -31,7 +31,7 @@ final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_is_a_promise()
     {
-        $collection = new PromiseCollection(promise_for([]));
+        $collection = new PromiseSequence(promise_for([]));
 
         $this->assertInstanceOf(PromiseInterface::class, $collection);
     }
@@ -41,7 +41,7 @@ final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_be_traversed()
     {
-        $collection = new PromiseCollection(promise_for([1, 2, 3, 4, 5]));
+        $collection = new PromiseSequence(promise_for([1, 2, 3, 4, 5]));
 
         foreach ($collection as $i => $element) {
             $this->assertSame($i + 1, $element);
@@ -53,7 +53,7 @@ final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_be_counted()
     {
-        $collection = new PromiseCollection(promise_for([1, 2, 3, 4, 5]));
+        $collection = new PromiseSequence(promise_for([1, 2, 3, 4, 5]));
 
         $this->assertSame(5, $collection->count());
     }
@@ -64,7 +64,7 @@ final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_casts_to_an_array($value, array $expected)
     {
-        $collection = new PromiseCollection(promise_for($value));
+        $collection = new PromiseSequence(promise_for($value));
 
         $this->assertSame($expected, $collection->toArray());
     }
@@ -73,7 +73,7 @@ final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
     {
         return [
             'array' => [['foo'], ['foo']],
-            'collection' => [new ArrayCollection(['foo']), ['foo']],
+            'collection' => [new ArraySequence(['foo']), ['foo']],
             'traversable' => [new ArrayObject(['foo']), ['foo']],
             'string' => ['foo', ['foo']],
         ];
@@ -86,7 +86,7 @@ final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
     public function it_can_be_sliced(int $offset, int $length = null, array $expected)
     {
         $promise = new Promise();
-        $collection = new PromiseCollection($promise);
+        $collection = new PromiseSequence($promise);
 
         $sliced = $collection->slice($offset, $length);
 
@@ -111,7 +111,7 @@ final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
     public function it_can_be_mapped()
     {
         $promise = new Promise();
-        $collection = new PromiseCollection($promise);
+        $collection = new PromiseSequence($promise);
 
         $map = function (int $number) {
             return $number * 100;
@@ -130,7 +130,7 @@ final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
     public function it_can_be_filtered()
     {
         $promise = new Promise();
-        $collection = new PromiseCollection($promise);
+        $collection = new PromiseSequence($promise);
 
         $filter = function (int $number) {
             return $number > 3;
@@ -148,7 +148,7 @@ final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_be_reduced()
     {
-        $collection = new PromiseCollection(promise_for([1, 2, 3, 4, 5]));
+        $collection = new PromiseSequence(promise_for([1, 2, 3, 4, 5]));
 
         $reduce = function (int $carry = null, int $number) {
             return $carry + $number;
@@ -162,7 +162,7 @@ final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_be_sorted()
     {
-        $collection = new PromiseCollection(promise_for([1, 2, 3, 4, 5]));
+        $collection = new PromiseSequence(promise_for([1, 2, 3, 4, 5]));
 
         $sort = function (int $a, int $b) {
             return $b <=> $a;
@@ -178,7 +178,7 @@ final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_be_reversed()
     {
-        $collection = new PromiseCollection(promise_for([1, 2, 3, 4, 5]));
+        $collection = new PromiseSequence(promise_for([1, 2, 3, 4, 5]));
 
         $this->assertSame([5, 4, 3, 2, 1], $collection->reverse()->toArray());
     }
@@ -188,7 +188,7 @@ final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_be_chained()
     {
-        $collection = new PromiseCollection(promise_for([1, 2, 3, 4, 5]));
+        $collection = new PromiseSequence(promise_for([1, 2, 3, 4, 5]));
 
         $result = $collection->then(function () {
             return 'foo';
@@ -202,7 +202,7 @@ final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_handle_exceptions()
     {
-        $collection = new PromiseCollection(rejection_for('foo'));
+        $collection = new PromiseSequence(rejection_for('foo'));
 
         $result = $collection->otherwise(function () {
             return 'bar';
@@ -217,7 +217,7 @@ final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
     public function it_has_a_state()
     {
         $promise = new Promise();
-        $collection = new PromiseCollection($promise);
+        $collection = new PromiseSequence($promise);
 
         $this->assertSame(PromiseInterface::PENDING, $collection->getState());
 
@@ -233,7 +233,7 @@ final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
     public function it_cannot_be_resolved()
     {
         $promise = new Promise();
-        $collection = new PromiseCollection($promise);
+        $collection = new PromiseSequence($promise);
 
         $this->expectException(LogicException::class);
 
@@ -246,7 +246,7 @@ final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
     public function it_cannot_be_rejected()
     {
         $promise = new Promise();
-        $collection = new PromiseCollection($promise);
+        $collection = new PromiseSequence($promise);
 
         $this->expectException(LogicException::class);
 
@@ -259,7 +259,7 @@ final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
     public function it_cannot_be_cancelled()
     {
         $promise = new Promise();
-        $collection = new PromiseCollection($promise);
+        $collection = new PromiseSequence($promise);
 
         $this->expectException(LogicException::class);
 
@@ -271,7 +271,7 @@ final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_be_waited_on()
     {
-        $collection = new PromiseCollection(rejection_for('foo'));
+        $collection = new PromiseSequence(rejection_for('foo'));
 
         $this->assertNull($collection->wait(false));
     }
@@ -281,7 +281,7 @@ final class PromiseCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_be_unwrapped()
     {
-        $collection = new PromiseCollection(promise_for([1, 2, 3, 4, 5]));
+        $collection = new PromiseSequence(promise_for([1, 2, 3, 4, 5]));
 
         $this->assertSame([1, 2, 3, 4, 5], $collection->wait()->toArray());
     }

--- a/test/Model/ArticlePoATest.php
+++ b/test/Model/ArticlePoATest.php
@@ -3,7 +3,7 @@
 namespace test\eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
-use eLife\ApiSdk\Collection;
+use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\ArticlePoA;
 use eLife\ApiSdk\Model\ArticleVersion;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -23,12 +23,12 @@ final class ArticlePoATest extends ArticleTest
         int $volume,
         string $elocationId,
         string $pdf = null,
-        Collection $subjects = null,
+        Sequence $subjects = null,
         array $researchOrganisms,
         PromiseInterface $abstract,
         PromiseInterface $issue,
         PromiseInterface $copyright,
-        Collection $authors
+        Sequence $authors
     ) : ArticleVersion {
         return new ArticlePoA($id, $version, $type, $doi, $authorLine, $titlePrefix, $title, $published, $statusDate,
             $volume, $elocationId, $pdf, $subjects, $researchOrganisms, $abstract, $issue, $copyright, $authors);

--- a/test/Model/ArticleSectionTest.php
+++ b/test/Model/ArticleSectionTest.php
@@ -2,7 +2,7 @@
 
 namespace test\eLife\ApiSdk\Model;
 
-use eLife\ApiSdk\Collection\ArrayCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Model\ArticleSection;
 use eLife\ApiSdk\Model\Block\Paragraph;
 use PHPUnit_Framework_TestCase;
@@ -14,7 +14,7 @@ final class ArticleSectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_content()
     {
-        $content = new ArrayCollection([new Paragraph('content')]);
+        $content = new ArraySequence([new Paragraph('content')]);
         $articleSection = new ArticleSection($content);
 
         $this->assertEquals($content, $articleSection->getContent());
@@ -25,8 +25,8 @@ final class ArticleSectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_may_have_a_doi()
     {
-        $with = new ArticleSection(new ArrayCollection([]), '10.1000/182');
-        $withOut = new ArticleSection(new ArrayCollection([]));
+        $with = new ArticleSection(new ArraySequence([]), '10.1000/182');
+        $withOut = new ArticleSection(new ArraySequence([]));
 
         $this->assertSame('10.1000/182', $with->getDoi());
         $this->assertNull($withOut->getDoi());

--- a/test/Model/ArticleTest.php
+++ b/test/Model/ArticleTest.php
@@ -3,9 +3,9 @@
 namespace test\eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
-use eLife\ApiSdk\Collection;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
+use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\ArticleSection;
 use eLife\ApiSdk\Model\ArticleVersion;
 use eLife\ApiSdk\Model\Block\Paragraph;
@@ -30,7 +30,7 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
         $article = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, null, [],
             rejection_for('No abstract'), rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
 
         $this->assertSame('id', $article->getId());
     }
@@ -43,7 +43,7 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
         $article = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, null, [],
             rejection_for('No abstract'), rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
 
         $this->assertSame(1, $article->getVersion());
     }
@@ -56,7 +56,7 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
         $article = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, null, [],
             rejection_for('No abstract'), rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
 
         $this->assertSame('type', $article->getType());
     }
@@ -69,7 +69,7 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
         $article = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, null, [],
             rejection_for('No abstract'), rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
 
         $this->assertSame('doi', $article->getDoi());
     }
@@ -82,7 +82,7 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
         $article = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, null, [],
             rejection_for('No abstract'), rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
 
         $this->assertSame('author line', $article->getAuthorLine());
     }
@@ -95,11 +95,11 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
         $with = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', 'title prefix', 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, null, [],
             rejection_for('No abstract'), rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
         $withOut = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, null, [],
             rejection_for('No abstract'), rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
 
         $this->assertSame('title prefix', $with->getTitlePrefix());
         $this->assertSame('title prefix: title', $with->getFullTitle());
@@ -115,7 +115,7 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
         $article = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, null, [],
             rejection_for('No abstract'), rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
 
         $this->assertSame('title', $article->getTitle());
     }
@@ -128,7 +128,7 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
         $article = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             $date = new DateTimeImmutable(), new DateTimeImmutable('-1 day'), 1, 'elocationId', null, null, [],
             rejection_for('No abstract'), rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
 
         $this->assertEquals($date, $article->getPublishedDate());
     }
@@ -141,7 +141,7 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
         $article = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), $statusDate = new DateTimeImmutable('-1 day'), 1, 'elocationId', null, null, [],
             rejection_for('No abstract'), rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
 
         $this->assertEquals($statusDate, $article->getStatusDate());
     }
@@ -154,7 +154,7 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
         $article = $this->createArticleVersion('id', 2, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, null, [],
             rejection_for('No abstract'), rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
 
         $this->assertSame(1, $article->getVolume());
     }
@@ -167,7 +167,7 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
         $article = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, null, [],
             rejection_for('No abstract'), rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
 
         $this->assertSame('elocationId', $article->getElocationId());
     }
@@ -180,11 +180,11 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
         $with = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', 'http://www.example.com/article.pdf',
             null, [], rejection_for('No abstract'), rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
         $withOut = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, null, [],
             rejection_for('No abstract'), rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
 
         $this->assertSame('http://www.example.com/article.pdf', $with->getPdf());
         $this->assertNull($withOut->getPdf());
@@ -194,12 +194,12 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
      * @test
      * @dataProvider subjectsProvider
      */
-    final public function it_may_have_subjects(Collection $subjects = null, bool $hasSubjects, array $expected)
+    final public function it_may_have_subjects(Sequence $subjects = null, bool $hasSubjects, array $expected)
     {
         $article = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, $subjects, [],
             rejection_for('No abstract'), rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
 
         $this->assertSame($hasSubjects, $article->hasSubjects());
         $this->assertEquals($expected, $article->getSubjects()->toArray());
@@ -220,8 +220,8 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
                 false,
                 [],
             ],
-            'collection' => [
-                new ArrayCollection($subjects),
+            'Sequence' => [
+                new ArraySequence($subjects),
                 true,
                 $subjects,
             ],
@@ -235,9 +235,9 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
     {
         $article = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null,
-            new PromiseCollection(rejection_for('Subjects should not be unwrapped')), [], rejection_for('No abstract'),
+            new PromiseSequence(rejection_for('Subjects should not be unwrapped')), [], rejection_for('No abstract'),
             rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
 
         $this->assertTrue($article->hasSubjects());
     }
@@ -250,11 +250,11 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
         $with = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, null, ['organism'],
             rejection_for('No abstract'), rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
         $withOut = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, null, [],
             rejection_for('No abstract'), rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
 
         $this->assertSame(['organism'], $with->getResearchOrganisms());
         $this->assertEmpty($withOut->getResearchOrganisms());
@@ -267,13 +267,13 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
     {
         $with = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, null, [],
-            promise_for($abstract = new ArticleSection(new ArrayCollection([new Paragraph('abstract')]))),
+            promise_for($abstract = new ArticleSection(new ArraySequence([new Paragraph('abstract')]))),
             rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
         $withOut = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, null, [], promise_for(null),
             rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
 
         $this->assertEquals($abstract, $with->getAbstract());
         $this->assertNull($withOut->getAbstract());
@@ -287,11 +287,11 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
         $with = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, null, [],
             rejection_for('No abstract'), promise_for(3), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
         $withOut = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, null, [],
             rejection_for('No abstract'), promise_for(null), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
 
         $this->assertEquals(3, $with->getIssue());
         $this->assertNull($withOut->getIssue());
@@ -306,7 +306,7 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, null, [],
             rejection_for('No abstract'), promise_for(3),
             promise_for($copyright = new Copyright('license', 'statement')),
-            new PromiseCollection(rejection_for('No authors')));
+            new PromiseSequence(rejection_for('No authors')));
 
         $this->assertEquals($copyright, $article->getCopyright());
     }
@@ -319,7 +319,7 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
         $article = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
             new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, null, [],
             rejection_for('No abstract'), promise_for(3), rejection_for('No copyright'),
-            $authors = new ArrayCollection([new PersonAuthor(new Person('preferred name', 'index name'))]));
+            $authors = new ArraySequence([new PersonAuthor(new Person('preferred name', 'index name'))]));
 
         $this->assertEquals($authors, $article->getAuthors());
     }
@@ -337,11 +337,11 @@ abstract class ArticleTest extends PHPUnit_Framework_TestCase
         int $volume,
         string $elocationId,
         string $pdf = null,
-        Collection $subjects = null,
+        Sequence $subjects = null,
         array $researchOrganisms,
         PromiseInterface $abstract,
         PromiseInterface $issue,
         PromiseInterface $copyright,
-        Collection $authors
+        Sequence $authors
     ) : ArticleVersion;
 }

--- a/test/Model/ArticleVoRTest.php
+++ b/test/Model/ArticleVoRTest.php
@@ -3,9 +3,9 @@
 namespace test\eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
-use eLife\ApiSdk\Collection;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
+use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\ArticleSection;
 use eLife\ApiSdk\Model\ArticleVersion;
 use eLife\ApiSdk\Model\ArticleVoR;
@@ -30,18 +30,18 @@ final class ArticleVoRTest extends ArticleTest
         $with = new ArticleVoR('id', 1, 'type', 'doi', 'author line', null, 'title', new DateTimeImmutable(),
             new DateTimeImmutable(), 1, 'elocationId', null, null, [], rejection_for('No abstract'),
             rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')), 'impact statement', null,
-            new PromiseCollection(rejection_for('No keywords')), rejection_for('No digest'),
-            new PromiseCollection(rejection_for('No content')), new PromiseCollection(rejection_for('No references')),
-            rejection_for('No decision letter'), new PromiseCollection(rejection_for('No decision letter description')),
+            new PromiseSequence(rejection_for('No authors')), 'impact statement', null,
+            new PromiseSequence(rejection_for('No keywords')), rejection_for('No digest'),
+            new PromiseSequence(rejection_for('No content')), new PromiseSequence(rejection_for('No references')),
+            rejection_for('No decision letter'), new PromiseSequence(rejection_for('No decision letter description')),
             rejection_for('No author response'));
         $withOut = new ArticleVoR('id', 1, 'type', 'doi', 'author line', null, 'title', new DateTimeImmutable(),
             new DateTimeImmutable(), 1, 'elocationId', null, null, [], rejection_for('No abstract'),
             rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')), null, null,
-            new PromiseCollection(rejection_for('No keywords')), rejection_for('No digest'),
-            new PromiseCollection(rejection_for('No content')), new PromiseCollection(rejection_for('No references')),
-            rejection_for('No decision letter'), new PromiseCollection(rejection_for('No decision letter description')),
+            new PromiseSequence(rejection_for('No authors')), null, null,
+            new PromiseSequence(rejection_for('No keywords')), rejection_for('No digest'),
+            new PromiseSequence(rejection_for('No content')), new PromiseSequence(rejection_for('No references')),
+            rejection_for('No decision letter'), new PromiseSequence(rejection_for('No decision letter description')),
             rejection_for('No author response'));
 
         $this->assertSame('impact statement', $with->getImpactStatement());
@@ -56,19 +56,19 @@ final class ArticleVoRTest extends ArticleTest
         $with = new ArticleVoR('id', 1, 'type', 'doi', 'author line', null, 'title', new DateTimeImmutable(),
             new DateTimeImmutable(), 1, 'elocationId', null, null, [], rejection_for('No abstract'),
             rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')), null,
+            new PromiseSequence(rejection_for('No authors')), null,
             $image = new Image('', [900 => 'https://placehold.it/900x450']),
-            new PromiseCollection(rejection_for('No keywords')), rejection_for('No digest'),
-            new PromiseCollection(rejection_for('No contents')), new PromiseCollection(rejection_for('No references')),
-            rejection_for('No decision letter'), new PromiseCollection(rejection_for('No decision letter description')),
+            new PromiseSequence(rejection_for('No keywords')), rejection_for('No digest'),
+            new PromiseSequence(rejection_for('No contents')), new PromiseSequence(rejection_for('No references')),
+            rejection_for('No decision letter'), new PromiseSequence(rejection_for('No decision letter description')),
             rejection_for('No author response'));
         $withOut = new ArticleVoR('id', 1, 'type', 'doi', 'author line', null, 'title', new DateTimeImmutable(),
             new DateTimeImmutable(), 1, 'elocationId', null, null, [], rejection_for('No abstract'),
             rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')), null, null,
-            new PromiseCollection(rejection_for('No keywords')), rejection_for('No digest'),
-            new PromiseCollection(rejection_for('No content')), new PromiseCollection(rejection_for('No references')),
-            rejection_for('No decision letter'), new PromiseCollection(rejection_for('No decision letter description')),
+            new PromiseSequence(rejection_for('No authors')), null, null,
+            new PromiseSequence(rejection_for('No keywords')), rejection_for('No digest'),
+            new PromiseSequence(rejection_for('No content')), new PromiseSequence(rejection_for('No references')),
+            rejection_for('No decision letter'), new PromiseSequence(rejection_for('No decision letter description')),
             rejection_for('No author response'));
 
         $this->assertEquals($image, $with->getImage());
@@ -83,10 +83,10 @@ final class ArticleVoRTest extends ArticleTest
         $article = new ArticleVoR('id', 1, 'type', 'doi', 'author line', null, 'title', new DateTimeImmutable(),
             new DateTimeImmutable(), 1, 'elocationId', null, null, [], rejection_for('No abstract'),
             rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')), null, null,
-            $keywords = new ArrayCollection(['keyword']), rejection_for('No digest'),
-            new PromiseCollection(rejection_for('No content')), new PromiseCollection(rejection_for('No references')),
-            rejection_for('No decision letter'), new PromiseCollection(rejection_for('No decision letter description')),
+            new PromiseSequence(rejection_for('No authors')), null, null,
+            $keywords = new ArraySequence(['keyword']), rejection_for('No digest'),
+            new PromiseSequence(rejection_for('No content')), new PromiseSequence(rejection_for('No references')),
+            rejection_for('No decision letter'), new PromiseSequence(rejection_for('No decision letter description')),
             rejection_for('No author response'));
 
         $this->assertEquals($keywords, $article->getKeywords());
@@ -100,19 +100,19 @@ final class ArticleVoRTest extends ArticleTest
         $with = new ArticleVoR('id', 1, 'type', 'doi', 'author line', null, 'title', new DateTimeImmutable(),
             new DateTimeImmutable(), 1, 'elocationId', null, null, [], rejection_for('No abstract'),
             rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')), null, null,
-            new PromiseCollection(rejection_for('No keywords')),
-            promise_for($digest = new ArticleSection(new ArrayCollection([new Paragraph('digest')]))),
-            new PromiseCollection(rejection_for('No content')), new PromiseCollection(rejection_for('No references')),
-            rejection_for('No decision letter'), new PromiseCollection(rejection_for('No decision letter description')),
+            new PromiseSequence(rejection_for('No authors')), null, null,
+            new PromiseSequence(rejection_for('No keywords')),
+            promise_for($digest = new ArticleSection(new ArraySequence([new Paragraph('digest')]))),
+            new PromiseSequence(rejection_for('No content')), new PromiseSequence(rejection_for('No references')),
+            rejection_for('No decision letter'), new PromiseSequence(rejection_for('No decision letter description')),
             rejection_for('No author response'));
         $withOut = new ArticleVoR('id', 1, 'type', 'doi', 'author line', null, 'title', new DateTimeImmutable(),
             new DateTimeImmutable(), 1, 'elocationId', null, null, [], rejection_for('No abstract'),
             rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')), null, null,
-            new PromiseCollection(rejection_for('No keywords')), promise_for(null),
-            new PromiseCollection(rejection_for('No content')), new PromiseCollection(rejection_for('No references')),
-            rejection_for('No decision letter'), new PromiseCollection(rejection_for('No decision letter description')),
+            new PromiseSequence(rejection_for('No authors')), null, null,
+            new PromiseSequence(rejection_for('No keywords')), promise_for(null),
+            new PromiseSequence(rejection_for('No content')), new PromiseSequence(rejection_for('No references')),
+            rejection_for('No decision letter'), new PromiseSequence(rejection_for('No decision letter description')),
             rejection_for('No author response'));
 
         $this->assertEquals($digest, $with->getDigest());
@@ -127,11 +127,11 @@ final class ArticleVoRTest extends ArticleTest
         $article = new ArticleVoR('id', 1, 'type', 'doi', 'author line', null, 'title', new DateTimeImmutable(),
             new DateTimeImmutable(), 1, 'elocationId', null, null, [], rejection_for('No abstract'),
             rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')), null, null,
-            new PromiseCollection(rejection_for('No keywords')), rejection_for('No digest'),
-            $content = new ArrayCollection([new Paragraph('content')]),
-            new PromiseCollection(rejection_for('No references')), rejection_for('No decision letter'),
-            new PromiseCollection(rejection_for('No decision letter description')),
+            new PromiseSequence(rejection_for('No authors')), null, null,
+            new PromiseSequence(rejection_for('No keywords')), rejection_for('No digest'),
+            $content = new ArraySequence([new Paragraph('content')]),
+            new PromiseSequence(rejection_for('No references')), rejection_for('No decision letter'),
+            new PromiseSequence(rejection_for('No decision letter description')),
             rejection_for('No author response'));
 
         $this->assertEquals($content, $article->getContent());
@@ -145,15 +145,15 @@ final class ArticleVoRTest extends ArticleTest
         $article = new ArticleVoR('id', 1, 'type', 'doi', 'author line', null, 'title', new DateTimeImmutable(),
             new DateTimeImmutable(), 1, 'elocationId', null, null, [], rejection_for('No abstract'),
             rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')), null, null,
-            new PromiseCollection(rejection_for('No keywords')),
-            promise_for($digest = new ArticleSection(new ArrayCollection([new Paragraph('digest')]))),
-            new PromiseCollection(rejection_for('No content')), $references = new ArrayCollection([
+            new PromiseSequence(rejection_for('No authors')), null, null,
+            new PromiseSequence(rejection_for('No keywords')),
+            promise_for($digest = new ArticleSection(new ArraySequence([new Paragraph('digest')]))),
+            new PromiseSequence(rejection_for('No content')), $references = new ArraySequence([
                 new BookReference(new ReferenceDate(2000),
                     [new PersonAuthor(new Person('preferred name', 'index name'))], false, 'book title',
                     new Place(null, null, ['publisher'])),
             ]), rejection_for('No decision letter'),
-            new PromiseCollection(rejection_for('No decision letter description')),
+            new PromiseSequence(rejection_for('No decision letter description')),
             rejection_for('No author response'));
 
         $this->assertEquals($references, $article->getReferences());
@@ -167,19 +167,19 @@ final class ArticleVoRTest extends ArticleTest
         $with = new ArticleVoR('id', 1, 'type', 'doi', 'author line', null, 'title', new DateTimeImmutable(),
             new DateTimeImmutable(), 1, 'elocationId', null, null, [], rejection_for('No abstract'),
             rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')), null, null,
-            new PromiseCollection(rejection_for('No keywords')), rejection_for('No digest'),
-            new PromiseCollection(rejection_for('No content')), new PromiseCollection(rejection_for('No references')),
-            promise_for($decisionLetter = new ArticleSection(new ArrayCollection([new Paragraph('Decision letter')]))),
-            new PromiseCollection(rejection_for('No decision letter description')),
+            new PromiseSequence(rejection_for('No authors')), null, null,
+            new PromiseSequence(rejection_for('No keywords')), rejection_for('No digest'),
+            new PromiseSequence(rejection_for('No content')), new PromiseSequence(rejection_for('No references')),
+            promise_for($decisionLetter = new ArticleSection(new ArraySequence([new Paragraph('Decision letter')]))),
+            new PromiseSequence(rejection_for('No decision letter description')),
             rejection_for('No author response'));
         $withOut = new ArticleVoR('id', 1, 'type', 'doi', 'author line', null, 'title', new DateTimeImmutable(),
             new DateTimeImmutable(), 1, 'elocationId', null, null, [], rejection_for('No abstract'),
             rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')), null, null,
-            new PromiseCollection(rejection_for('No keywords')), rejection_for('No digest'),
-            new PromiseCollection(rejection_for('No content')), new PromiseCollection(rejection_for('No references')),
-            promise_for(null), new PromiseCollection(rejection_for('No decision letter description')),
+            new PromiseSequence(rejection_for('No authors')), null, null,
+            new PromiseSequence(rejection_for('No keywords')), rejection_for('No digest'),
+            new PromiseSequence(rejection_for('No content')), new PromiseSequence(rejection_for('No references')),
+            promise_for(null), new PromiseSequence(rejection_for('No decision letter description')),
             rejection_for('No author response'));
 
         $this->assertEquals($decisionLetter, $with->getDecisionLetter());
@@ -194,11 +194,11 @@ final class ArticleVoRTest extends ArticleTest
         $article = new ArticleVoR('id', 1, 'type', 'doi', 'author line', null, 'title', new DateTimeImmutable(),
             new DateTimeImmutable(), 1, 'elocationId', null, null, [], rejection_for('No abstract'),
             rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')), null, null,
-            new PromiseCollection(rejection_for('No keywords')), rejection_for('No digest'),
-            new PromiseCollection(rejection_for('No content')), new PromiseCollection(rejection_for('No references')),
+            new PromiseSequence(rejection_for('No authors')), null, null,
+            new PromiseSequence(rejection_for('No keywords')), rejection_for('No digest'),
+            new PromiseSequence(rejection_for('No content')), new PromiseSequence(rejection_for('No references')),
             rejection_for('No decision letter'),
-            $decisionLetterDescription = new ArrayCollection([new Paragraph('Decision letter description')]),
+            $decisionLetterDescription = new ArraySequence([new Paragraph('Decision letter description')]),
             rejection_for('No author response'));
 
         $this->assertEquals($decisionLetterDescription, $article->getDecisionLetterDescription());
@@ -212,18 +212,18 @@ final class ArticleVoRTest extends ArticleTest
         $with = new ArticleVoR('id', 1, 'type', 'doi', 'author line', null, 'title', new DateTimeImmutable(),
             new DateTimeImmutable(), 1, 'elocationId', null, null, [], rejection_for('No abstract'),
             rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')), null, null,
-            new PromiseCollection(rejection_for('No keywords')), rejection_for('No digest'),
-            new PromiseCollection(rejection_for('No content')), new PromiseCollection(rejection_for('No references')),
-            rejection_for('No decision letter'), new PromiseCollection(rejection_for('No decision letter description')),
-            promise_for($authorResponse = new ArticleSection(new ArrayCollection([new Paragraph('Author response')]))));
+            new PromiseSequence(rejection_for('No authors')), null, null,
+            new PromiseSequence(rejection_for('No keywords')), rejection_for('No digest'),
+            new PromiseSequence(rejection_for('No content')), new PromiseSequence(rejection_for('No references')),
+            rejection_for('No decision letter'), new PromiseSequence(rejection_for('No decision letter description')),
+            promise_for($authorResponse = new ArticleSection(new ArraySequence([new Paragraph('Author response')]))));
         $withOut = new ArticleVoR('id', 1, 'type', 'doi', 'author line', null, 'title', new DateTimeImmutable(),
             new DateTimeImmutable(), 1, 'elocationId', null, null, [], rejection_for('No abstract'),
             rejection_for('No issue'), rejection_for('No copyright'),
-            new PromiseCollection(rejection_for('No authors')), null, null,
-            new PromiseCollection(rejection_for('No keywords')), rejection_for('No digest'),
-            new PromiseCollection(rejection_for('No content')), new PromiseCollection(rejection_for('No references')),
-            rejection_for('No decision letter'), new PromiseCollection(rejection_for('No decision letter description')),
+            new PromiseSequence(rejection_for('No authors')), null, null,
+            new PromiseSequence(rejection_for('No keywords')), rejection_for('No digest'),
+            new PromiseSequence(rejection_for('No content')), new PromiseSequence(rejection_for('No references')),
+            rejection_for('No decision letter'), new PromiseSequence(rejection_for('No decision letter description')),
             promise_for(null));
 
         $this->assertEquals($authorResponse, $with->getAuthorResponse());
@@ -243,18 +243,18 @@ final class ArticleVoRTest extends ArticleTest
         int $volume,
         string $elocationId,
         string $pdf = null,
-        Collection $subjects = null,
+        Sequence $subjects = null,
         array $researchOrganisms,
         PromiseInterface $abstract,
         PromiseInterface $issue,
         PromiseInterface $copyright,
-        Collection $authors
+        Sequence $authors
     ) : ArticleVersion {
         return new ArticleVoR($id, $version, $type, $doi, $authorLine, $titlePrefix, $title, $published, $statusDate,
             $volume, $elocationId, $pdf, $subjects, $researchOrganisms, $abstract, $issue, $copyright, $authors, null,
-            null, new PromiseCollection(rejection_for('No keywords')), rejection_for('No digest'),
-            new PromiseCollection(rejection_for('No content')), new PromiseCollection(rejection_for('No references')),
-            rejection_for('No decision letter'), new PromiseCollection(rejection_for('No decision letter description')),
+            null, new PromiseSequence(rejection_for('No keywords')), rejection_for('No digest'),
+            new PromiseSequence(rejection_for('No content')), new PromiseSequence(rejection_for('No references')),
+            rejection_for('No decision letter'), new PromiseSequence(rejection_for('No decision letter description')),
             rejection_for('No author response'));
     }
 }

--- a/test/Model/BlogArticleTest.php
+++ b/test/Model/BlogArticleTest.php
@@ -4,8 +4,8 @@ namespace test\eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
 use eLife\ApiSdk\Collection;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Block;
 use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Image;
@@ -22,8 +22,8 @@ final class BlogArticleTest extends PHPUnit_Framework_TestCase
     public function it_has_an_id()
     {
         $blogArticle = new BlogArticle('id', 'title', new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Full blog article should not be unwrapped')),
-            new PromiseCollection(rejection_for('Subjects should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full blog article should not be unwrapped')),
+            new PromiseSequence(rejection_for('Subjects should not be unwrapped'))
         );
 
         $this->assertSame('id', $blogArticle->getId());
@@ -35,8 +35,8 @@ final class BlogArticleTest extends PHPUnit_Framework_TestCase
     public function it_has_a_title()
     {
         $blogArticle = new BlogArticle('id', 'title', new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Full blog article should not be unwrapped')),
-            new PromiseCollection(rejection_for('Subjects should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full blog article should not be unwrapped')),
+            new PromiseSequence(rejection_for('Subjects should not be unwrapped'))
         );
 
         $this->assertSame('title', $blogArticle->getTitle());
@@ -48,12 +48,12 @@ final class BlogArticleTest extends PHPUnit_Framework_TestCase
     public function it_may_have_an_impact_statement()
     {
         $with = new BlogArticle('id', 'title', new DateTimeImmutable(), 'impact statement',
-            new PromiseCollection(rejection_for('Full blog article should not be unwrapped')),
-            new PromiseCollection(rejection_for('Subjects should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full blog article should not be unwrapped')),
+            new PromiseSequence(rejection_for('Subjects should not be unwrapped'))
         );
         $withOut = new BlogArticle('id', 'title', new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Full blog article should not be unwrapped')),
-            new PromiseCollection(rejection_for('Subjects should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full blog article should not be unwrapped')),
+            new PromiseSequence(rejection_for('Subjects should not be unwrapped'))
         );
 
         $this->assertSame('impact statement', $with->getImpactStatement());
@@ -66,8 +66,8 @@ final class BlogArticleTest extends PHPUnit_Framework_TestCase
     public function it_has_a_published_date()
     {
         $blogArticle = new BlogArticle('id', 'title', $date = new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Full blog article should not be unwrapped')),
-            new PromiseCollection(rejection_for('Subjects should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full blog article should not be unwrapped')),
+            new PromiseSequence(rejection_for('Subjects should not be unwrapped'))
         );
 
         $this->assertEquals($date, $blogArticle->getPublishedDate());
@@ -80,7 +80,7 @@ final class BlogArticleTest extends PHPUnit_Framework_TestCase
     public function it_may_have_subjects(Collection $subjects = null, bool $hasSubjects, array $expected)
     {
         $blogArticle = new BlogArticle('id', 'title', new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Full blog article should not be unwrapped')), $subjects
+            new PromiseSequence(rejection_for('Full blog article should not be unwrapped')), $subjects
         );
 
         $this->assertSame($hasSubjects, $blogArticle->hasSubjects());
@@ -103,7 +103,7 @@ final class BlogArticleTest extends PHPUnit_Framework_TestCase
                 [],
             ],
             'collection' => [
-                new ArrayCollection($subjects),
+                new ArraySequence($subjects),
                 true,
                 $subjects,
             ],
@@ -116,8 +116,8 @@ final class BlogArticleTest extends PHPUnit_Framework_TestCase
     public function it_does_not_unwrap_subjects_when_checking_if_it_has_any()
     {
         $blogArticle = new BlogArticle('id', 'title', new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Full blog article should not be unwrapped')),
-            new PromiseCollection(rejection_for('Subjects should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full blog article should not be unwrapped')),
+            new PromiseSequence(rejection_for('Subjects should not be unwrapped'))
         );
 
         $this->assertTrue($blogArticle->hasSubjects());
@@ -140,8 +140,8 @@ final class BlogArticleTest extends PHPUnit_Framework_TestCase
             new Block\YouTube('foo', 300, 200),
         ];
 
-        $blogArticle = new BlogArticle('id', 'title', new DateTimeImmutable(), null, new ArrayCollection($content),
-            new PromiseCollection(rejection_for('Subjects should not be unwrapped'))
+        $blogArticle = new BlogArticle('id', 'title', new DateTimeImmutable(), null, new ArraySequence($content),
+            new PromiseSequence(rejection_for('Subjects should not be unwrapped'))
         );
 
         $this->assertEquals($content, $blogArticle->getContent()->toArray());

--- a/test/Model/EventTest.php
+++ b/test/Model/EventTest.php
@@ -4,8 +4,8 @@ namespace test\eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
 use DateTimeZone;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Block;
 use eLife\ApiSdk\Model\Event;
 use eLife\ApiSdk\Model\Place;
@@ -21,7 +21,7 @@ final class EventTest extends PHPUnit_Framework_TestCase
     public function it_has_an_id()
     {
         $event = new Event('id', 'title', null, new DateTimeImmutable(), new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Event content should not be unwrapped')),
+            new PromiseSequence(rejection_for('Event content should not be unwrapped')),
             rejection_for('Event venue should not be unwrapped'));
 
         $this->assertSame('id', $event->getId());
@@ -33,7 +33,7 @@ final class EventTest extends PHPUnit_Framework_TestCase
     public function it_has_a_title()
     {
         $event = new Event('id', 'title', null, new DateTimeImmutable(), new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Event content should not be unwrapped')),
+            new PromiseSequence(rejection_for('Event content should not be unwrapped')),
             rejection_for('Event venue should not be unwrapped'));
 
         $this->assertSame('title', $event->getTitle());
@@ -45,10 +45,10 @@ final class EventTest extends PHPUnit_Framework_TestCase
     public function it_may_have_an_impact_statement()
     {
         $with = new Event('id', 'title', 'impact statement', new DateTimeImmutable(), new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Event content should not be unwrapped')),
+            new PromiseSequence(rejection_for('Event content should not be unwrapped')),
             rejection_for('Event venue should not be unwrapped'));
         $withOut = new Event('id', 'title', null, new DateTimeImmutable(), new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Event content should not be unwrapped')),
+            new PromiseSequence(rejection_for('Event content should not be unwrapped')),
             rejection_for('Event venue should not be unwrapped'));
 
         $this->assertSame('impact statement', $with->getImpactStatement());
@@ -61,7 +61,7 @@ final class EventTest extends PHPUnit_Framework_TestCase
     public function it_has_a_start_date()
     {
         $event = new Event('id', 'title', null, $starts = new DateTimeImmutable(), new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Event content should not be unwrapped')),
+            new PromiseSequence(rejection_for('Event content should not be unwrapped')),
             rejection_for('Event venue should not be unwrapped'));
 
         $this->assertEquals($starts, $event->getStarts());
@@ -73,7 +73,7 @@ final class EventTest extends PHPUnit_Framework_TestCase
     public function it_has_an_end_date()
     {
         $event = new Event('id', 'title', null, new DateTimeImmutable(), $ends = new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Event content should not be unwrapped')),
+            new PromiseSequence(rejection_for('Event content should not be unwrapped')),
             rejection_for('Event venue should not be unwrapped'));
 
         $this->assertEquals($ends, $event->getEnds());
@@ -86,10 +86,10 @@ final class EventTest extends PHPUnit_Framework_TestCase
     {
         $with = new Event('id', 'title', 'impact statement', new DateTimeImmutable(), new DateTimeImmutable(),
             $timeZone = new DateTimeZone('Europe/London'),
-            new PromiseCollection(rejection_for('Event content should not be unwrapped')),
+            new PromiseSequence(rejection_for('Event content should not be unwrapped')),
             rejection_for('Event venue should not be unwrapped'));
         $withOut = new Event('id', 'title', null, new DateTimeImmutable(), new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Event content should not be unwrapped')),
+            new PromiseSequence(rejection_for('Event content should not be unwrapped')),
             rejection_for('Event venue should not be unwrapped'));
 
         $this->assertEquals($timeZone, $with->getTimeZone());
@@ -104,7 +104,7 @@ final class EventTest extends PHPUnit_Framework_TestCase
         $content = [new Block\Paragraph('foo')];
 
         $event = new Event('id', 'title', null, new DateTimeImmutable(), new DateTimeImmutable(), null,
-            new ArrayCollection($content),
+            new ArraySequence($content),
             rejection_for('Event venue should not be unwrapped'));
 
         $this->assertEquals($content, $event->getContent()->toArray());
@@ -118,9 +118,9 @@ final class EventTest extends PHPUnit_Framework_TestCase
         $venue = new Place(null, null, ['foo']);
 
         $with = new Event('id', 'title', null, new DateTimeImmutable(), new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Event content should not be unwrapped')), promise_for($venue));
+            new PromiseSequence(rejection_for('Event content should not be unwrapped')), promise_for($venue));
         $withOut = new Event('id', 'title', null, new DateTimeImmutable(), new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Event content should not be unwrapped')));
+            new PromiseSequence(rejection_for('Event content should not be unwrapped')));
 
         $this->assertTrue($with->hasVenue());
         $this->assertEquals($venue, $with->getVenue()->wait());

--- a/test/Model/GroupAuthorTest.php
+++ b/test/Model/GroupAuthorTest.php
@@ -2,7 +2,7 @@
 
 namespace test\eLife\ApiSdk\Model;
 
-use eLife\ApiSdk\Collection\ArrayCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Model\Author;
 use eLife\ApiSdk\Model\GroupAuthor;
 use eLife\ApiSdk\Model\Person;
@@ -15,7 +15,7 @@ final class GroupAuthorTest extends AuthorTest
      */
     public function it_has_a_name()
     {
-        $author = new GroupAuthor('name', new ArrayCollection([]));
+        $author = new GroupAuthor('name', new ArraySequence([]));
 
         $this->assertSame('name', $author->getName());
     }
@@ -26,8 +26,8 @@ final class GroupAuthorTest extends AuthorTest
     public function it_may_have_people()
     {
         $with = new GroupAuthor('name',
-            $people = new ArrayCollection([new PersonAuthor(new Person('preferred name', 'index name'))]));
-        $withOut = new GroupAuthor('name', new ArrayCollection([]));
+            $people = new ArraySequence([new PersonAuthor(new Person('preferred name', 'index name'))]));
+        $withOut = new GroupAuthor('name', new ArraySequence([]));
 
         $this->assertEquals($people, $with->getPeople());
         $this->assertEmpty($withOut->getPeople());
@@ -38,9 +38,9 @@ final class GroupAuthorTest extends AuthorTest
      */
     public function it_may_have_groups()
     {
-        $with = new GroupAuthor('name', new ArrayCollection([]),
+        $with = new GroupAuthor('name', new ArraySequence([]),
             $groups = ['group' => [new Person('preferred name', 'index name')]]);
-        $withOut = new GroupAuthor('name', new ArrayCollection([]));
+        $withOut = new GroupAuthor('name', new ArraySequence([]));
 
         $this->assertEquals($groups, $with->getGroups());
         $this->assertEmpty($withOut->getGroups());
@@ -55,7 +55,7 @@ final class GroupAuthorTest extends AuthorTest
         array $phoneNumbers = [],
         array $postalAddresses = []
     ) : Author {
-        return new GroupAuthor('name', new ArrayCollection([]), [], $affiliations,
+        return new GroupAuthor('name', new ArraySequence([]), [], $affiliations,
             $competingInterests, $contribution, $emailAddresses, $equalContributionGroups, $phoneNumbers,
             $postalAddresses);
     }

--- a/test/Model/InterviewTest.php
+++ b/test/Model/InterviewTest.php
@@ -3,8 +3,8 @@
 namespace test\eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Block;
 use eLife\ApiSdk\Model\Interview;
 use eLife\ApiSdk\Model\Interviewee;
@@ -21,9 +21,9 @@ final class InterviewTest extends PHPUnit_Framework_TestCase
     {
         $person = new Person('preferred name', 'index name');
         $interviewee = new Interviewee($person,
-            new PromiseCollection(rejection_for('Full interviewee should not be unwrapped')));
+            new PromiseSequence(rejection_for('Full interviewee should not be unwrapped')));
         $interview = new Interview('id', $interviewee, 'title', new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Full interview should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full interview should not be unwrapped'))
         );
 
         $this->assertSame('id', $interview->getId());
@@ -36,9 +36,9 @@ final class InterviewTest extends PHPUnit_Framework_TestCase
     {
         $person = new Person('preferred name', 'index name');
         $interviewee = new Interviewee($person,
-            new PromiseCollection(rejection_for('Full interviewee should not be unwrapped')));
+            new PromiseSequence(rejection_for('Full interviewee should not be unwrapped')));
         $interview = new Interview('id', $interviewee, 'title', new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Full interview should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full interview should not be unwrapped'))
         );
 
         $this->assertEquals($interviewee, $interview->getInterviewee());
@@ -51,9 +51,9 @@ final class InterviewTest extends PHPUnit_Framework_TestCase
     {
         $person = new Person('preferred name', 'index name');
         $interviewee = new Interviewee($person,
-            new PromiseCollection(rejection_for('Full interviewee should not be unwrapped')));
+            new PromiseSequence(rejection_for('Full interviewee should not be unwrapped')));
         $interview = new Interview('id', $interviewee, 'title', new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Full interview should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full interview should not be unwrapped'))
         );
 
         $this->assertSame('title', $interview->getTitle());
@@ -66,15 +66,15 @@ final class InterviewTest extends PHPUnit_Framework_TestCase
     {
         $person = new Person('preferred name', 'index name');
         $intervieweeWith = new Interviewee($person,
-            new PromiseCollection(rejection_for('Full interviewee should not be unwrapped')));
+            new PromiseSequence(rejection_for('Full interviewee should not be unwrapped')));
         $intervieweeWithOut = new Interviewee($person,
-            new PromiseCollection(rejection_for('Full interviewee should not be unwrapped')));
+            new PromiseSequence(rejection_for('Full interviewee should not be unwrapped')));
 
         $with = new Interview('id', $intervieweeWith, 'title', new DateTimeImmutable(), 'impact statement',
-            new PromiseCollection(rejection_for('Full interview should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full interview should not be unwrapped'))
         );
         $withOut = new Interview('id', $intervieweeWithOut, 'title', new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Full interview should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full interview should not be unwrapped'))
         );
 
         $this->assertSame('impact statement', $with->getImpactStatement());
@@ -88,9 +88,9 @@ final class InterviewTest extends PHPUnit_Framework_TestCase
     {
         $person = new Person('preferred name', 'index name');
         $interviewee = new Interviewee($person,
-            new PromiseCollection(rejection_for('Full interviewee should not be unwrapped')));
+            new PromiseSequence(rejection_for('Full interviewee should not be unwrapped')));
         $interview = new Interview('id', $interviewee, 'title', $date = new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Full interview should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full interview should not be unwrapped'))
         );
 
         $this->assertEquals($date, $interview->getPublishedDate());
@@ -105,10 +105,10 @@ final class InterviewTest extends PHPUnit_Framework_TestCase
 
         $person = new Person('preferred name', 'index name');
         $interviewee = new Interviewee($person,
-            new PromiseCollection(rejection_for('Full interviewee should not be unwrapped')));
+            new PromiseSequence(rejection_for('Full interviewee should not be unwrapped')));
 
         $interview = new Interview('id', $interviewee, 'title', new DateTimeImmutable(), null,
-            new ArrayCollection($content)
+            new ArraySequence($content)
         );
 
         $this->assertEquals($content, $interview->getContent()->toArray());

--- a/test/Model/IntervieweeTest.php
+++ b/test/Model/IntervieweeTest.php
@@ -3,8 +3,8 @@
 namespace test\eLife\ApiSdk\Model;
 
 use eLife\ApiSdk\Collection;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Interviewee;
 use eLife\ApiSdk\Model\IntervieweeCvLine;
 use eLife\ApiSdk\Model\Person;
@@ -20,7 +20,7 @@ final class IntervieweeTest extends PHPUnit_Framework_TestCase
     {
         $person = new Person('preferred name', 'index name');
         $interviewee = new Interviewee($person,
-            new PromiseCollection(rejection_for('Full interviewee should not be unwrapped')));
+            new PromiseSequence(rejection_for('Full interviewee should not be unwrapped')));
 
         $this->assertEquals($person, $interviewee->getPerson());
     }
@@ -49,7 +49,7 @@ final class IntervieweeTest extends PHPUnit_Framework_TestCase
                 [],
             ],
             'collection' => [
-                new ArrayCollection($cvLines),
+                new ArraySequence($cvLines),
                 true,
                 $cvLines,
             ],
@@ -63,7 +63,7 @@ final class IntervieweeTest extends PHPUnit_Framework_TestCase
     {
         $person = new Person('preferred name', 'index name');
         $interviewee = new Interviewee($person,
-            new PromiseCollection(rejection_for('CV lines should not be unwrapped')));
+            new PromiseSequence(rejection_for('CV lines should not be unwrapped')));
 
         $this->assertTrue($interviewee->hasCvLines());
     }

--- a/test/Model/LabsExperimentTest.php
+++ b/test/Model/LabsExperimentTest.php
@@ -3,8 +3,8 @@
 namespace test\eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Block;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\LabsExperiment;
@@ -20,7 +20,7 @@ final class LabsExperimentTest extends PHPUnit_Framework_TestCase
     {
         $labsExperiment = new LabsExperiment(1, 'title', new DateTimeImmutable(), null,
             new Image('', [900 => 'https://placehold.it/900x450']),
-            new PromiseCollection(rejection_for('Full Labs experiment should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full Labs experiment should not be unwrapped'))
         );
 
         $this->assertSame(1, $labsExperiment->getNumber());
@@ -33,7 +33,7 @@ final class LabsExperimentTest extends PHPUnit_Framework_TestCase
     {
         $labsExperiment = new LabsExperiment(1, 'title', new DateTimeImmutable(), null,
             new Image('', [900 => 'https://placehold.it/900x450']),
-            new PromiseCollection(rejection_for('Full Labs experiment should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full Labs experiment should not be unwrapped'))
         );
 
         $this->assertSame('title', $labsExperiment->getTitle());
@@ -46,11 +46,11 @@ final class LabsExperimentTest extends PHPUnit_Framework_TestCase
     {
         $with = new LabsExperiment(1, 'title', new DateTimeImmutable(), 'impact statement',
             new Image('', [900 => 'https://placehold.it/900x450']),
-            new PromiseCollection(rejection_for('Full Labs experiment should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full Labs experiment should not be unwrapped'))
         );
         $withOut = new LabsExperiment(1, 'title', new DateTimeImmutable(), null,
             new Image('', [900 => 'https://placehold.it/900x450']),
-            new PromiseCollection(rejection_for('Full Labs experiment should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full Labs experiment should not be unwrapped'))
         );
 
         $this->assertSame('impact statement', $with->getImpactStatement());
@@ -64,7 +64,7 @@ final class LabsExperimentTest extends PHPUnit_Framework_TestCase
     {
         $labsExperiment = new LabsExperiment(1, 'title', $date = new DateTimeImmutable(), null,
             new Image('', [900 => 'https://placehold.it/900x450']),
-            new PromiseCollection(rejection_for('Full Labs experiment should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full Labs experiment should not be unwrapped'))
         );
 
         $this->assertEquals($date, $labsExperiment->getPublishedDate());
@@ -77,7 +77,7 @@ final class LabsExperimentTest extends PHPUnit_Framework_TestCase
     {
         $labsExperiment = new LabsExperiment(1, 'title', new DateTimeImmutable(), null,
             $image = new Image('', [900 => 'https://placehold.it/900x450']),
-            new PromiseCollection(rejection_for('Full Labs experiment should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full Labs experiment should not be unwrapped'))
         );
 
         $this->assertEquals($image, $labsExperiment->getImage());
@@ -91,7 +91,7 @@ final class LabsExperimentTest extends PHPUnit_Framework_TestCase
         $content = [new Block\Paragraph('foo')];
 
         $labsExperiment = new LabsExperiment(1, 'title', new DateTimeImmutable(), null,
-            new Image('', [900 => 'https://placehold.it/900x450']), new ArrayCollection($content)
+            new Image('', [900 => 'https://placehold.it/900x450']), new ArraySequence($content)
         );
 
         $this->assertEquals($content, $labsExperiment->getContent()->toArray());

--- a/test/Serializer/ArticlePoANormalizerTest.php
+++ b/test/Serializer/ArticlePoANormalizerTest.php
@@ -5,8 +5,8 @@ namespace test\eLife\ApiSdk\Serializer;
 use DateTimeImmutable;
 use eLife\ApiClient\ApiClient\SubjectsClient;
 use eLife\ApiSdk\Client\Subjects;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\ArticlePoA;
 use eLife\ApiSdk\Model\ArticleSection;
 use eLife\ApiSdk\Model\Block\Paragraph;
@@ -72,9 +72,9 @@ final class ArticlePoANormalizerTest extends ApiTestCase
     public function canNormalizeProvider() : array
     {
         $articlePoA = new ArticlePoA('id', 1, 'type', 'doi', 'author line', null, 'title', new DateTimeImmutable(),
-            new DateTimeImmutable(), 1, 'elocationId', null, new ArrayCollection([]), [], promise_for(null),
+            new DateTimeImmutable(), 1, 'elocationId', null, new ArraySequence([]), [], promise_for(null),
             promise_for(null), promise_for(new Copyright('license', 'statement', 'holder')),
-            new ArrayCollection([new PersonAuthor(new Person('preferred name', 'index name'))]));
+            new ArraySequence([new PersonAuthor(new Person('preferred name', 'index name'))]));
 
         return [
             'article poa' => [$articlePoA, null, true],
@@ -160,10 +160,10 @@ final class ArticlePoANormalizerTest extends ApiTestCase
         return [
             'complete' => [
                 new ArticlePoA('id', 1, 'type', 'doi', 'author line', 'title prefix', 'title', $date, $statusDate, 2,
-                    'elocationId', 'http://www.example.com/', new ArrayCollection([$subject]), ['research organism'],
-                    promise_for(new ArticleSection(new ArrayCollection([new Paragraph('abstract')]))), promise_for(1),
+                    'elocationId', 'http://www.example.com/', new ArraySequence([$subject]), ['research organism'],
+                    promise_for(new ArticleSection(new ArraySequence([new Paragraph('abstract')]))), promise_for(1),
                     promise_for(new Copyright('license', 'statement', 'holder')),
-                    new ArrayCollection([new PersonAuthor(new Person('preferred name', 'index name'))])),
+                    new ArraySequence([new PersonAuthor(new Person('preferred name', 'index name'))])),
                 [],
                 [
                     'id' => 'id',
@@ -210,7 +210,7 @@ final class ArticlePoANormalizerTest extends ApiTestCase
                 new ArticlePoA('id', 1, 'type', 'doi', 'author line', null, 'title', $date, $statusDate, 1,
                     'elocationId', null, null, [], promise_for(null), promise_for(null),
                     promise_for(new Copyright('license', 'statement')),
-                    new ArrayCollection([new PersonAuthor(new Person('preferred name', 'index name'))])),
+                    new ArraySequence([new PersonAuthor(new Person('preferred name', 'index name'))])),
                 [],
                 [
                     'id' => 'id',
@@ -241,10 +241,10 @@ final class ArticlePoANormalizerTest extends ApiTestCase
             ],
             'complete snippet' => [
                 new ArticlePoA('id', 1, 'type', 'doi', 'author line', 'title prefix', 'title', $date, $statusDate, 2,
-                    'elocationId', 'http://www.example.com/', new ArrayCollection([$subject]), ['research organism'],
+                    'elocationId', 'http://www.example.com/', new ArraySequence([$subject]), ['research organism'],
                     rejection_for('Abstract should not be unwrapped'), rejection_for('Issue should not be unwrapped'),
                     rejection_for('Copyright should not be unwrapped'),
-                    new PromiseCollection(rejection_for('Authors should not be unwrapped'))),
+                    new PromiseSequence(rejection_for('Authors should not be unwrapped'))),
                 ['snippet' => true],
                 [
                     'id' => 'id',
@@ -269,7 +269,7 @@ final class ArticlePoANormalizerTest extends ApiTestCase
                     'elocationId', null, null, [], rejection_for('Abstract should not be unwrapped'),
                     rejection_for('Issue should not be unwrapped'),
                     rejection_for('Copyright should not be unwrapped'),
-                    new PromiseCollection(rejection_for('Authors should not be unwrapped'))),
+                    new PromiseSequence(rejection_for('Authors should not be unwrapped'))),
                 ['snippet' => true],
                 [
                     'id' => 'id',

--- a/test/Serializer/ArticleVoRNormalizerTest.php
+++ b/test/Serializer/ArticleVoRNormalizerTest.php
@@ -5,8 +5,8 @@ namespace test\eLife\ApiSdk\Serializer;
 use DateTimeImmutable;
 use eLife\ApiClient\ApiClient\SubjectsClient;
 use eLife\ApiSdk\Client\Subjects;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\ArticleSection;
 use eLife\ApiSdk\Model\ArticleVoR;
 use eLife\ApiSdk\Model\Block\Paragraph;
@@ -82,12 +82,12 @@ final class ArticleVoRNormalizerTest extends ApiTestCase
     public function canNormalizeProvider() : array
     {
         $articleVoR = new ArticleVoR('id', 1, 'type', 'doi', 'author line', null, 'title', new DateTimeImmutable(),
-            new DateTimeImmutable(), 1, 'elocationId', null, new ArrayCollection([]), [], promise_for(null),
+            new DateTimeImmutable(), 1, 'elocationId', null, new ArraySequence([]), [], promise_for(null),
             promise_for(null), promise_for(new Copyright('license', 'statement', 'holder')),
-            new ArrayCollection([new PersonAuthor(new Person('preferred name', 'index name'))]), null, null,
-            new ArrayCollection([]), promise_for(null),
-            new ArrayCollection([new Section('section', 'sectionId', [new Paragraph('paragraph')])]),
-            new ArrayCollection([]), promise_for(null), new ArrayCollection([]), promise_for(null));
+            new ArraySequence([new PersonAuthor(new Person('preferred name', 'index name'))]), null, null,
+            new ArraySequence([]), promise_for(null),
+            new ArraySequence([new Section('section', 'sectionId', [new Paragraph('paragraph')])]),
+            new ArraySequence([]), promise_for(null), new ArraySequence([]), promise_for(null));
 
         return [
             'article vor' => [$articleVoR, null, true],
@@ -173,21 +173,21 @@ final class ArticleVoRNormalizerTest extends ApiTestCase
         return [
             'complete' => [
                 new ArticleVoR('id', 1, 'type', 'doi', 'author line', 'title prefix', 'title', $date, $statusDate, 1,
-                    'elocationId', 'http://www.example.com/', new ArrayCollection([$subject]), ['research organism'],
-                    promise_for(new ArticleSection(new ArrayCollection([new Paragraph('abstract')]), 'abstractDoi')),
+                    'elocationId', 'http://www.example.com/', new ArraySequence([$subject]), ['research organism'],
+                    promise_for(new ArticleSection(new ArraySequence([new Paragraph('abstract')]), 'abstractDoi')),
                     promise_for(1), promise_for(new Copyright('license', 'statement', 'holder')),
-                    new ArrayCollection([new PersonAuthor(new Person('preferred name', 'index name'))]),
-                    'impact statement', $image, new ArrayCollection(['keyword']),
-                    promise_for(new ArticleSection(new ArrayCollection([new Paragraph('digest')]), 'digestDoi')),
-                    new ArrayCollection([new Section('Section', 'section', [new Paragraph('content')])]),
-                    new ArrayCollection([
+                    new ArraySequence([new PersonAuthor(new Person('preferred name', 'index name'))]),
+                    'impact statement', $image, new ArraySequence(['keyword']),
+                    promise_for(new ArticleSection(new ArraySequence([new Paragraph('digest')]), 'digestDoi')),
+                    new ArraySequence([new Section('Section', 'section', [new Paragraph('content')])]),
+                    new ArraySequence([
                         new BookReference(ReferenceDate::fromString('2000-01-01'),
                             [new PersonAuthor(new Person('preferred name', 'index name'))], true, 'book title',
                             new Place(null, null, ['publisher']), 'volume', 'edition', '10.1000/182', 18183754,
                             '978-3-16-148410-0'),
-                    ]), promise_for(new ArticleSection(new ArrayCollection([new Paragraph('Decision letter content')]),
-                        'decisionLetterDoi')), new ArrayCollection([new Paragraph('Decision letter description')]),
-                    promise_for(new ArticleSection(new ArrayCollection([new Paragraph('Author response content')]),
+                    ]), promise_for(new ArticleSection(new ArraySequence([new Paragraph('Decision letter content')]),
+                        'decisionLetterDoi')), new ArraySequence([new Paragraph('Decision letter description')]),
+                    promise_for(new ArticleSection(new ArraySequence([new Paragraph('Author response content')]),
                         'authorResponseDoi'))),
                 [],
                 [
@@ -326,10 +326,10 @@ final class ArticleVoRNormalizerTest extends ApiTestCase
                 new ArticleVoR('id', 1, 'type', 'doi', 'author line', null, 'title', $date, $statusDate, 1,
                     'elocationId', null, null, [], promise_for(null), promise_for(null),
                     promise_for(new Copyright('license', 'statement')),
-                    new ArrayCollection([new PersonAuthor(new Person('preferred name', 'index name'))]), null, null,
-                    new ArrayCollection([]), promise_for(null),
-                    new ArrayCollection([new Section('Section', 'section', [new Paragraph('content')])]),
-                    new ArrayCollection([]), promise_for(null), new ArrayCollection([]), promise_for(null)),
+                    new ArraySequence([new PersonAuthor(new Person('preferred name', 'index name'))]), null, null,
+                    new ArraySequence([]), promise_for(null),
+                    new ArraySequence([new Section('Section', 'section', [new Paragraph('content')])]),
+                    new ArraySequence([]), promise_for(null), new ArraySequence([]), promise_for(null)),
                 [],
                 [
                     'id' => 'id',
@@ -373,16 +373,16 @@ final class ArticleVoRNormalizerTest extends ApiTestCase
             ],
             'complete snippet' => [
                 new ArticleVoR('id', 1, 'type', 'doi', 'author line', 'title prefix', 'title', $date, $statusDate, 1,
-                    'elocationId', 'http://www.example.com/', new ArrayCollection([$subject]), ['research organism'],
+                    'elocationId', 'http://www.example.com/', new ArraySequence([$subject]), ['research organism'],
                     rejection_for('Abstract should not be unwrapped'), rejection_for('Issue should not be unwrapped'),
                     rejection_for('Copyright should not be unwrapped'),
-                    new PromiseCollection(rejection_for('Authors should not be unwrapped')), 'impact statement', $image,
-                    new PromiseCollection(rejection_for('Keywords should not be unwrapped')),
+                    new PromiseSequence(rejection_for('Authors should not be unwrapped')), 'impact statement', $image,
+                    new PromiseSequence(rejection_for('Keywords should not be unwrapped')),
                     rejection_for('Digest should not be unwrapped'),
-                    new PromiseCollection(rejection_for('Content should not be unwrapped')),
-                    new PromiseCollection(rejection_for('Authors should not be unwrapped')),
+                    new PromiseSequence(rejection_for('Content should not be unwrapped')),
+                    new PromiseSequence(rejection_for('Authors should not be unwrapped')),
                     rejection_for('Decision letter should not be unwrapped'),
-                    new PromiseCollection(rejection_for('Decision letter description should not be unwrapped')),
+                    new PromiseSequence(rejection_for('Decision letter description should not be unwrapped')),
                     rejection_for('Author response should not be unwrapped')),
                 ['snippet' => true],
                 [
@@ -425,13 +425,13 @@ final class ArticleVoRNormalizerTest extends ApiTestCase
                 new ArticleVoR('id', 1, 'type', 'doi', 'author line', null, 'title', $date, $statusDate, 1,
                     'elocationId', null, null, [], rejection_for('Abstract should not be unwrapped'),
                     rejection_for('Issue should not be unwrapped'), rejection_for('Copyright should not be unwrapped'),
-                    new PromiseCollection(rejection_for('Authors should not be unwrapped')), null, null,
-                    new PromiseCollection(rejection_for('Keywords should not be unwrapped')),
+                    new PromiseSequence(rejection_for('Authors should not be unwrapped')), null, null,
+                    new PromiseSequence(rejection_for('Keywords should not be unwrapped')),
                     rejection_for('Digest should not be unwrapped'),
-                    new PromiseCollection(rejection_for('Content should not be unwrapped')),
-                    new PromiseCollection(rejection_for('Authors should not be unwrapped')),
+                    new PromiseSequence(rejection_for('Content should not be unwrapped')),
+                    new PromiseSequence(rejection_for('Authors should not be unwrapped')),
                     rejection_for('Decision letter should not be unwrapped'),
-                    new PromiseCollection(rejection_for('Decision letter description should not be unwrapped')),
+                    new PromiseSequence(rejection_for('Decision letter description should not be unwrapped')),
                     rejection_for('Author response should not be unwrapped')),
                 ['snippet' => true],
                 [

--- a/test/Serializer/BlogArticleNormalizerTest.php
+++ b/test/Serializer/BlogArticleNormalizerTest.php
@@ -5,8 +5,8 @@ namespace test\eLife\ApiSdk\Serializer;
 use DateTimeImmutable;
 use eLife\ApiClient\ApiClient\SubjectsClient;
 use eLife\ApiSdk\Client\Subjects;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Block\Paragraph;
 use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Image;
@@ -63,8 +63,8 @@ final class BlogArticleNormalizerTest extends ApiTestCase
     public function canNormalizeProvider() : array
     {
         $blogArticle = new BlogArticle('id', 'title', new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Full blog article should not be unwrapped')),
-            new PromiseCollection(rejection_for('Subjects should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full blog article should not be unwrapped')),
+            new PromiseSequence(rejection_for('Subjects should not be unwrapped'))
         );
 
         return [
@@ -149,8 +149,8 @@ final class BlogArticleNormalizerTest extends ApiTestCase
 
         return [
             'complete' => [
-                new BlogArticle('id', 'title', $date, 'impact statement', new ArrayCollection([new Paragraph('text')]),
-                    new ArrayCollection([$subject])),
+                new BlogArticle('id', 'title', $date, 'impact statement', new ArraySequence([new Paragraph('text')]),
+                    new ArraySequence([$subject])),
                 [],
                 [
                     'id' => 'id',
@@ -169,7 +169,7 @@ final class BlogArticleNormalizerTest extends ApiTestCase
                 ],
             ],
             'minimum' => [
-                new BlogArticle('id', 'title', $date, null, new ArrayCollection([new Paragraph('text')]), null),
+                new BlogArticle('id', 'title', $date, null, new ArraySequence([new Paragraph('text')]), null),
                 [],
                 [
                     'id' => 'id',
@@ -185,8 +185,8 @@ final class BlogArticleNormalizerTest extends ApiTestCase
             ],
             'complete snippet' => [
                 new BlogArticle('id', 'title', $date, 'impact statement',
-                    new PromiseCollection(rejection_for('Full blog article should not be unwrapped')),
-                    new ArrayCollection([$subject])),
+                    new PromiseSequence(rejection_for('Full blog article should not be unwrapped')),
+                    new ArraySequence([$subject])),
                 ['snippet' => true],
                 [
                     'id' => 'id',
@@ -200,7 +200,7 @@ final class BlogArticleNormalizerTest extends ApiTestCase
             ],
             'minimum snippet' => [
                 new BlogArticle('id', 'title', $date, null,
-                    new PromiseCollection(rejection_for('Full blog article should not be unwrapped')), null),
+                    new PromiseSequence(rejection_for('Full blog article should not be unwrapped')), null),
                 ['snippet' => true],
                 [
                     'id' => 'id',

--- a/test/Serializer/EventNormalizerTest.php
+++ b/test/Serializer/EventNormalizerTest.php
@@ -4,8 +4,8 @@ namespace test\eLife\ApiSdk\Serializer;
 
 use DateTimeImmutable;
 use DateTimeZone;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Block\Paragraph;
 use eLife\ApiSdk\Model\Event;
 use eLife\ApiSdk\Model\Place;
@@ -58,7 +58,7 @@ final class EventNormalizerTest extends TestCase
     public function canNormalizeProvider() : array
     {
         $event = new Event('id', 'title', null, new DateTimeImmutable(), new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Event content should not be unwrapped')),
+            new PromiseSequence(rejection_for('Event content should not be unwrapped')),
             rejection_for('Event venue should not be unwrapped'));
 
         return [
@@ -133,7 +133,7 @@ final class EventNormalizerTest extends TestCase
         return [
             'complete' => [
                 new Event('id', 'title', 'impact statement', $starts, $ends, $timezone,
-                    new ArrayCollection([new Paragraph('text')]), promise_for($venue)),
+                    new ArraySequence([new Paragraph('text')]), promise_for($venue)),
                 [],
                 [
                     'id' => 'id',
@@ -152,7 +152,7 @@ final class EventNormalizerTest extends TestCase
                 ],
             ],
             'minimum' => [
-                new Event('id', 'title', null, $starts, $ends, null, new ArrayCollection([new Paragraph('text')])),
+                new Event('id', 'title', null, $starts, $ends, null, new ArraySequence([new Paragraph('text')])),
                 [],
                 [
                     'id' => 'id',
@@ -169,7 +169,7 @@ final class EventNormalizerTest extends TestCase
             ],
             'complete snippet' => [
                 new Event('id', 'title', 'impact statement', $starts, $ends, $timezone,
-                    new PromiseCollection(rejection_for('Event content should not be unwrapped')),
+                    new PromiseSequence(rejection_for('Event content should not be unwrapped')),
                     rejection_for('Event venue should not be unwrapped')),
                 ['snippet' => true],
                 [
@@ -183,7 +183,7 @@ final class EventNormalizerTest extends TestCase
             ],
             'minimum snippet' => [
                 new Event('id', 'title', null, $starts, $ends, null,
-                    new PromiseCollection(rejection_for('Event content should not be unwrapped')),
+                    new PromiseSequence(rejection_for('Event content should not be unwrapped')),
                     rejection_for('Event venue should not be unwrapped')),
                 ['snippet' => true],
                 [

--- a/test/Serializer/GroupAuthorNormalizerTest.php
+++ b/test/Serializer/GroupAuthorNormalizerTest.php
@@ -2,7 +2,7 @@
 
 namespace test\eLife\ApiSdk\Serializer;
 
-use eLife\ApiSdk\Collection\ArrayCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Model\Address;
 use eLife\ApiSdk\Model\AuthorEntry;
 use eLife\ApiSdk\Model\GroupAuthor;
@@ -59,7 +59,7 @@ final class GroupAuthorNormalizerTest extends PHPUnit_Framework_TestCase
 
     public function canNormalizeProvider() : array
     {
-        $groupAuthor = new GroupAuthor('group', new ArrayCollection([]));
+        $groupAuthor = new GroupAuthor('group', new ArraySequence([]));
 
         return [
             'group author' => [$groupAuthor, null, true],
@@ -81,7 +81,7 @@ final class GroupAuthorNormalizerTest extends PHPUnit_Framework_TestCase
     {
         return [
             'complete' => [
-                new GroupAuthor('group', new ArrayCollection([
+                new GroupAuthor('group', new ArraySequence([
                     new PersonAuthor(new Person('preferred name', 'index name', '0000-0002-1825-0097'), true,
                         [new Place(null, null, ['affiliation'])], 'competing interests', 'contribution',
                         ['foo@example.com'], [1], ['+12025550182;ext=555'],
@@ -154,7 +154,7 @@ final class GroupAuthorNormalizerTest extends PHPUnit_Framework_TestCase
                 ],
             ],
             'minimum' => [
-                new GroupAuthor('group', new ArrayCollection([])),
+                new GroupAuthor('group', new ArraySequence([])),
                 [
                     'type' => 'group',
                     'name' => 'group',
@@ -265,7 +265,7 @@ final class GroupAuthorNormalizerTest extends PHPUnit_Framework_TestCase
                         ],
                     ],
                 ],
-                new GroupAuthor('group', new ArrayCollection([
+                new GroupAuthor('group', new ArraySequence([
                     new PersonAuthor(new Person('preferred name', 'index name', '0000-0002-1825-0097'), true,
                         [new Place(null, null, ['affiliation'])], 'competing interests', 'contribution',
                         ['foo@example.com'], [1], ['+12025550182;ext=555'],
@@ -280,7 +280,7 @@ final class GroupAuthorNormalizerTest extends PHPUnit_Framework_TestCase
                     'type' => 'group',
                     'name' => 'group',
                 ],
-                $groupAuthor = new GroupAuthor('group', new ArrayCollection([])),
+                $groupAuthor = new GroupAuthor('group', new ArraySequence([])),
             ],
         ];
     }

--- a/test/Serializer/InterviewNormalizerTest.php
+++ b/test/Serializer/InterviewNormalizerTest.php
@@ -3,8 +3,8 @@
 namespace test\eLife\ApiSdk\Serializer;
 
 use DateTimeImmutable;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Block\Paragraph;
 use eLife\ApiSdk\Model\Interview;
 use eLife\ApiSdk\Model\Interviewee;
@@ -59,9 +59,9 @@ final class InterviewNormalizerTest extends TestCase
     {
         $person = new Person('preferred name', 'index name');
         $interviewee = new Interviewee($person,
-            new PromiseCollection(rejection_for('Full interviewee should not be unwrapped')));
+            new PromiseSequence(rejection_for('Full interviewee should not be unwrapped')));
         $interview = new Interview('id', $interviewee, 'title', new DateTimeImmutable(), null,
-            new PromiseCollection(rejection_for('Full interview should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full interview should not be unwrapped'))
         );
 
         return [
@@ -132,8 +132,8 @@ final class InterviewNormalizerTest extends TestCase
             'complete' => [
                 $interview = new Interview('id',
                     new Interviewee(new Person('preferred name', 'index name', '0000-0002-1825-0097'),
-                        new ArrayCollection([new IntervieweeCvLine('date', 'text')])), 'title',
-                    $date = new DateTimeImmutable(), 'impact statement', new ArrayCollection([new Paragraph('text')])
+                        new ArraySequence([new IntervieweeCvLine('date', 'text')])), 'title',
+                    $date = new DateTimeImmutable(), 'impact statement', new ArraySequence([new Paragraph('text')])
                 ),
                 [],
                 [
@@ -164,7 +164,7 @@ final class InterviewNormalizerTest extends TestCase
             ],
             'minimum' => [
                 new Interview('id', new Interviewee(new Person('preferred name', 'index name')), 'title', $date, null,
-                    new ArrayCollection([new Paragraph('text')])),
+                    new ArraySequence([new Paragraph('text')])),
                 [],
                 [
                     'id' => 'id',
@@ -187,9 +187,9 @@ final class InterviewNormalizerTest extends TestCase
             'complete snippet' => [
                 $interview = new Interview('id',
                     new Interviewee(new Person('preferred name', 'index name', '0000-0002-1825-0097'),
-                        new PromiseCollection(rejection_for('Full interviewee should not be unwrapped'))), 'title',
+                        new PromiseSequence(rejection_for('Full interviewee should not be unwrapped'))), 'title',
                     $date, 'impact statement',
-                    new PromiseCollection(rejection_for('Full interview should not be unwrapped'))
+                    new PromiseSequence(rejection_for('Full interview should not be unwrapped'))
                 ),
                 ['snippet' => true],
                 [
@@ -209,7 +209,7 @@ final class InterviewNormalizerTest extends TestCase
             'minimum snippet' => [
                 $interview = new Interview('id',
                     new Interviewee(new Person('preferred name', 'index name')), 'title', $date, null,
-                    new PromiseCollection(rejection_for('Full interview should not be unwrapped'))
+                    new PromiseSequence(rejection_for('Full interview should not be unwrapped'))
                 ),
                 ['snippet' => true],
                 [

--- a/test/Serializer/LabsExperimentNormalizerTest.php
+++ b/test/Serializer/LabsExperimentNormalizerTest.php
@@ -3,8 +3,8 @@
 namespace test\eLife\ApiSdk\Serializer;
 
 use DateTimeImmutable;
-use eLife\ApiSdk\Collection\ArrayCollection;
-use eLife\ApiSdk\Collection\PromiseCollection;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Block\Paragraph;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\ImageSize;
@@ -58,7 +58,7 @@ final class LabsExperimentNormalizerTest extends TestCase
     {
         $image = new Image('', [new ImageSize('2:1', [900 => 'https://placehold.it/900x450'])]);
         $labsExperiment = new LabsExperiment(1, 'title', new DateTimeImmutable(), null, $image,
-            new PromiseCollection(rejection_for('Full Labs experiment should not be unwrapped'))
+            new PromiseSequence(rejection_for('Full Labs experiment should not be unwrapped'))
         );
 
         return [
@@ -131,7 +131,7 @@ final class LabsExperimentNormalizerTest extends TestCase
         return [
             'complete' => [
                 new LabsExperiment(1, 'title', $date, 'impact statement', $image,
-                    new ArrayCollection([new Paragraph('text')])),
+                    new ArraySequence([new Paragraph('text')])),
                 [],
                 [
                     'number' => 1,
@@ -148,7 +148,7 @@ final class LabsExperimentNormalizerTest extends TestCase
                 ],
             ],
             'minimum' => [
-                new LabsExperiment(1, 'title', $date, null, $image, new ArrayCollection([new Paragraph('text')])),
+                new LabsExperiment(1, 'title', $date, null, $image, new ArraySequence([new Paragraph('text')])),
                 [],
                 [
                     'number' => 1,
@@ -165,7 +165,7 @@ final class LabsExperimentNormalizerTest extends TestCase
             ],
             'complete snippet' => [
                 new LabsExperiment(1, 'title', $date, 'impact statement', $image,
-                    new PromiseCollection(rejection_for('Full Labs experiment should not be unwrapped'))),
+                    new PromiseSequence(rejection_for('Full Labs experiment should not be unwrapped'))),
                 ['snippet' => true],
                 [
                     'number' => 1,
@@ -177,7 +177,7 @@ final class LabsExperimentNormalizerTest extends TestCase
             ],
             'minimum snippet' => [
                 new LabsExperiment(1, 'title', $date, null, $image,
-                    new PromiseCollection(rejection_for('Full Labs experiment should not be unwrapped'))),
+                    new PromiseSequence(rejection_for('Full Labs experiment should not be unwrapped'))),
                 ['snippet' => true],
                 [
                     'number' => 1,


### PR DESCRIPTION
We need to add a content type called 'Collection', which makes the existing `Collection` a rather bad name. We're currently always using it as lists, so this as a subtype (called `Sequence`, as `List` is a reserved word).
