### PR TITLE
Apply transformations on resolved callback promises

### DIFF
--- a/src/Promise/CallbackPromise.php
+++ b/src/Promise/CallbackPromise.php
@@ -8,6 +8,8 @@ use GuzzleHttp\Promise\PromiseInterface;
 use LogicException;
 use RuntimeException;
 use function GuzzleHttp\Promise\exception_for;
+use function GuzzleHttp\Promise\promise_for;
+use function GuzzleHttp\Promise\rejection_for;
 
 /**
  * @internal
@@ -28,6 +30,17 @@ final class CallbackPromise implements PromiseInterface
 
     public function then(callable $onFulfilled = null, callable $onRejected = null)
     {
+        switch ($this->getState()) {
+            case PromiseInterface::FULFILLED:
+                return $onFulfilled
+                    ? promise_for($this->result)->then($onFulfilled)
+                    : promise_for($this->result);
+            case PromiseInterface::REJECTED:
+                return $onRejected
+                    ? rejection_for($this->result)->otherwise($onRejected)
+                    : rejection_for($this->result);
+        }
+
         $clone = clone $this;
 
         if ($onFulfilled) {

--- a/test/Promise/CallbackPromiseTest.php
+++ b/test/Promise/CallbackPromiseTest.php
@@ -25,6 +25,42 @@ final class CallbackPromiseTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
+     */
+    public function it_returns_a_callback_after_being_resolved()
+    {
+        $promise = new CallbackPromise(function () {
+            return 'foo';
+        });
+
+        $promise->wait();
+
+        $promise = $promise->then(function () {
+            return 'bar';
+        });
+
+        $this->assertSame('bar', $promise->wait());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_a_callback_after_being_rejected()
+    {
+        $promise = new CallbackPromise(function () {
+            return 'foo';
+        });
+
+        $promise->reject('bar');
+
+        $promise = $promise->otherwise(function () {
+            return 'baz';
+        });
+
+        $this->assertSame('baz', $promise->wait());
+    }
+
+    /**
+     * @test
      * @dataProvider stateProvider
      */
     public function it_has_a_state(callable $callback, string $outcome)


### PR DESCRIPTION
Currently if the callback has been triggered, any further transformations aren't applied.
