### PR TITLE
Collections

### DIFF
--- a/src/ApiSdk.php
+++ b/src/ApiSdk.php
@@ -5,6 +5,7 @@ namespace eLife\ApiSdk;
 use eLife\ApiClient\ApiClient\AnnualReportsClient;
 use eLife\ApiClient\ApiClient\ArticlesClient;
 use eLife\ApiClient\ApiClient\BlogClient;
+use eLife\ApiClient\ApiClient\CollectionsClient;
 use eLife\ApiClient\ApiClient\EventsClient;
 use eLife\ApiClient\ApiClient\InterviewsClient;
 use eLife\ApiClient\ApiClient\LabsClient;
@@ -16,6 +17,7 @@ use eLife\ApiClient\HttpClient;
 use eLife\ApiSdk\Client\AnnualReports;
 use eLife\ApiSdk\Client\Articles;
 use eLife\ApiSdk\Client\BlogArticles;
+use eLife\ApiSdk\Client\Collections;
 use eLife\ApiSdk\Client\Events;
 use eLife\ApiSdk\Client\Interviews;
 use eLife\ApiSdk\Client\LabsExperiments;
@@ -29,6 +31,7 @@ use eLife\ApiSdk\Serializer\ArticlePoANormalizer;
 use eLife\ApiSdk\Serializer\ArticleVoRNormalizer;
 use eLife\ApiSdk\Serializer\Block;
 use eLife\ApiSdk\Serializer\BlogArticleNormalizer;
+use eLife\ApiSdk\Serializer\CollectionNormalizer;
 use eLife\ApiSdk\Serializer\EventNormalizer;
 use eLife\ApiSdk\Serializer\GroupAuthorNormalizer;
 use eLife\ApiSdk\Serializer\ImageNormalizer;
@@ -74,6 +77,7 @@ final class ApiSdk
         $this->httpClient = $httpClient;
         $this->articlesClient = new ArticlesClient($this->httpClient);
         $this->blogClient = new BlogClient($this->httpClient);
+        $this->collectionsClient = new CollectionsClient($this->httpClient);
         $this->eventsClient = new EventsClient($this->httpClient);
         $this->interviewsClient = new InterviewsClient($this->httpClient);
         $this->labsClient = new LabsClient($this->httpClient);
@@ -208,6 +212,15 @@ final class ApiSdk
         }
 
         return $this->podcastEpisodes;
+    }
+
+    public function collections() : Collections
+    {
+        if (empty($this->collections)) {
+            $this->collections = new Collections($this->collectionsClient, $this->serializer);
+        }
+
+        return $this->collections;
     }
 
     public function subjects() : Subjects

--- a/src/ApiSdk.php
+++ b/src/ApiSdk.php
@@ -91,6 +91,7 @@ final class ApiSdk
             new ArticlePoANormalizer($this->articlesClient),
             new ArticleVoRNormalizer($this->articlesClient),
             new BlogArticleNormalizer($this->blogClient),
+            new CollectionNormalizer($this->collectionsClient),
             new EventNormalizer($this->eventsClient),
             new GroupAuthorNormalizer(),
             new ImageNormalizer(),

--- a/src/Client/Collections.php
+++ b/src/Client/Collections.php
@@ -3,12 +3,11 @@
 namespace eLife\ApiSdk\Client;
 
 use ArrayObject;
+use eLife\ApiClient\ApiClient\CollectionsClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
-use eLife\ApiClient\ApiClient\CollectionsClient;
 use eLife\ApiSdk\Model\Collection;
 use GuzzleHttp\Promise\PromiseInterface;
-
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class Collections
@@ -35,5 +34,4 @@ final class Collections
                 return $this->denormalizer->denormalize($result->toArray(), Collection::class);
             });
     }
-
 }

--- a/src/Client/Collections.php
+++ b/src/Client/Collections.php
@@ -70,7 +70,6 @@ final class Collections implements Iterator, Sequence
         return $clone;
     }
 
-
     public function slice(int $offset, int $length = null) : Sequence
     {
         if (null === $length) {

--- a/src/Client/Collections.php
+++ b/src/Client/Collections.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace eLife\ApiSdk\Client;
+
+final class Collections
+{
+    
+}

--- a/src/Client/Collections.php
+++ b/src/Client/Collections.php
@@ -36,6 +36,11 @@ final class Collections implements Iterator, Sequence
         $this->denormalizer = $denormalizer;
     }
 
+    public function __clone()
+    {
+        $this->resetIterator();
+    }
+
     public function get(string $id) : PromiseInterface
     {
         if (isset($this->collections[$id])) {
@@ -51,6 +56,20 @@ final class Collections implements Iterator, Sequence
                 return $this->denormalizer->denormalize($result->toArray(), Collection::class);
             });
     }
+
+    public function forSubject(string ...$subjectId) : self
+    {
+        $clone = clone $this;
+
+        $clone->subjectsQuery = array_unique(array_merge($this->subjectsQuery, $subjectId));
+
+        if ($clone->subjectsQuery !== $this->subjectsQuery) {
+            $clone->count = null;
+        }
+
+        return $clone;
+    }
+
 
     public function slice(int $offset, int $length = null) : Sequence
     {

--- a/src/Client/Collections.php
+++ b/src/Client/Collections.php
@@ -2,7 +2,38 @@
 
 namespace eLife\ApiSdk\Client;
 
+use ArrayObject;
+use eLife\ApiClient\MediaType;
+use eLife\ApiClient\Result;
+use eLife\ApiClient\ApiClient\CollectionsClient;
+use eLife\ApiSdk\Model\Collection;
+use GuzzleHttp\Promise\PromiseInterface;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
 final class Collections
 {
-    
+    public function __construct(CollectionsClient $collectionsClient, DenormalizerInterface $denormalizer)
+    {
+        $this->collections = new ArrayObject();
+        $this->collectionsClient = $collectionsClient;
+        $this->denormalizer = $denormalizer;
+    }
+
+    public function get(string $id) : PromiseInterface
+    {
+        if (isset($this->collections[$id])) {
+            return $this->collections[$id];
+        }
+
+        return $this->collections[$id] = $this->collectionsClient
+            ->getCollection(
+                ['Accept' => new MediaType(CollectionsClient::TYPE_COLLECTION, 1)],
+                $id
+            )
+            ->then(function (Result $result) {
+                return $this->denormalizer->denormalize($result->toArray(), Collection::class);
+            });
+    }
+
 }

--- a/src/Client/Collections.php
+++ b/src/Client/Collections.php
@@ -6,12 +6,29 @@ use ArrayObject;
 use eLife\ApiClient\ApiClient\CollectionsClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
+use eLife\ApiSdk\ArrayFromIterator;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
+use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Collection;
+use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
+use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use function GuzzleHttp\Promise\promise_for;
 
-final class Collections
+final class Collections implements Iterator, Sequence
 {
+    use ArrayFromIterator;
+    use SlicedIterator;
+
+    private $count;
+    private $collections = [];
+    private $descendingOrder = true;
+    private $subjectsQuery = [];
+    private $collectionsClient;
+    private $denormalizer;
+
     public function __construct(CollectionsClient $collectionsClient, DenormalizerInterface $denormalizer)
     {
         $this->collections = new ArrayObject();
@@ -33,5 +50,64 @@ final class Collections
             ->then(function (Result $result) {
                 return $this->denormalizer->denormalize($result->toArray(), Collection::class);
             });
+    }
+
+    public function slice(int $offset, int $length = null) : Sequence
+    {
+        if (null === $length) {
+            return new PromiseSequence($this->all()
+                ->then(function (Sequence $sequence) use ($offset) {
+                    return $sequence->slice($offset);
+                })
+            );
+        }
+
+        return new PromiseSequence($this->collectionsClient
+            ->listCollections(
+                ['Accept' => new MediaType(CollectionsClient::TYPE_COLLECTION_LIST, 1)],
+                ($offset / $length) + 1,
+                $length,
+                $this->descendingOrder,
+                $this->subjectsQuery
+            )
+            ->then(function (Result $result) {
+                $this->count = $result['total'];
+
+                return $result;
+            })
+            ->then(function (Result $result) {
+                $collections = [];
+
+                foreach ($result['items'] as $collection) {
+                    if (isset($this->collections[$collection['id']])) {
+                        $collections[] = $this->collections[$collection['id']]->wait();
+                    } else {
+                        $collections[] = $collection = $this->denormalizer->denormalize($collection, Collection::class,
+                            null, ['snippet' => true]);
+                        $this->collections[$collection->getId()] = promise_for($collection);
+                    }
+                }
+
+                return new ArraySequence($collections);
+            })
+        );
+    }
+
+    public function reverse() : Sequence
+    {
+        $clone = clone $this;
+
+        $clone->descendingOrder = !$this->descendingOrder;
+
+        return $clone;
+    }
+
+    public function count() : int
+    {
+        if (null === $this->count) {
+            $this->slice(0, 1)->count();
+        }
+
+        return $this->count;
     }
 }

--- a/src/Collection/ArraySequence.php
+++ b/src/Collection/ArraySequence.php
@@ -13,7 +13,7 @@ final class ArraySequence implements IteratorAggregate, Sequence
 {
     private $array;
 
-    public function __construct(array $array)
+    public function __construct(array $array = [])
     {
         $this->array = array_values($array);
     }

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -127,7 +127,7 @@ final class Collection
 
     public function getCurators() : Sequence
     {
-        return $this->curators;        
+        return $this->curators;
     }
 
     public function getContent() : Sequence

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -10,8 +10,14 @@ final class Collection
 {
     private $id;
     private $title;
+    private $subTitle;
     private $impactStatement;
     private $publishedDate;
+    private $banner;
+    private $thumbnail;
+    private $subjects;
+    private $selectedCurator;
+    private $selectedCuratorEtAl;
 
     public function __construct(
         $id,
@@ -21,7 +27,9 @@ final class Collection
         DateTimeImmutable $publishedDate,
         PromiseInterface $banner,
         Image $thumbnail,
-        Sequence $subjects
+        Sequence $subjects,
+        Person $selectedCurator,
+        bool $selectedCuratorEtAl
     ) {
         $this->id = $id;
         $this->title = $title;
@@ -31,6 +39,8 @@ final class Collection
         $this->banner = $banner;
         $this->thumbnail = $thumbnail;
         $this->subjects = $subjects;
+        $this->selectedCurator = $selectedCurator;
+        $this->selectedCuratorEtAl = $selectedCuratorEtAl;
     }
 
     public function getId() : string
@@ -88,5 +98,15 @@ final class Collection
     public function getSubjects() : Sequence
     {
         return $this->subjects;
+    }
+
+    public function getSelectedCurator() : Person
+    {
+        return $this->selectedCurator;
+    }
+
+    public function selectedCuratorEtAl() : bool
+    {
+        return $this->selectedCuratorEtAl;
     }
 }

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -2,17 +2,21 @@
 
 namespace eLife\ApiSdk\Model;
 
+use DateTimeImmutable;
+
 final class Collection
 {
     private $id;
     private $title;
     private $impactStatement;
+    private $publishedDate;
 
-    public function __construct($id, $title, $impactStatement = null)
+    public function __construct($id, $title, $impactStatement, DateTimeImmutable $publishedDate)
     {
         $this->id = $id;
         $this->title = $title;
         $this->impactStatement = $impactStatement;
+        $this->publishedDate = $publishedDate;
     }
 
     public function getId()
@@ -28,5 +32,10 @@ final class Collection
     public function getImpactStatement()
     {
         return $this->impactStatement;
+    }
+
+    public function getPublishedDate()
+    {
+        return $this->publishedDate; 
     }
 }

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace eLife\ApiSdk\Model;
+
+final class Collection
+{
+    private $id;
+    private $title;
+
+    public function __construct($id, $title)
+    {
+        $this->id = $id;
+        $this->title = $title;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -18,6 +18,7 @@ final class Collection
     private $subjects;
     private $selectedCurator;
     private $selectedCuratorEtAl;
+    private $curators;
 
     public function __construct(
         $id,
@@ -29,7 +30,8 @@ final class Collection
         Image $thumbnail,
         Sequence $subjects,
         Person $selectedCurator,
-        bool $selectedCuratorEtAl
+        bool $selectedCuratorEtAl,
+        Sequence $curators
     ) {
         $this->id = $id;
         $this->title = $title;
@@ -41,6 +43,7 @@ final class Collection
         $this->subjects = $subjects;
         $this->selectedCurator = $selectedCurator;
         $this->selectedCuratorEtAl = $selectedCuratorEtAl;
+        $this->curators = $curators;
     }
 
     public function getId() : string
@@ -108,5 +111,10 @@ final class Collection
     public function selectedCuratorEtAl() : bool
     {
         return $this->selectedCuratorEtAl;
+    }
+
+    public function getCurators() : Sequence
+    {
+        return $this->curators;        
     }
 }

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -3,7 +3,6 @@
 namespace eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
-use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\Sequence;
 use GuzzleHttp\Promise\PromiseInterface;
 
@@ -23,8 +22,7 @@ final class Collection
         PromiseInterface $banner,
         Image $thumbnail,
         Sequence $subjects
-    )
-    {
+    ) {
         $this->id = $id;
         $this->title = $title;
         $this->subTitle = $subTitle;
@@ -60,7 +58,7 @@ final class Collection
 
     public function getPublishedDate() : DateTimeImmutable
     {
-        return $this->publishedDate; 
+        return $this->publishedDate;
     }
 
     public function getBanner() : Image
@@ -70,7 +68,7 @@ final class Collection
 
     public function getThumbnail() : Image
     {
-        return $this->thumbnail; 
+        return $this->thumbnail;
     }
 
     public function withSubjects(Sequence $subjects) : Collection

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -21,6 +21,7 @@ final class Collection
     private $curators;
     private $content;
     private $relatedContent;
+    private $podcastEpisodes;
 
     public function __construct(
         $id,
@@ -35,7 +36,8 @@ final class Collection
         bool $selectedCuratorEtAl,
         Sequence $curators,
         Sequence $content,
-        Sequence $relatedContent
+        Sequence $relatedContent,
+        Sequence $podcastEpisodes
     ) {
         $this->id = $id;
         $this->title = $title;
@@ -50,6 +52,7 @@ final class Collection
         $this->curators = $curators;
         $this->content = $content;
         $this->relatedContent = $relatedContent;
+        $this->podcastEpisodes = $podcastEpisodes;
     }
 
     public function getId() : string
@@ -132,5 +135,10 @@ final class Collection
     public function getRelatedContent() : Sequence
     {
         return $this->relatedContent;
+    }
+
+    public function getPodcastEpisodes() : Sequence
+    {
+        return $this->podcastEpisodes;
     }
 }

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -4,6 +4,7 @@ namespace eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
 use eLife\ApiSdk\Model\Image;
+use GuzzleHttp\Promise\PromiseInterface;
 
 final class Collection
 {
@@ -12,12 +13,13 @@ final class Collection
     private $impactStatement;
     private $publishedDate;
 
-    public function __construct($id, $title, $impactStatement, DateTimeImmutable $publishedDate, Image $thumbnail)
+    public function __construct($id, $title, $impactStatement, DateTimeImmutable $publishedDate, PromiseInterface $banner, Image $thumbnail)
     {
         $this->id = $id;
         $this->title = $title;
         $this->impactStatement = $impactStatement;
         $this->publishedDate = $publishedDate;
+        $this->banner = $banner;
         $this->thumbnail = $thumbnail;
     }
 
@@ -39,6 +41,11 @@ final class Collection
     public function getPublishedDate()
     {
         return $this->publishedDate; 
+    }
+
+    public function getBanner() : Image
+    {
+        return $this->banner->wait();
     }
 
     public function getThumbnail() : Image

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -25,14 +25,12 @@ final class Collection
 
     /**
      * @internal
-     *
-     * @param string|null $impactStatement
      */
     public function __construct(
         string $id,
         string $title,
         PromiseInterface $subTitle,
-        $impactStatement,
+        string $impactStatement = null,
         DateTimeImmutable $publishedDate,
         PromiseInterface $banner,
         Image $thumbnail,

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -19,6 +19,7 @@ final class Collection
     private $selectedCurator;
     private $selectedCuratorEtAl;
     private $curators;
+    private $content;
 
     public function __construct(
         $id,
@@ -31,7 +32,8 @@ final class Collection
         Sequence $subjects,
         Person $selectedCurator,
         bool $selectedCuratorEtAl,
-        Sequence $curators
+        Sequence $curators,
+        Sequence $content
     ) {
         $this->id = $id;
         $this->title = $title;
@@ -44,6 +46,7 @@ final class Collection
         $this->selectedCurator = $selectedCurator;
         $this->selectedCuratorEtAl = $selectedCuratorEtAl;
         $this->curators = $curators;
+        $this->content = $content;
     }
 
     public function getId() : string
@@ -116,5 +119,10 @@ final class Collection
     public function getCurators() : Sequence
     {
         return $this->curators;        
+    }
+
+    public function getContent() : Sequence
+    {
+        return $this->content;
     }
 }

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -22,7 +22,7 @@ final class Collection
         DateTimeImmutable $publishedDate,
         PromiseInterface $banner,
         Image $thumbnail,
-        Sequence $subjects = null
+        Sequence $subjects
     )
     {
         $this->id = $id;
@@ -32,9 +32,6 @@ final class Collection
         $this->publishedDate = $publishedDate;
         $this->banner = $banner;
         $this->thumbnail = $thumbnail;
-        if ($subjects === null) {
-            $subjects = new ArraySequence([]);
-        }
         $this->subjects = $subjects;
     }
 

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -20,6 +20,7 @@ final class Collection
     private $selectedCuratorEtAl;
     private $curators;
     private $content;
+    private $relatedContent;
 
     public function __construct(
         $id,
@@ -33,7 +34,8 @@ final class Collection
         Person $selectedCurator,
         bool $selectedCuratorEtAl,
         Sequence $curators,
-        Sequence $content
+        Sequence $content,
+        Sequence $relatedContent
     ) {
         $this->id = $id;
         $this->title = $title;
@@ -47,6 +49,7 @@ final class Collection
         $this->selectedCuratorEtAl = $selectedCuratorEtAl;
         $this->curators = $curators;
         $this->content = $content;
+        $this->relatedContent = $relatedContent;
     }
 
     public function getId() : string
@@ -124,5 +127,10 @@ final class Collection
     public function getContent() : Sequence
     {
         return $this->content;
+    }
+
+    public function getRelatedContent() : Sequence
+    {
+        return $this->relatedContent;
     }
 }

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -6,11 +6,13 @@ final class Collection
 {
     private $id;
     private $title;
+    private $impactStatement;
 
-    public function __construct($id, $title)
+    public function __construct($id, $title, $impactStatement = null)
     {
         $this->id = $id;
         $this->title = $title;
+        $this->impactStatement = $impactStatement;
     }
 
     public function getId()
@@ -21,5 +23,10 @@ final class Collection
     public function getTitle()
     {
         return $this->title;
+    }
+
+    public function getImpactStatement()
+    {
+        return $this->impactStatement;
     }
 }

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -3,6 +3,7 @@
 namespace eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
+use eLife\ApiSdk\Model\Image;
 
 final class Collection
 {
@@ -11,12 +12,13 @@ final class Collection
     private $impactStatement;
     private $publishedDate;
 
-    public function __construct($id, $title, $impactStatement, DateTimeImmutable $publishedDate)
+    public function __construct($id, $title, $impactStatement, DateTimeImmutable $publishedDate, Image $thumbnail)
     {
         $this->id = $id;
         $this->title = $title;
         $this->impactStatement = $impactStatement;
         $this->publishedDate = $publishedDate;
+        $this->thumbnail = $thumbnail;
     }
 
     public function getId()
@@ -37,5 +39,10 @@ final class Collection
     public function getPublishedDate()
     {
         return $this->publishedDate; 
+    }
+
+    public function getThumbnail() : Image
+    {
+        return $this->thumbnail; 
     }
 }

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -65,7 +65,10 @@ final class Collection
         return $this->title;
     }
 
-    public function getSubTitle() : string
+    /**
+     * @return string|null
+     */
+    public function getSubTitle()
     {
         return $this->subTitle->wait();
     }

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -3,7 +3,8 @@
 namespace eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
-use eLife\ApiSdk\Model\Image;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\Sequence;
 use GuzzleHttp\Promise\PromiseInterface;
 
 final class Collection
@@ -13,7 +14,7 @@ final class Collection
     private $impactStatement;
     private $publishedDate;
 
-    public function __construct($id, $title, $impactStatement, DateTimeImmutable $publishedDate, PromiseInterface $banner, Image $thumbnail)
+    public function __construct($id, $title, $impactStatement, DateTimeImmutable $publishedDate, PromiseInterface $banner, Image $thumbnail, Sequence $subjects = null)
     {
         $this->id = $id;
         $this->title = $title;
@@ -21,6 +22,10 @@ final class Collection
         $this->publishedDate = $publishedDate;
         $this->banner = $banner;
         $this->thumbnail = $thumbnail;
+        if ($subjects === null) {
+            $subjects = new ArraySequence([]);
+        }
+        $this->subjects = $subjects;
     }
 
     public function getId()
@@ -51,5 +56,23 @@ final class Collection
     public function getThumbnail() : Image
     {
         return $this->thumbnail; 
+    }
+
+    public function withSubjects(Sequence $subjects) : Collection
+    {
+        return new self(
+            $this->id,
+            $this->title,
+            $this->impactStatement,
+            $this->publishedDate,
+            $this->banner,
+            $this->thumbnail,
+            $subjects
+        );
+    }
+
+    public function getSubjects() : Sequence
+    {
+        return $this->subjects;
     }
 }

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -23,9 +23,13 @@ final class Collection
     private $relatedContent;
     private $podcastEpisodes;
 
+    /**
+     * @internal
+     * @param string|null $impactStatement
+     */
     public function __construct(
-        $id,
-        $title,
+        string $id,
+        string $title,
         PromiseInterface $subTitle,
         $impactStatement,
         DateTimeImmutable $publishedDate,
@@ -94,20 +98,6 @@ final class Collection
     public function getThumbnail() : Image
     {
         return $this->thumbnail;
-    }
-
-    public function withSubjects(Sequence $subjects) : Collection
-    {
-        return new self(
-            $this->id,
-            $this->title,
-            $this->subTitle,
-            $this->impactStatement,
-            $this->publishedDate,
-            $this->banner,
-            $this->thumbnail,
-            $subjects
-        );
     }
 
     public function getSubjects() : Sequence

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -14,10 +14,20 @@ final class Collection
     private $impactStatement;
     private $publishedDate;
 
-    public function __construct($id, $title, $impactStatement, DateTimeImmutable $publishedDate, PromiseInterface $banner, Image $thumbnail, Sequence $subjects = null)
+    public function __construct(
+        $id,
+        $title,
+        PromiseInterface $subTitle,
+        $impactStatement,
+        DateTimeImmutable $publishedDate,
+        PromiseInterface $banner,
+        Image $thumbnail,
+        Sequence $subjects = null
+    )
     {
         $this->id = $id;
         $this->title = $title;
+        $this->subTitle = $subTitle;
         $this->impactStatement = $impactStatement;
         $this->publishedDate = $publishedDate;
         $this->banner = $banner;
@@ -28,22 +38,30 @@ final class Collection
         $this->subjects = $subjects;
     }
 
-    public function getId()
+    public function getId() : string
     {
         return $this->id;
     }
 
-    public function getTitle()
+    public function getTitle() : string
     {
         return $this->title;
     }
 
+    public function getSubTitle() : string
+    {
+        return $this->subTitle->wait();
+    }
+
+    /**
+     * @return string|null
+     */
     public function getImpactStatement()
     {
         return $this->impactStatement;
     }
 
-    public function getPublishedDate()
+    public function getPublishedDate() : DateTimeImmutable
     {
         return $this->publishedDate; 
     }
@@ -63,6 +81,7 @@ final class Collection
         return new self(
             $this->id,
             $this->title,
+            $this->subTitle,
             $this->impactStatement,
             $this->publishedDate,
             $this->banner,

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -25,6 +25,7 @@ final class Collection
 
     /**
      * @internal
+     *
      * @param string|null $impactStatement
      */
     public function __construct(

--- a/src/Serializer/ArticleVersionNormalizer.php
+++ b/src/Serializer/ArticleVersionNormalizer.php
@@ -41,9 +41,10 @@ abstract class ArticleVersionNormalizer implements NormalizerInterface, Denormal
     }
 
     /**
-     * Selects the Model class from the 'type' and 'status' fields
+     * Selects the Model class from the 'type' and 'status' fields.
      *
      * @param string|null $status
+     *
      * @return string|null
      */
     public static function articleClass(string $type, $status)
@@ -66,6 +67,7 @@ abstract class ArticleVersionNormalizer implements NormalizerInterface, Denormal
                 } else {
                     $class = ArticleVoR::class;
                 }
+
                 return $class;
         }
 

--- a/src/Serializer/ArticleVersionNormalizer.php
+++ b/src/Serializer/ArticleVersionNormalizer.php
@@ -7,8 +7,10 @@ use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
+use eLife\ApiSdk\Model\ArticlePoA;
 use eLife\ApiSdk\Model\ArticleSection;
 use eLife\ApiSdk\Model\ArticleVersion;
+use eLife\ApiSdk\Model\ArticleVoR;
 use eLife\ApiSdk\Model\AuthorEntry;
 use eLife\ApiSdk\Model\Block;
 use eLife\ApiSdk\Model\Copyright;
@@ -36,6 +38,38 @@ abstract class ArticleVersionNormalizer implements NormalizerInterface, Denormal
     public function __construct(ArticlesClient $articlesClient)
     {
         $this->articlesClient = $articlesClient;
+    }
+
+    /**
+     * Selects the Model class from the 'type' and 'status' fields
+     *
+     * @param string|null $status
+     * @return string|null
+     */
+    public static function articleClass(string $type, $status)
+    {
+        switch ($type) {
+            case 'correction':
+            case 'editorial':
+            case 'feature':
+            case 'insight':
+            case 'research-advance':
+            case 'research-article':
+            case 'research-exchange':
+            case 'retraction':
+            case 'registered-report':
+            case 'replication-study':
+            case 'short-report':
+            case 'tools-resources':
+                if ('poa' === $status) {
+                    $class = ArticlePoA::class;
+                } else {
+                    $class = ArticleVoR::class;
+                }
+                return $class;
+        }
+
+        return null;
     }
 
     final public function denormalize($data, $class, $format = null, array $context = []) : ArticleVersion

--- a/src/Serializer/ArticleVersionNormalizer.php
+++ b/src/Serializer/ArticleVersionNormalizer.php
@@ -43,11 +43,9 @@ abstract class ArticleVersionNormalizer implements NormalizerInterface, Denormal
     /**
      * Selects the Model class from the 'type' and 'status' fields.
      *
-     * @param string|null $status
-     *
      * @return string|null
      */
-    public static function articleClass(string $type, $status)
+    public static function articleClass(string $type, string $status = null)
     {
         switch ($type) {
             case 'correction':

--- a/src/Serializer/CollectionNormalizer.php
+++ b/src/Serializer/CollectionNormalizer.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace eLife\ApiSdk\Serializer;
+
+#use DateTimeImmutable;
+use eLife\ApiClient\ApiClient\CollectionsClient;
+#use eLife\ApiClient\MediaType;
+#use eLife\ApiClient\Result;
+#use eLife\ApiSdk\Collection\ArraySequence;
+#use eLife\ApiSdk\Collection\PromiseSequence;
+#use eLife\ApiSdk\Model\ArticlePoA;
+#use eLife\ApiSdk\Model\ArticleVoR;
+#use eLife\ApiSdk\Model\Image;
+#use eLife\ApiSdk\Model\Collection;
+#use eLife\ApiSdk\Model\CollectionChapter;
+#use eLife\ApiSdk\Model\CollectionSource;
+#use eLife\ApiSdk\Model\Subject;
+#use eLife\ApiSdk\Promise\CallbackPromise;
+#use GuzzleHttp\Promise\PromiseInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+#use function GuzzleHttp\Promise\all;
+#use function GuzzleHttp\Promise\promise_for;
+
+final class CollectionNormalizer implements NormalizerInterface, DenormalizerInterface, NormalizerAwareInterface, DenormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+
+    private $collectionsClient;
+    private $found = [];
+    private $globalCallback;
+
+    public function __construct(CollectionsClient $collectionsClient)
+    {
+        $this->collectionsClient = $collectionsClient;
+    }
+
+    public function denormalize($data, $class, $format = null, array $context = []) : Collection
+    {
+    }
+
+    public function normalize($object, $format = null, array $context = []) : array
+    {
+    }
+
+    public function supportsDenormalization($data, $type, $format = null) : bool
+    {
+        return PodcastEpisode::class === $type;
+    }
+
+    public function supportsNormalization($data, $format = null) : bool
+    {
+        return $data instanceof Collection;
+    }
+}

--- a/src/Serializer/CollectionNormalizer.php
+++ b/src/Serializer/CollectionNormalizer.php
@@ -6,7 +6,7 @@ use DateTimeImmutable;
 use eLife\ApiClient\ApiClient\CollectionsClient;
 #use eLife\ApiClient\MediaType;
 #use eLife\ApiClient\Result;
-#use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\ArraySequence;
 #use eLife\ApiSdk\Collection\PromiseSequence;
 #use eLife\ApiSdk\Model\ArticlePoA;
 #use eLife\ApiSdk\Model\ArticleVoR;
@@ -48,6 +48,12 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
                 return $this->denormalizer->denormalize($banner, Image::class, $format, $context);
             });
 
+        $data['subjects'] = new ArraySequence(array_map(function (array $subject) use ($format, $context) {
+            $context['snippet'] = true;
+
+            return $this->denormalizer->denormalize($subject, Subject::class, $format, $context);
+        }, $data['subjects'] ?? []));
+
         return new Collection(
             $data['id'],
             $data['title'],
@@ -55,7 +61,8 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
             $data['impactStatement'] ?? null,
             DateTimeImmutable::createFromFormat(DATE_ATOM, $data['updated']),
             promise_for($data['image']['banner']),
-            $data['image']['thumbnail'] = $this->denormalizer->denormalize($data['image']['thumbnail'], Image::class, $format, $context)
+            $data['image']['thumbnail'] = $this->denormalizer->denormalize($data['image']['thumbnail'], Image::class, $format, $context),
+            $data['subjects']
         );
     }
 

--- a/src/Serializer/CollectionNormalizer.php
+++ b/src/Serializer/CollectionNormalizer.php
@@ -54,90 +54,90 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
                 });
 
             $data['curators'] = new PromiseSequence($collection
-                ->then(function(Result $collection) use ($format, $context) {
-                    return array_map(function($curator) use ($format, $context) {
+                ->then(function (Result $collection) use ($format, $context) {
+                    return array_map(function ($curator) use ($format, $context) {
                         return $this->denormalizer->denormalize($curator, Person::class, $format, $context + ['snippet' => true]);
                     }, $collection['curators']);
                 }));
 
             $data['content'] = new PromiseSequence($collection
-                ->then(function(Result $collection) use ($format, $context) {
-                    return (array_map(function($eachContent) use ($format, $context) {
+                ->then(function (Result $collection) use ($format, $context) {
+                    return array_map(function ($eachContent) use ($format, $context) {
                         if ($eachContent['type'] == 'research-article') {
                             if ($eachContent['status'] == 'poa') {
                                 return $this->denormalizer->denormalize($eachContent, ArticlePoA::class, $format, $context + ['snippet' => true]);
                             } else {
                                 return $this->denormalizer->denormalize($eachContent, ArticleVoR::class, $format, $context + ['snippet' => true]);
                             }
-                        } else if ($eachContent['type'] == 'blog-article') {
+                        } elseif ($eachContent['type'] == 'blog-article') {
                             return $this->denormalizer->denormalize($eachContent, BlogArticle::class, $format, $context + ['snippet' => true]);
                         } else {
                             throw new \NotImplementedException($eachContent['type']);
                         }
-                    }, $collection['content']));
+                    }, $collection['content']);
                 }));
 
             $data['relatedContent'] = new PromiseSequence($collection
-                ->then(function(Result $collection) use ($format, $context) {
-                    return (array_map(function($eachContent) use ($format, $context) {
+                ->then(function (Result $collection) use ($format, $context) {
+                    return array_map(function ($eachContent) use ($format, $context) {
                         if ($eachContent['type'] == 'research-article') {
                             if ($eachContent['status'] == 'poa') {
                                 return $this->denormalizer->denormalize($eachContent, ArticlePoA::class, $format, $context + ['snippet' => true]);
                             } else {
                                 return $this->denormalizer->denormalize($eachContent, ArticleVoR::class, $format, $context + ['snippet' => true]);
                             }
-                        } else if ($eachContent['type'] == 'blog-article') {
+                        } elseif ($eachContent['type'] == 'blog-article') {
                             return $this->denormalizer->denormalize($eachContent, BlogArticle::class, $format, $context + ['snippet' => true]);
                         } else {
                             throw new \NotImplementedException($eachContent['type']);
                         }
-                    }, $collection['relatedContent'] ?? []));
+                    }, $collection['relatedContent'] ?? []);
                 }));
 
             $data['podcastEpisodes'] = new PromiseSequence($collection
-                ->then(function(Result $collection) use ($format, $context) {
-                    return array_map(function($podcastEpisode) use ($format, $context) {
+                ->then(function (Result $collection) use ($format, $context) {
+                    return array_map(function ($podcastEpisode) use ($format, $context) {
                         return $this->denormalizer->denormalize($podcastEpisode, PodcastEpisode::class, $format, $context + ['snippet' => true]);
                     }, $collection['podcastEpisodes'] ?? []);
                 }));
         } else {
             $data['image']['banner'] = promise_for($data['image']['banner']);
-            $data['curators'] = new ArraySequence(array_map(function($curator) use ($format, $context) {
+            $data['curators'] = new ArraySequence(array_map(function ($curator) use ($format, $context) {
                 return $this->denormalizer->denormalize($curator, Person::class, $format, $context + ['snippet' => true]);
             }, $data['curators']));
-            $data['content'] = new ArraySequence(array_map(function($eachContent) use ($format, $context) {
-                        if ($eachContent['type'] == 'research-article') {
-                            if ($eachContent['status'] == 'poa') {
-                                return $this->denormalizer->denormalize($eachContent, ArticlePoA::class, $format, $context + ['snippet' => true]);
-                            } else {
-                                return $this->denormalizer->denormalize($eachContent, ArticleVoR::class, $format, $context + ['snippet' => true]);
-                            }
-                        } else if ($eachContent['type'] == 'blog-article') {
-                            return $this->denormalizer->denormalize($eachContent, BlogArticle::class, $format, $context + ['snippet' => true]);
-                        } else {
-                            return $this->denormalizer->denormalize($eachContent, Interview::class, $format, $context + ['snippet' => true]);
-                            throw new \NotImplementedException($eachContent['type']);
-                        }
+            $data['content'] = new ArraySequence(array_map(function ($eachContent) use ($format, $context) {
+                if ($eachContent['type'] == 'research-article') {
+                    if ($eachContent['status'] == 'poa') {
+                        return $this->denormalizer->denormalize($eachContent, ArticlePoA::class, $format, $context + ['snippet' => true]);
+                    } else {
+                        return $this->denormalizer->denormalize($eachContent, ArticleVoR::class, $format, $context + ['snippet' => true]);
+                    }
+                } elseif ($eachContent['type'] == 'blog-article') {
+                    return $this->denormalizer->denormalize($eachContent, BlogArticle::class, $format, $context + ['snippet' => true]);
+                } else {
+                    return $this->denormalizer->denormalize($eachContent, Interview::class, $format, $context + ['snippet' => true]);
+                    throw new \NotImplementedException($eachContent['type']);
+                }
                         // missing blog-article and interview here, extract common code
             }, $data['content']));
 
-            $data['relatedContent'] = new ArraySequence(array_map(function($eachContent) use ($format, $context) {
-                        if ($eachContent['type'] == 'research-article') {
-                            if ($eachContent['status'] == 'poa') {
-                                return $this->denormalizer->denormalize($eachContent, ArticlePoA::class, $format, $context + ['snippet' => true]);
-                            } else {
-                                return $this->denormalizer->denormalize($eachContent, ArticleVoR::class, $format, $context + ['snippet' => true]);
-                            }
-                        } else if ($eachContent['type'] == 'blog-article') {
-                            return $this->denormalizer->denormalize($eachContent, BlogArticle::class, $format, $context + ['snippet' => true]);
-                        } else {
-                            return $this->denormalizer->denormalize($eachContent, Interview::class, $format, $context + ['snippet' => true]);
-                            throw new \NotImplementedException($eachContent['type']);
-                        }
+            $data['relatedContent'] = new ArraySequence(array_map(function ($eachContent) use ($format, $context) {
+                if ($eachContent['type'] == 'research-article') {
+                    if ($eachContent['status'] == 'poa') {
+                        return $this->denormalizer->denormalize($eachContent, ArticlePoA::class, $format, $context + ['snippet' => true]);
+                    } else {
+                        return $this->denormalizer->denormalize($eachContent, ArticleVoR::class, $format, $context + ['snippet' => true]);
+                    }
+                } elseif ($eachContent['type'] == 'blog-article') {
+                    return $this->denormalizer->denormalize($eachContent, BlogArticle::class, $format, $context + ['snippet' => true]);
+                } else {
+                    return $this->denormalizer->denormalize($eachContent, Interview::class, $format, $context + ['snippet' => true]);
+                    throw new \NotImplementedException($eachContent['type']);
+                }
                         // missing blog-article and interview here, extract common code
             }, $data['relatedContent'] ?? []));
 
-            $data['podcastEpisodes'] = new ArraySequence(array_map(function($podcastEpisode) use ($format, $context) {
+            $data['podcastEpisodes'] = new ArraySequence(array_map(function ($podcastEpisode) use ($format, $context) {
                 return $this->denormalizer->denormalize($podcastEpisode, PodcastEpisode::class, $format, $context + ['snippet' => true]);
             }, $data['podcastEpisodes'] ?? []));
         }

--- a/src/Serializer/CollectionNormalizer.php
+++ b/src/Serializer/CollectionNormalizer.php
@@ -14,7 +14,7 @@ use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\Collection;
 #use eLife\ApiSdk\Model\CollectionChapter;
 #use eLife\ApiSdk\Model\CollectionSource;
-#use eLife\ApiSdk\Model\Subject;
+use eLife\ApiSdk\Model\Subject;
 #use eLife\ApiSdk\Promise\CallbackPromise;
 #use GuzzleHttp\Promise\PromiseInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;

--- a/src/Serializer/CollectionNormalizer.php
+++ b/src/Serializer/CollectionNormalizer.php
@@ -72,12 +72,7 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
         $data['selectedCurator'] = $this->denormalizer->denormalize($data['selectedCurator'], Person::class, $format, $context + ['snippet' => true]);
 
         $contentItemDenormalization = function ($eachContent) use ($format, $context) {
-            if ($eachContent['type'] == 'research-article') {
-                if ($eachContent['status'] == 'poa') {
-                    $class = ArticlePoA::class;
-                } else {
-                    $class = ArticleVoR::class;
-                }
+            if ($class = (ArticleVersionNormalizer::articleClass($eachContent['type'], $eachContent['status'] ?? null))) {
             } elseif ($eachContent['type'] == 'blog-article') {
                 $class = BlogArticle::class;
             } elseif ($eachContent['type'] == 'interview') {

--- a/src/Serializer/CollectionNormalizer.php
+++ b/src/Serializer/CollectionNormalizer.php
@@ -50,11 +50,7 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
         if (!empty($context['snippet'])) {
             $collection = $this->denormalizeSnippet($data);
 
-            $data['image']['banner'] = $collection
-                ->then(function (Result $collection) {
-                    return $collection['image']['banner'];
-                });
-
+            $data['image']['banner'] = $normalizationHelper->selectField($collection, 'image.banner');
             $data['curators'] = new PromiseSequence($normalizationHelper->selectField($collection, 'curators'));
             $data['content'] = new PromiseSequence($normalizationHelper->selectField($collection, 'content'));
             $data['relatedContent'] = new PromiseSequence($normalizationHelper->selectField($collection, 'relatedContent', []));

--- a/src/Serializer/CollectionNormalizer.php
+++ b/src/Serializer/CollectionNormalizer.php
@@ -129,15 +129,12 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
 
         if (empty($this->globalCallback)) {
             $this->globalCallback = new CallbackPromise(function () {
-                foreach ($this->identityMap as $id => $collection) {
-                    if (null === $collection) {
-                        $p = $this->collectionsClient->getCollection(
-                            ['Accept' => new MediaType(CollectionsClient::TYPE_COLLECTION, 1)],
-                            $id
-                        );
-                        $this->identityMap->put($id, $p);
-                    }
-                }
+                $this->identityMap->fillMissingWith(function($id) {
+                    return $this->collectionsClient->getCollection(
+                        ['Accept' => new MediaType(CollectionsClient::TYPE_COLLECTION, 1)],
+                        $id
+                    );
+                });
 
                 $this->globalCallback = null;
 

--- a/src/Serializer/CollectionNormalizer.php
+++ b/src/Serializer/CollectionNormalizer.php
@@ -14,9 +14,8 @@ use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Collection;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\Interview;
-//use eLife\ApiSdk\Model\CollectionChapter;
-//use eLife\ApiSdk\Model\CollectionSource;
 use eLife\ApiSdk\Model\Person;
+use eLife\ApiSdk\Model\PodcastEpisode;
 use eLife\ApiSdk\Model\Subject;
 //use eLife\ApiSdk\Promise\CallbackPromise;
 //use GuzzleHttp\Promise\PromiseInterface;
@@ -121,6 +120,11 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
         };
         $data['content'] = $object->getContent()->map($contentNormalization)->toArray();
         $data['relatedContent'] = $object->getRelatedContent()->map($contentNormalization)->toArray();
+        $data['podcastEpisodes'] = $object->getPodcastEpisodes()->map(function (PodcastEpisode $podcastEpisode) use ($format, $context) {
+            $context['snippet'] = true;
+
+            return $this->normalizer->normalize($podcastEpisode, $format, $context);
+        })->toArray();
         
         return $data;
     }

--- a/src/Serializer/CollectionNormalizer.php
+++ b/src/Serializer/CollectionNormalizer.php
@@ -51,6 +51,7 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
         return new Collection(
             $data['id'],
             $data['title'],
+            promise_for($data['subTitle']),
             $data['impactStatement'] ?? null,
             DateTimeImmutable::createFromFormat(DATE_ATOM, $data['updated']),
             promise_for($data['image']['banner']),
@@ -63,6 +64,7 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
         $data = [];
         $data['id'] = $object->getId();
         $data['title'] = $object->getTitle();
+        $data['subTitle'] = $object->getSubTitle();
         $data['impactStatement'] = $object->getImpactStatement();
         $data['updated'] = $object->getPublishedDate()->format(DATE_ATOM);
 

--- a/src/Serializer/CollectionNormalizer.php
+++ b/src/Serializer/CollectionNormalizer.php
@@ -94,6 +94,7 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
 
             return $this->denormalizer->denormalize($subject, Subject::class, $format, $context);
         }, $data['subjects'] ?? []));
+        $selectedCuratorEtAl = $data['selectedCurator']['etAl'] ?? false;
         $data['selectedCurator'] = $this->denormalizer->denormalize($data['selectedCurator'], Person::class, $format, $context + ['snippet' => true]);
 
             $data['relatedContent'] = new ArraySequence([]);
@@ -109,7 +110,7 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
             $data['image']['thumbnail'] = $this->denormalizer->denormalize($data['image']['thumbnail'], Image::class, $format, $context),
             $data['subjects'],
             $data['selectedCurator'],
-            $data['selectedCuratorEtAl'] ?? false,
+            $selectedCuratorEtAl,
             $data['curators'],
             $data['content'],
             $data['relatedContent'],

--- a/src/Serializer/CollectionNormalizer.php
+++ b/src/Serializer/CollectionNormalizer.php
@@ -8,8 +8,6 @@ use eLife\ApiClient\ApiClient\CollectionsClient;
 //use eLife\ApiClient\Result;
 use eLife\ApiSdk\Collection\ArraySequence;
 //use eLife\ApiSdk\Collection\PromiseSequence;
-use eLife\ApiSdk\Model\ArticlePoA;
-use eLife\ApiSdk\Model\ArticleVoR;
 use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Collection;
 use eLife\ApiSdk\Model\Image;
@@ -107,7 +105,7 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
 
             $contentNormalization = function ($eachContent) use ($format, $context) {
                 if (!is_object($eachContent)) {
-                    throw new LogicException("Content not valid: " . var_export($eachContent, true));
+                    throw new LogicException('Content not valid: '.var_export($eachContent, true));
                 }
                 $context['snippet'] = true;
 
@@ -120,10 +118,11 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
                         Interview::class => 'interview',
                     ];
                     if (!array_key_exists(get_class($eachContent), $contentClasses)) {
-                        throw new LogicException("Class of content " . get_class($eachContent) . " is not supported in a Collection. Supported classes are: " . var_export($contentClasses, true));
+                        throw new LogicException('Class of content '.get_class($eachContent).' is not supported in a Collection. Supported classes are: '.var_export($contentClasses, true));
                     }
                     $eachContentData['type'] = $contentClasses[get_class($eachContent)];
                 }
+
                 return $eachContentData;
             };
 
@@ -139,7 +138,7 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
                 })->toArray();
             }
         }
-        
+
         return $data;
     }
 

--- a/src/Serializer/CollectionNormalizer.php
+++ b/src/Serializer/CollectionNormalizer.php
@@ -98,7 +98,10 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
             return $this->normalizer->normalize($person, $format, $context);
         })->toArray();
 
-        $data['content'] = $object->getContent()->map(function ($eachContent) use ($format, $context) {
+        $contentNormalization = function ($eachContent) use ($format, $context) {
+            if (!is_object($eachContent)) {
+                throw new LogicException("Content not valid: " . var_export($eachContent, true));
+            }
             $context['snippet'] = true;
 
             $eachContentData = $this->normalizer->normalize($eachContent, $format, $context);
@@ -115,7 +118,10 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
                 $eachContentData['type'] = $contentClasses[get_class($eachContent)];
             }
             return $eachContentData;
-        })->toArray();
+        };
+        $data['content'] = $object->getContent()->map($contentNormalization)->toArray();
+        $data['relatedContent'] = $object->getRelatedContent()->map($contentNormalization)->toArray();
+        
         return $data;
     }
 

--- a/src/Serializer/CollectionNormalizer.php
+++ b/src/Serializer/CollectionNormalizer.php
@@ -46,6 +46,16 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
 
     public function normalize($object, $format = null, array $context = []) : array
     {
+        $data = [];
+        $data['id'] = $object->getId();
+        $data['title'] = $object->getTitle();
+        $data['impact_statement'] = $object->getImpactStatement();
+        $data['updated'] = $object->getPublishedDate()->format(DATE_ATOM);
+
+        $data['image']['thumbnail'] = $this->normalizer->normalize($object->getThumbnail(), $format, $context);
+        $data['image']['banner'] = $this->normalizer->normalize($object->getBanner(), $format, $context);
+
+        return $data;
     }
 
     public function supportsDenormalization($data, $type, $format = null) : bool

--- a/src/Serializer/CollectionNormalizer.php
+++ b/src/Serializer/CollectionNormalizer.php
@@ -77,6 +77,14 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
 
         $data['image']['thumbnail'] = $this->normalizer->normalize($object->getThumbnail(), $format, $context);
         $data['image']['banner'] = $this->normalizer->normalize($object->getBanner(), $format, $context);
+        if (count($object->getSubjects()) > 0) {
+            $data['subjects'] = $object->getSubjects()->map(function (Subject $subject) use ($format, $context) {
+                $context['snippet'] = true;
+                var_dump($subject);
+
+                return $this->normalizer->normalize($subject, $format, $context);
+            })->toArray();
+        }
 
         return $data;
     }

--- a/src/Serializer/CollectionNormalizer.php
+++ b/src/Serializer/CollectionNormalizer.php
@@ -74,8 +74,12 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
         $data = [];
         $data['id'] = $object->getId();
         $data['title'] = $object->getTitle();
-        $data['subTitle'] = $object->getSubTitle();
-        $data['impactStatement'] = $object->getImpactStatement();
+        if ($object->getSubTitle()) {
+            $data['subTitle'] = $object->getSubTitle();
+        }
+        if ($object->getImpactStatement()) {
+            $data['impactStatement'] = $object->getImpactStatement();
+        }
         $data['updated'] = $object->getPublishedDate()->format(DATE_ATOM);
 
         $data['image']['thumbnail'] = $this->normalizer->normalize($object->getThumbnail(), $format, $context);
@@ -89,7 +93,9 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
         }
 
         $data['selectedCurator'] = $this->normalizer->normalize($object->getSelectedCurator(), $format, ['snippet' => true]);
-        $data['selectedCurator']['etAl'] = $object->selectedCuratorEtAl();
+        if ($object->selectedCuratorEtAl()) {
+            $data['selectedCurator']['etAl'] = $object->selectedCuratorEtAl();
+        }
 
         $data['curators'] = $object->getCurators()->map(function (Person $person) use ($format, $context) {
             $context['snippet'] = true;
@@ -119,12 +125,16 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
             return $eachContentData;
         };
         $data['content'] = $object->getContent()->map($contentNormalization)->toArray();
-        $data['relatedContent'] = $object->getRelatedContent()->map($contentNormalization)->toArray();
-        $data['podcastEpisodes'] = $object->getPodcastEpisodes()->map(function (PodcastEpisode $podcastEpisode) use ($format, $context) {
-            $context['snippet'] = true;
+        if (count($object->getRelatedContent()) > 0) {
+            $data['relatedContent'] = $object->getRelatedContent()->map($contentNormalization)->toArray();
+        }
+        if (count($object->getPodcastEpisodes()) > 0) {
+            $data['podcastEpisodes'] = $object->getPodcastEpisodes()->map(function (PodcastEpisode $podcastEpisode) use ($format, $context) {
+                $context['snippet'] = true;
 
-            return $this->normalizer->normalize($podcastEpisode, $format, $context);
-        })->toArray();
+                return $this->normalizer->normalize($podcastEpisode, $format, $context);
+            })->toArray();
+        }
         
         return $data;
     }

--- a/src/Serializer/CollectionNormalizer.php
+++ b/src/Serializer/CollectionNormalizer.php
@@ -5,7 +5,6 @@ namespace eLife\ApiSdk\Serializer;
 use DateTimeImmutable;
 use eLife\ApiClient\ApiClient\CollectionsClient;
 use eLife\ApiClient\MediaType;
-use eLife\ApiClient\Result;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\ArticlePoA;

--- a/src/Serializer/CollectionNormalizer.php
+++ b/src/Serializer/CollectionNormalizer.php
@@ -11,7 +11,7 @@ use eLife\ApiClient\ApiClient\CollectionsClient;
 #use eLife\ApiSdk\Model\ArticlePoA;
 #use eLife\ApiSdk\Model\ArticleVoR;
 #use eLife\ApiSdk\Model\Image;
-#use eLife\ApiSdk\Model\Collection;
+use eLife\ApiSdk\Model\Collection;
 #use eLife\ApiSdk\Model\CollectionChapter;
 #use eLife\ApiSdk\Model\CollectionSource;
 #use eLife\ApiSdk\Model\Subject;
@@ -50,7 +50,7 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
 
     public function supportsDenormalization($data, $type, $format = null) : bool
     {
-        return PodcastEpisode::class === $type;
+        return Collection::class === $type;
     }
 
     public function supportsNormalization($data, $format = null) : bool

--- a/src/Serializer/CollectionNormalizer.php
+++ b/src/Serializer/CollectionNormalizer.php
@@ -26,7 +26,6 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-use function GuzzleHttp\Promise\all;
 use function GuzzleHttp\Promise\promise_for;
 
 final class CollectionNormalizer implements NormalizerInterface, DenormalizerInterface, NormalizerAwareInterface, DenormalizerAwareInterface
@@ -90,6 +89,7 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
             } else {
                 throw new \LogicException("Cannot denormalize {$eachContent['type']}");
             }
+
             return $this->denormalizer->denormalize(
                 $eachContent,
                 $class,
@@ -129,7 +129,7 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
 
         if (empty($this->globalCallback)) {
             $this->globalCallback = new CallbackPromise(function () {
-                $this->identityMap->fillMissingWith(function($id) {
+                $this->identityMap->fillMissingWith(function ($id) {
                     return $this->collectionsClient->getCollection(
                         ['Accept' => new MediaType(CollectionsClient::TYPE_COLLECTION, 1)],
                         $id
@@ -199,7 +199,6 @@ final class CollectionNormalizer implements NormalizerInterface, DenormalizerInt
                 $data['relatedContent'] = $object->getRelatedContent()->map($contentNormalization)->toArray();
             }
             if (count($object->getPodcastEpisodes()) > 0) {
-
                 $data['podcastEpisodes'] = $normalizationHelper->normalizeSequenceToSnippets($object->getPodcastEpisodes(), $context);
             }
         }

--- a/src/Serializer/CollectionNormalizer.php
+++ b/src/Serializer/CollectionNormalizer.php
@@ -4,26 +4,26 @@ namespace eLife\ApiSdk\Serializer;
 
 use DateTimeImmutable;
 use eLife\ApiClient\ApiClient\CollectionsClient;
-#use eLife\ApiClient\MediaType;
-#use eLife\ApiClient\Result;
+//use eLife\ApiClient\MediaType;
+//use eLife\ApiClient\Result;
 use eLife\ApiSdk\Collection\ArraySequence;
-#use eLife\ApiSdk\Collection\PromiseSequence;
-#use eLife\ApiSdk\Model\ArticlePoA;
-#use eLife\ApiSdk\Model\ArticleVoR;
-use eLife\ApiSdk\Model\Image;
+//use eLife\ApiSdk\Collection\PromiseSequence;
+//use eLife\ApiSdk\Model\ArticlePoA;
+//use eLife\ApiSdk\Model\ArticleVoR;
 use eLife\ApiSdk\Model\Collection;
-#use eLife\ApiSdk\Model\CollectionChapter;
-#use eLife\ApiSdk\Model\CollectionSource;
+use eLife\ApiSdk\Model\Image;
+//use eLife\ApiSdk\Model\CollectionChapter;
+//use eLife\ApiSdk\Model\CollectionSource;
 use eLife\ApiSdk\Model\Subject;
-#use eLife\ApiSdk\Promise\CallbackPromise;
-#use GuzzleHttp\Promise\PromiseInterface;
+//use eLife\ApiSdk\Promise\CallbackPromise;
+//use GuzzleHttp\Promise\PromiseInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-#use function GuzzleHttp\Promise\all;
+//use function GuzzleHttp\Promise\all;
 use function GuzzleHttp\Promise\promise_for;
 
 final class CollectionNormalizer implements NormalizerInterface, DenormalizerInterface, NormalizerAwareInterface, DenormalizerAwareInterface

--- a/src/Serializer/IdentityMap.php
+++ b/src/Serializer/IdentityMap.php
@@ -2,13 +2,11 @@
 
 namespace eLife\ApiSdk\Serializer;
 
-use ArrayIterator;
-use IteratorAggregate;
 use GuzzleHttp\Promise\PromiseInterface;
 use function GuzzleHttp\Promise\all;
 
 /**
- * As in http://www.martinfowler.com/eaaCatalog/identityMap.html
+ * As in http://www.martinfowler.com/eaaCatalog/identityMap.html.
  */
 final class IdentityMap
 {
@@ -17,12 +15,13 @@ final class IdentityMap
     public function reset($id) : self
     {
         $this->contents[$id] = null;
-        return $this; 
+
+        return $this;
     }
 
     public function has($id) : bool
     {
-        return array_key_exists($id, $this->contents); 
+        return array_key_exists($id, $this->contents);
     }
 
     /**
@@ -37,9 +36,10 @@ final class IdentityMap
     {
         foreach ($this->contents as $id => $promise) {
             if (null === $promise) {
-                $this->contents[$id] =  $load($id);
+                $this->contents[$id] = $load($id);
             }
         }
+
         return $this;
     }
 

--- a/src/Serializer/IdentityMap.php
+++ b/src/Serializer/IdentityMap.php
@@ -43,7 +43,7 @@ final class IdentityMap
         return $this;
     }
 
-    public function waitForAll()
+    public function waitForAll() : array
     {
         return all($this->contents)->wait();
     }

--- a/src/Serializer/IdentityMap.php
+++ b/src/Serializer/IdentityMap.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace eLife\ApiSdk\Serializer;
+
+use ArrayIterator;
+use IteratorAggregate;
+use GuzzleHttp\Promise\PromiseInterface;
+use function GuzzleHttp\Promise\all;
+
+/**
+ * As in http://www.martinfowler.com/eaaCatalog/identityMap.html
+ */
+class IdentityMap implements IteratorAggregate
+{
+    private $contents = [];
+
+    public function reset($id)
+    {
+        $this->contents[$id] = null;
+        return $this; 
+    }
+
+    public function has($id)
+    {
+        return array_key_exists($id, $this->contents); 
+    }
+
+    public function get($id)
+    {
+        return $this->contents[$id];
+    }
+
+    public function put($id, PromiseInterface $promise)
+    {
+        $this->contents[$id] = $promise;        
+        return $id;
+    }
+
+    public function getIterator()
+    {
+        return new ArrayIterator($this->contents);
+    }
+
+    public function waitForAll()
+    {
+        return all($this->contents)->wait();
+    }
+}

--- a/src/Serializer/NormalizationHelper.php
+++ b/src/Serializer/NormalizationHelper.php
@@ -2,33 +2,12 @@
 
 namespace eLife\ApiSdk\Serializer;
 
-use DateTimeImmutable;
-use eLife\ApiClient\ApiClient\CollectionsClient;
-use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\ApiSdk\Collection\ArraySequence;
-use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
-use eLife\ApiSdk\Model\ArticlePoA;
-use eLife\ApiSdk\Model\ArticleVoR;
-use eLife\ApiSdk\Model\BlogArticle;
-use eLife\ApiSdk\Model\Collection;
-use eLife\ApiSdk\Model\Image;
-use eLife\ApiSdk\Model\Interview;
-use eLife\ApiSdk\Model\Person;
-use eLife\ApiSdk\Model\PodcastEpisode;
-use eLife\ApiSdk\Model\Subject;
-use eLife\ApiSdk\Promise\CallbackPromise;
 use GuzzleHttp\Promise\PromiseInterface;
-use LogicException;
-use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
-use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
-use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-use function GuzzleHttp\Promise\all;
-use function GuzzleHttp\Promise\promise_for;
 
 /**
  * A better name is welcome.
@@ -49,7 +28,7 @@ final class NormalizationHelper
      * @var string|null
      */
     private $format;
-    
+
     /**
      * @param string|null $format
      */

--- a/src/Serializer/NormalizationHelper.php
+++ b/src/Serializer/NormalizationHelper.php
@@ -29,10 +29,7 @@ final class NormalizationHelper
      */
     private $format;
 
-    /**
-     * @param string|null $format
-     */
-    public function __construct(NormalizerInterface $normalizer, DenormalizerInterface $denormalizer, $format)
+    public function __construct(NormalizerInterface $normalizer, DenormalizerInterface $denormalizer, string $format = null)
     {
         $this->normalizer = $normalizer;
         $this->denormalizer = $denormalizer;

--- a/src/Serializer/NormalizationHelper.php
+++ b/src/Serializer/NormalizationHelper.php
@@ -45,6 +45,7 @@ final class NormalizationHelper
     public function selectField(PromiseInterface $resultPromise, string $fieldPath, $default = null) : PromiseInterface
     {
         $selectors = explode('.', $fieldPath);
+
         return $resultPromise->then(function (Result $entity) use (/*array*/ $selectors, $default) {
             $result = $entity->toArray();
             foreach ($selectors as $selector) {

--- a/src/Serializer/NormalizationHelper.php
+++ b/src/Serializer/NormalizationHelper.php
@@ -33,7 +33,7 @@ use function GuzzleHttp\Promise\promise_for;
 /**
  * A better name is welcome.
  */
-class NormalizationHelper
+final class NormalizationHelper
 {
     /**
      * @var NormalizerInterface

--- a/src/Serializer/NormalizationHelper.php
+++ b/src/Serializer/NormalizationHelper.php
@@ -59,28 +59,28 @@ final class NormalizationHelper
         });
     }
 
-    public function denormalizePromise(PromiseInterface $promise, string $class, $context) : PromiseInterface
+    public function denormalizePromise(PromiseInterface $promise, string $class, array $context) : PromiseInterface
     {
         return $promise->then(function (array $entity) use ($class, $context) {
             return $this->denormalizer->denormalize($entity, $class, $this->format, $context);
         });
     }
 
-    public function denormalizeSequence(Sequence $sequence, string $class, $context) : Sequence
+    public function denormalizeSequence(Sequence $sequence, string $class, array $context) : Sequence
     {
         return $sequence->map(function (array $entity) use ($class, $context) {
             return $this->denormalizer->denormalize($entity, $class, $this->format, $context);
         });
     }
 
-    public function denormalizeArray(array $array, string $class, $context) : ArraySequence
+    public function denormalizeArray(array $array, string $class, array $context) : ArraySequence
     {
         return new ArraySequence(array_map(function (array $subject) use ($class, $context) {
             return $this->denormalizer->denormalize($subject, $class, $this->format, $context);
         }, $array));
     }
 
-    public function normalizeSequenceToSnippets(Sequence $sequence, $context) : array
+    public function normalizeSequenceToSnippets(Sequence $sequence, array $context) : array
     {
         return $sequence->map(function ($each) use ($context) {
             $context['snippet'] = true;

--- a/src/Serializer/NormalizationHelper.php
+++ b/src/Serializer/NormalizationHelper.php
@@ -39,14 +39,23 @@ final class NormalizationHelper
         $this->format = $format;
     }
 
-    public function selectField(PromiseInterface $resultPromise, $fieldName, $default = null) : PromiseInterface
+    /**
+     * @param string $fieldPath e.g. 'title' or 'image.banner'
+     */
+    public function selectField(PromiseInterface $resultPromise, string $fieldPath, $default = null) : PromiseInterface
     {
-        return $resultPromise->then(function (Result $entity) use ($fieldName, $default) {
-            if ($default !== null) {
-                return $entity[$fieldName] ?? $default;
-            } else {
-                return $entity[$fieldName];
+        $selectors = explode('.', $fieldPath);
+        return $resultPromise->then(function (Result $entity) use (/*array*/ $selectors, $default) {
+            $result = $entity->toArray();
+            foreach ($selectors as $selector) {
+                if (array_key_exists($selector, $result)) {
+                    $result = $result[$selector];
+                } else {
+                    return $default;
+                }
             }
+
+            return $result;
         });
     }
 

--- a/src/Serializer/NormalizationHelper.php
+++ b/src/Serializer/NormalizationHelper.php
@@ -30,6 +30,9 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use function GuzzleHttp\Promise\all;
 use function GuzzleHttp\Promise\promise_for;
 
+/**
+ * A better name is welcome.
+ */
 class NormalizationHelper
 {
     /**
@@ -68,21 +71,21 @@ class NormalizationHelper
         });
     }
 
-    public function denormalizePromise($promise, $class, $context) : PromiseInterface
+    public function denormalizePromise(PromiseInterface $promise, string $class, $context) : PromiseInterface
     {
         return $promise->then(function (array $entity) use ($class, $context) {
             return $this->denormalizer->denormalize($entity, $class, $this->format, $context);
         });
     }
 
-    public function denormalizeSequence($sequence, $class, $context) : Sequence
+    public function denormalizeSequence(Sequence $sequence, string $class, $context) : Sequence
     {
         return $sequence->map(function (array $entity) use ($class, $context) {
             return $this->denormalizer->denormalize($entity, $class, $this->format, $context);
         });
     }
 
-    public function denormalizeArray(array $array, $class, $context) : ArraySequence
+    public function denormalizeArray(array $array, string $class, $context) : ArraySequence
     {
         return new ArraySequence(array_map(function (array $subject) use ($class, $context) {
             return $this->denormalizer->denormalize($subject, $class, $this->format, $context);
@@ -98,7 +101,7 @@ class NormalizationHelper
         })->toArray();
     }
 
-    public function normalizeToSnippet($object)
+    public function normalizeToSnippet($object) : array
     {
         return $this->normalizer->normalize($object, $this->format, ['snippet' => true]);
     }

--- a/src/Serializer/NormalizationHelper.php
+++ b/src/Serializer/NormalizationHelper.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace eLife\ApiSdk\Serializer;
+
+use DateTimeImmutable;
+use eLife\ApiClient\ApiClient\CollectionsClient;
+use eLife\ApiClient\MediaType;
+use eLife\ApiClient\Result;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\PromiseSequence;
+use eLife\ApiSdk\Collection\Sequence;
+use eLife\ApiSdk\Model\ArticlePoA;
+use eLife\ApiSdk\Model\ArticleVoR;
+use eLife\ApiSdk\Model\BlogArticle;
+use eLife\ApiSdk\Model\Collection;
+use eLife\ApiSdk\Model\Image;
+use eLife\ApiSdk\Model\Interview;
+use eLife\ApiSdk\Model\Person;
+use eLife\ApiSdk\Model\PodcastEpisode;
+use eLife\ApiSdk\Model\Subject;
+use eLife\ApiSdk\Promise\CallbackPromise;
+use GuzzleHttp\Promise\PromiseInterface;
+use LogicException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use function GuzzleHttp\Promise\all;
+use function GuzzleHttp\Promise\promise_for;
+
+class NormalizationHelper
+{
+    /**
+     * @var NormalizerInterface
+     */
+    private $normalizer;
+
+    /**
+     * @var DenormalizerInterface
+     */
+    private $denormalizer;
+
+    /**
+     * @var string|null
+     */
+    private $format;
+    
+    /**
+     * @param string|null $format
+     */
+    public function __construct(NormalizerInterface $normalizer, DenormalizerInterface $denormalizer, $format)
+    {
+        $this->normalizer = $normalizer;
+        $this->denormalizer = $denormalizer;
+        $this->format = $format;
+    }
+
+    public function selectField(PromiseInterface $resultPromise, $fieldName, $default = null) : PromiseInterface
+    {
+        return $resultPromise->then(function (Result $entity) use ($fieldName, $default) {
+            if ($default !== null) {
+                return $entity[$fieldName] ?? $default;
+            } else {
+                return $entity[$fieldName];
+            }
+        });
+    }
+
+    public function denormalizePromise($promise, $class, $context) : PromiseInterface
+    {
+        return $promise->then(function (array $entity) use ($class, $context) {
+            return $this->denormalizer->denormalize($entity, $class, $this->format, $context);
+        });
+    }
+
+    public function denormalizeSequence($sequence, $class, $context) : Sequence
+    {
+        return $sequence->map(function (array $entity) use ($class, $context) {
+            return $this->denormalizer->denormalize($entity, $class, $this->format, $context);
+        });
+    }
+
+    public function denormalizeArray(array $array, $class, $context) : ArraySequence
+    {
+        return new ArraySequence(array_map(function (array $subject) use ($class, $context) {
+            return $this->denormalizer->denormalize($subject, $class, $this->format, $context);
+        }, $array));
+    }
+
+    public function normalizeSequenceToSnippets(Sequence $sequence, $context) : array
+    {
+        return $sequence->map(function ($each) use ($context) {
+            $context['snippet'] = true;
+
+            return $this->normalizer->normalize($each, $this->format, $context);
+        })->toArray();
+    }
+
+    public function normalizeToSnippet($object)
+    {
+        return $this->normalizer->normalize($object, $this->format, ['snippet' => true]);
+    }
+}

--- a/src/Serializer/PersonNormalizer.php
+++ b/src/Serializer/PersonNormalizer.php
@@ -115,7 +115,6 @@ final class PersonNormalizer implements NormalizerInterface, DenormalizerInterfa
             $this->globalCallback = new CallbackPromise(function () {
                 foreach ($this->found as $id => $person) {
                     if (null === $person) {
-                        var_Dump($id);
                         $this->found[$id] = $this->peopleClient->getPerson(
                             ['Accept' => new MediaType(PeopleClient::TYPE_PERSON, 1)],
                             $id

--- a/src/Serializer/PersonNormalizer.php
+++ b/src/Serializer/PersonNormalizer.php
@@ -115,6 +115,7 @@ final class PersonNormalizer implements NormalizerInterface, DenormalizerInterfa
             $this->globalCallback = new CallbackPromise(function () {
                 foreach ($this->found as $id => $person) {
                     if (null === $person) {
+                        var_Dump($id);
                         $this->found[$id] = $this->peopleClient->getPerson(
                             ['Accept' => new MediaType(PeopleClient::TYPE_PERSON, 1)],
                             $id

--- a/src/Serializer/PodcastEpisodeNormalizer.php
+++ b/src/Serializer/PodcastEpisodeNormalizer.php
@@ -8,8 +8,6 @@ use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
-use eLife\ApiSdk\Model\ArticlePoA;
-use eLife\ApiSdk\Model\ArticleVoR;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\PodcastEpisode;
 use eLife\ApiSdk\Model\PodcastEpisodeChapter;

--- a/src/Serializer/PodcastEpisodeNormalizer.php
+++ b/src/Serializer/PodcastEpisodeNormalizer.php
@@ -66,27 +66,7 @@ final class PodcastEpisodeNormalizer implements NormalizerInterface, Denormalize
                     $chapter['impactStatement'] ?? null,
                     new ArraySequence(array_map(function (array $item) use ($format, $context) {
                         $context['snippet'] = true;
-
-                        switch ($item['type']) {
-                            case 'correction':
-                            case 'editorial':
-                            case 'feature':
-                            case 'insight':
-                            case 'research-advance':
-                            case 'research-article':
-                            case 'research-exchange':
-                            case 'retraction':
-                            case 'registered-report':
-                            case 'replication-study':
-                            case 'short-report':
-                            case 'tools-resources':
-                                if ('poa' === $item['status']) {
-                                    $class = ArticlePoA::class;
-                                } else {
-                                    $class = ArticleVoR::class;
-                                }
-                                break;
-                        }
+                        $class = ArticleVersionNormalizer::articleClass($item['type'], $item['status']);
 
                         return $this->denormalizer->denormalize($item, $class, $format, $context);
                     }, $chapter['content'])));

--- a/test/ApiSdkTest.php
+++ b/test/ApiSdkTest.php
@@ -6,6 +6,7 @@ use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Client\AnnualReports;
 use eLife\ApiSdk\Client\Articles;
 use eLife\ApiSdk\Client\BlogArticles;
+use eLife\ApiSdk\Client\Collections;
 use eLife\ApiSdk\Client\Events;
 use eLife\ApiSdk\Client\Interviews;
 use eLife\ApiSdk\Client\LabsExperiments;
@@ -67,6 +68,18 @@ final class ApiSdkTest extends ApiTestCase
         $this->mockSubjectCall(1);
 
         $this->apiSdk->getSerializer()->normalize($this->apiSdk->blogArticles()->get('blogArticle7')->wait());
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_collections()
+    {
+        $this->assertInstanceOf(Collections::class, $this->apiSdk->collections());
+
+        $this->mockCollectionCall('1');
+
+        $this->apiSdk->getSerializer()->normalize($this->apiSdk->collections()->get('1')->wait());
     }
 
     /**

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -143,26 +143,31 @@ abstract class ApiTestCase extends TestCase
         );
     }
 
-    final protected function mockArticleCall(int $number, bool $complete = false, bool $vor = false)
+    final protected function mockArticleCall($numberOrId, bool $complete = false, bool $vor = false)
     {
+        if (is_integer($numberOrId)) {
+            $id = "blogArticle{$numberOrId}";
+        } else {
+            $id = (string) $numberOrId;
+        }
         if ($vor) {
             $response = new Response(
                 200,
                 ['Content-Type' => new MediaType(ArticlesClient::TYPE_ARTICLE_VOR, 1)],
-                json_encode($this->createArticleVoRJson($number, false, $complete))
+                json_encode($this->createArticleVoRJson($id, false, $complete))
             );
         } else {
             $response = new Response(
                 200,
                 ['Content-Type' => new MediaType(ArticlesClient::TYPE_ARTICLE_POA, 1)],
-                json_encode($this->createArticlePoAJson($number, false, $complete))
+                json_encode($this->createArticlePoAJson($id, false, $complete))
             );
         }
 
         $this->storage->save(
             new Request(
                 'GET',
-                'http://api.elifesciences.org/articles/article'.$number,
+                'http://api.elifesciences.org/articles/'.$id,
                 [
                     'Accept' => [
                         new MediaType(ArticlesClient::TYPE_ARTICLE_POA, 1),
@@ -581,24 +586,24 @@ abstract class ApiTestCase extends TestCase
         ];
     }
 
-    private function createArticlePoAJson(int $number, bool $isSnippet = false, bool $complete = false) : array
+    private function createArticlePoAJson(string $id, bool $isSnippet = false, bool $complete = false) : array
     {
         $article = [
             'status' => 'poa',
-            'id' => 'article'.$number,
+            'id' => $id,
             'version' => 1,
             'type' => 'research-article',
-            'doi' => '10.7554/eLife.'.$number,
-            'title' => 'Article '.$number.' title',
-            'titlePrefix' => 'Article '.$number.' title prefix',
+            'doi' => '10.7554/eLife.'.$id,
+            'title' => 'Article '.$id.' title',
+            'titlePrefix' => 'Article '.$id.' title prefix',
             'published' => '2000-01-01T00:00:00+00:00',
             'statusDate' => '1999-12-31T00:00:00+00:00',
             'volume' => 1,
             'issue' => 1,
-            'elocationId' => 'e'.$number,
+            'elocationId' => 'e'.$id,
             'pdf' => 'http://www.example.com/',
             'subjects' => [$this->createSubjectJson(1, true)],
-            'researchOrganisms' => ['Article '.$number.' research organism'],
+            'researchOrganisms' => ['Article '.$id.' research organism'],
             'copyright' => [
                 'license' => 'CC-BY-4.0',
                 'holder' => 'Author et al',
@@ -618,7 +623,7 @@ abstract class ApiTestCase extends TestCase
                 'content' => [
                     [
                         'type' => 'paragraph',
-                        'text' => 'Article '.$number.' abstract text',
+                        'text' => 'Article '.$id.' abstract text',
                     ],
                 ],
             ],
@@ -643,9 +648,9 @@ abstract class ApiTestCase extends TestCase
         return $article;
     }
 
-    private function createArticleVoRJson(int $number, bool $isSnippet = false, bool $complete = false) : array
+    private function createArticleVoRJson(string $id, bool $isSnippet = false, bool $complete = false) : array
     {
-        $article = $this->createArticlePoAJson($number, $isSnippet, $complete);
+        $article = $this->createArticlePoAJson($id, $isSnippet, $complete);
 
         $article['status'] = 'vor';
 

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -1210,14 +1210,20 @@ abstract class ApiTestCase extends TestCase
 
         if (!$complete) {
             unset($collection['impactStatement']);
-            unset($collection['subjects']);
+            unset($collection['selectedCurator']['etAl']);
+            unset($collection['subTitle']);
             unset($collection['relatedContent']);
+            unset($collection['podcastEpisodes']);
+            unset($collection['subjects']);
         }
 
         if ($isSnippet) {
             unset($collection['image']['banner']);
+            unset($collection['subTitle']);
+            unset($collection['curators']);
             unset($collection['content']);
             unset($collection['relatedContent']);
+            unset($collection['podcastEpisodes']);
         }
 
         return $collection;

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -300,7 +300,7 @@ abstract class ApiTestCase extends TestCase
     }
 
     /**
-     * @param string|integer $numberOrId
+     * @param string|int $numberOrId
      */
     final protected function mockInterviewCall($numberOrId, bool $complete = false)
     {
@@ -425,7 +425,7 @@ abstract class ApiTestCase extends TestCase
     }
 
     /**
-     * @param string|integer $numberOrId
+     * @param string|int $numberOrId
      */
     final protected function mockPersonCall($numberOrId, bool $complete = false, bool $isSnippet = false)
     {
@@ -1186,7 +1186,7 @@ abstract class ApiTestCase extends TestCase
                     'type' => 'blog-article',
                     'id' => '359325',
                     'title' => 'Media coverage: Slime can see',
-                    'impactStatement' => "In their research paper – Cyanobacteria use micro-optics to sense light direction – Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world’s oldest and smallest camera eye, allowing them to ‘see’.",
+                    'impactStatement' => 'In their research paper – Cyanobacteria use micro-optics to sense light direction – Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world’s oldest and smallest camera eye, allowing them to ‘see’.',
                     'published' => '2016-07-08T08:33:25+00:00',
                     'subjects' => [
                         [
@@ -1209,7 +1209,7 @@ abstract class ApiTestCase extends TestCase
                     'statusDate' => '2016-03-28T00:00:00+00:00',
                     'volume' => 5,
                     'elocationId' => 'e14107',
-                ]
+                ],
             ],
             'podcastEpisodes' => [
             ],

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -206,18 +206,23 @@ abstract class ApiTestCase extends TestCase
         );
     }
 
-    final protected function mockBlogArticleCall(int $number, bool $complete = false)
+    final protected function mockBlogArticleCall($numberOrId, bool $complete = false)
     {
+        if (is_integer($numberOrId)) {
+            $id = "blogArticle{$numberOrId}";
+        } else {
+            $id = (string) $numberOrId;
+        }
         $this->storage->save(
             new Request(
                 'GET',
-                'http://api.elifesciences.org/blog-articles/blogArticle'.$number,
+                'http://api.elifesciences.org/blog-articles/'.$id,
                 ['Accept' => new MediaType(BlogClient::TYPE_BLOG_ARTICLE, 1)]
             ),
             new Response(
                 200,
                 ['Content-Type' => new MediaType(BlogClient::TYPE_BLOG_ARTICLE, 1)],
-                json_encode($this->createBlogArticleJson($number, false, $complete))
+                json_encode($this->createBlogArticleJson($id, false, $complete))
             )
         );
     }
@@ -409,7 +414,7 @@ abstract class ApiTestCase extends TestCase
     /**
      * @param string|integer $numberOrId
      */
-    final protected function mockPersonCall($numberOrId, bool $complete = false)
+    final protected function mockPersonCall($numberOrId, bool $complete = false, bool $isSnippet = false)
     {
         if (is_integer($numberOrId)) {
             $id = "person{$numberOrId}";
@@ -425,7 +430,7 @@ abstract class ApiTestCase extends TestCase
             new Response(
                 200,
                 ['Content-Type' => new MediaType(PeopleClient::TYPE_PERSON, 1)],
-                json_encode($this->createPersonJson($id, false, $complete))
+                json_encode($this->createPersonJson($id, $isSnippet, $complete))
             )
         );
     }
@@ -517,18 +522,23 @@ abstract class ApiTestCase extends TestCase
         );
     }
 
-    final protected function mockSubjectCall(int $number)
+    final protected function mockSubjectCall($numberOrId)
     {
+        if (is_integer($numberOrId)) {
+            $id = "person{$numberOrId}";
+        } else {
+            $id = (string) $numberOrId;
+        }
         $this->storage->save(
             new Request(
                 'GET',
-                'http://api.elifesciences.org/subjects/subject'.$number,
+                'http://api.elifesciences.org/subjects/'.$id,
                 ['Accept' => new MediaType(SubjectsClient::TYPE_SUBJECT, 1)]
             ),
             new Response(
                 200,
                 ['Content-Type' => new MediaType(SubjectsClient::TYPE_SUBJECT, 1)],
-                json_encode($this->createSubjectJson($number))
+                json_encode($this->createSubjectJson($id))
             )
         );
     }
@@ -763,22 +773,22 @@ abstract class ApiTestCase extends TestCase
         return $article;
     }
 
-    private function createBlogArticleJson(int $number, bool $isSnippet = false, bool $complete = false) : array
+    private function createBlogArticleJson(string $id, bool $isSnippet = false, bool $complete = false) : array
     {
         $blogArticle = [
-            'id' => 'blogArticle'.$number,
-            'title' => 'Blog article '.$number.' title',
+            'id' => $id,
+            'title' => 'Blog article '.$id.' title',
             'published' => '2000-01-01T00:00:00+00:00',
             'content' => [
                 [
                     'type' => 'paragraph',
-                    'text' => 'Blog article '.$number.' text',
+                    'text' => 'Blog article '.$id.' text',
                 ],
             ],
         ];
 
         if ($complete) {
-            $blogArticle['impactStatement'] = 'Blog article '.$number.' impact statement';
+            $blogArticle['impactStatement'] = 'Blog article '.$id.' impact statement';
             $blogArticle['subjects'][] = $this->createSubjectJson(1, true);
         }
 
@@ -1106,19 +1116,6 @@ abstract class ApiTestCase extends TestCase
                     'preferred' => 'Prabhat Jha',
                     'index' => 'Jha, Prabhat',
                 ],
-                'image' => [
-                    'alt' => '',
-                    'sizes' => [
-                        '16:9' => [
-                            '250' => 'https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=250&height=141',
-                            '500' => 'https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=500&height=281',
-                        ],
-                        '1:1' => [
-                            '70' => 'https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=70&height=70',
-                            '140' => 'https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=140&height=140',
-                        ],
-                    ],
-                ],
                 'etAl' => true,
             ],
             'curators' => [
@@ -1137,27 +1134,14 @@ abstract class ApiTestCase extends TestCase
                         'preferred' => 'Prabhat Jha',
                         'index' => 'Jha, Prabhat',
                     ],
-                    'image' => [
-                    'alt' => '',
-                        'sizes' => [
-                            '16:9' => [
-                                '250' => 'https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=250&height=141',
-                                '500' => 'https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=500&height=281',
-                            ],
-                            '1:1' => [
-                                '70' => 'https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=70&height=70',
-                                '140' => 'https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=140&height=140',
-                            ],
-                        ],
-                    ],
                 ],
             ],
             'content' => [
                 [
                     'type' => 'blog-article',
                     'id' => '359325',
-                    'title' => 'Media coverage => Slime can see',
-                    'impactStatement' => "In their research paper \u2013 Cyanobacteria use micro-optics to sense light direction \u2013 Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world\u2019s oldest and smallest camera eye, allowing them to \u2018see\u2019.",
+                    'title' => 'Media coverage: Slime can see',
+                    'impactStatement' => "In their research paper – Cyanobacteria use micro-optics to sense light direction – Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world’s oldest and smallest camera eye, allowing them to ‘see’.",
                     'published' => '2016-07-08T08:33:25+00:00',
                     'subjects' => [
                         [
@@ -1183,12 +1167,12 @@ abstract class ApiTestCase extends TestCase
         return $collection;
     }
 
-    final private function createSubjectJson(int $number, bool $isSnippet = false) : array
+    final private function createSubjectJson(string $id, bool $isSnippet = false) : array
     {
         $subject = [
-            'id' => 'subject'.$number,
-            'name' => 'Subject '.$number.' name',
-            'impactStatement' => 'Subject '.$number.' impact statement',
+            'id' => $id,
+            'name' => 'Subject '.$id.' name',
+            'impactStatement' => 'Subject '.$id.' impact statement',
             'image' => [
                 'banner' => [
                     'alt' => '',

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -1056,6 +1056,7 @@ abstract class ApiTestCase extends TestCase
         $collection = [
             'id' => $id,
             'title' => ucfirst($id),
+            'subTitle' => ucfirst($id).' subtitle',
             'impactStatement' => ucfirst($id).' impact statement',
             'updated' => '2000-01-01T00:00:00+00:00',
             'image' => [

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -299,18 +299,26 @@ abstract class ApiTestCase extends TestCase
         );
     }
 
-    final protected function mockInterviewCall(int $number, bool $complete = false)
+    /**
+     * @param string|integer $numberOrId
+     */
+    final protected function mockInterviewCall($numberOrId, bool $complete = false)
     {
+        if (is_integer($numberOrId)) {
+            $id = "person{$numberOrId}";
+        } else {
+            $id = (string) $numberOrId;
+        }
         $this->storage->save(
             new Request(
                 'GET',
-                'http://api.elifesciences.org/interviews/interview'.$number,
+                'http://api.elifesciences.org/interviews/'.$id,
                 ['Accept' => new MediaType(InterviewsClient::TYPE_INTERVIEW, 1)]
             ),
             new Response(
                 200,
                 ['Content-Type' => new MediaType(InterviewsClient::TYPE_INTERVIEW, 1)],
-                json_encode($this->createInterviewJson($number, false, $complete))
+                json_encode($this->createInterviewJson($id, false, $complete))
             )
         );
     }
@@ -655,11 +663,11 @@ abstract class ApiTestCase extends TestCase
         $article['status'] = 'vor';
 
         if (false === empty($article['abstract'])) {
-            $article['abstract']['doi'] = '10.7554/eLife.'.$number.'abstract';
+            $article['abstract']['doi'] = '10.7554/eLife.'.$id.'abstract';
         }
 
         $article += [
-            'impactStatement' => 'Article '.$number.' impact statement',
+            'impactStatement' => 'Article '.$id.' impact statement',
             'image' => [
                 'banner' => [
                     'alt' => '',
@@ -684,25 +692,25 @@ abstract class ApiTestCase extends TestCase
                     ],
                 ],
             ],
-            'keywords' => ['Article '.$number.' keyword'],
+            'keywords' => ['Article '.$id.' keyword'],
             'digest' => [
                 'content' => [
                     [
                         'type' => 'paragraph',
-                        'text' => 'Article '.$number.' digest',
+                        'text' => 'Article '.$id.' digest',
                     ],
                 ],
-                'doi' => '10.7554/eLife.'.$number.'digest',
+                'doi' => '10.7554/eLife.'.$id.'digest',
             ],
             'body' => [
                 [
                     'type' => 'section',
-                    'title' => 'Article '.$number.' section title',
-                    'id' => 'article'.$number.'section',
+                    'title' => 'Article '.$id.' section title',
+                    'id' => 'article'.$id.'section',
                     'content' => [
                         [
                             'type' => 'paragraph',
-                            'text' => 'Article '.$number.' text',
+                            'text' => 'Article '.$id.' text',
                         ],
                     ],
                 ],
@@ -728,26 +736,26 @@ abstract class ApiTestCase extends TestCase
                 ],
             ],
             'decisionLetter' => [
-                'doi' => '10.7554/eLife.'.$number.'decisionLetter',
+                'doi' => '10.7554/eLife.'.$id.'decisionLetter',
                 'description' => [
                     [
                         'type' => 'paragraph',
-                        'text' => 'Article '.$number.' decision letter description',
+                        'text' => 'Article '.$id.' decision letter description',
                     ],
                 ],
                 'content' => [
                     [
                         'type' => 'paragraph',
-                        'text' => 'Article '.$number.' decision letter text',
+                        'text' => 'Article '.$id.' decision letter text',
                     ],
                 ],
             ],
             'authorResponse' => [
-                'doi' => '10.7554/eLife.'.$number.'authorResponse',
+                'doi' => '10.7554/eLife.'.$id.'authorResponse',
                 'content' => [
                     [
                         'type' => 'paragraph',
-                        'text' => 'Article '.$number.' author response text',
+                        'text' => 'Article '.$id.' author response text',
                     ],
                 ],
             ],
@@ -833,10 +841,10 @@ abstract class ApiTestCase extends TestCase
         return $event;
     }
 
-    private function createInterviewJson(int $number, bool $isSnippet = false, bool $complete = false) : array
+    private function createInterviewJson(string $id, bool $isSnippet = false, bool $complete = false) : array
     {
         $interview = [
-            'id' => 'interview'.$number,
+            'id' => $id,
             'interviewee' => [
                 'name' => [
                     'preferred' => 'preferred name',
@@ -850,13 +858,13 @@ abstract class ApiTestCase extends TestCase
                     ],
                 ],
             ],
-            'title' => 'Interview '.$number.' title',
-            'impactStatement' => 'Interview '.$number.' impact statement',
+            'title' => 'Interview '.$id.' title',
+            'impactStatement' => 'Interview '.$id.' impact statement',
             'published' => '2000-01-01T00:00:00+00:00',
             'content' => [
                 [
                     'type' => 'paragraph',
-                    'text' => 'Interview '.$number.' text',
+                    'text' => 'Interview '.$id.' text',
                 ],
             ],
         ];
@@ -1156,17 +1164,36 @@ abstract class ApiTestCase extends TestCase
                     ],
                 ],
             ],
+            'relatedContent' => [
+                [
+                    'type' => 'research-article',
+                    'status' => 'poa',
+                    'id' => '14107',
+                    'version' => 1,
+                    'doi' => '10.7554/eLife.14107',
+                    'authorLine' => 'Yongjian Huang et al',
+                    'title' => 'Molecular basis for multimerization in the activation of the epidermal growth factor',
+                    'published' => '2016-03-28T00:00:00+00:00',
+                    'statusDate' => '2016-03-28T00:00:00+00:00',
+                    'volume' => 5,
+                    'elocationId' => 'e14107',
+                ]
+            ],
+            'podcastEpisodes' => [
+            ],
             'subjects' => [$this->createSubjectJson(1, true)],
         ];
 
         if (!$complete) {
             unset($collection['impactStatement']);
             unset($collection['subjects']);
+            unset($collection['relatedContent']);
         }
 
         if ($isSnippet) {
             unset($collection['image']['banner']);
             unset($collection['content']);
+            unset($collection['relatedContent']);
         }
 
         return $collection;

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -116,10 +116,10 @@ abstract class ApiTestCase extends TestCase
     ) {
         $articles = array_map(function (int $id) use ($vor) {
             if ($vor) {
-                return $this->createArticleVoRJson($id, true);
+                return $this->createArticleVoRJson('article'.$id, true);
             }
 
-            return $this->createArticlePoAJson($id, true);
+            return $this->createArticlePoAJson('article'.$id, true);
         }, $this->generateIdList($page, $perPage, $total));
 
         $subjectsQuery = implode('', array_map(function (string $subjectId) {
@@ -146,7 +146,7 @@ abstract class ApiTestCase extends TestCase
     final protected function mockArticleCall($numberOrId, bool $complete = false, bool $vor = false)
     {
         if (is_integer($numberOrId)) {
-            $id = "blogArticle{$numberOrId}";
+            $id = "article{$numberOrId}";
         } else {
             $id = (string) $numberOrId;
         }
@@ -187,7 +187,7 @@ abstract class ApiTestCase extends TestCase
         array $subjects = []
     ) {
         $blogArticles = array_map(function (int $id) {
-            return $this->createBlogArticleJson($id, true);
+            return $this->createBlogArticleJson('blogArticle'.$id, true);
         }, $this->generateIdList($page, $perPage, $total));
 
         $subjectsQuery = implode('', array_map(function (string $subjectId) {
@@ -279,7 +279,7 @@ abstract class ApiTestCase extends TestCase
     final protected function mockInterviewListCall(int $page, int $perPage, int $total, $descendingOrder = true)
     {
         $interviews = array_map(function (int $id) {
-            return $this->createInterviewJson($id, true);
+            return $this->createInterviewJson('interview'.$id, true);
         }, $this->generateIdList($page, $perPage, $total));
 
         $this->storage->save(
@@ -305,7 +305,7 @@ abstract class ApiTestCase extends TestCase
     final protected function mockInterviewCall($numberOrId, bool $complete = false)
     {
         if (is_integer($numberOrId)) {
-            $id = "person{$numberOrId}";
+            $id = "interview{$numberOrId}";
         } else {
             $id = (string) $numberOrId;
         }
@@ -515,7 +515,7 @@ abstract class ApiTestCase extends TestCase
     final protected function mockSubjectListCall(int $page, int $perPage, int $total, $descendingOrder = true)
     {
         $subjects = array_map(function (int $id) {
-            return $this->createSubjectJson($id);
+            return $this->createSubjectJson('subject'.$id);
         }, $this->generateIdList($page, $perPage, $total));
 
         $this->storage->save(
@@ -538,7 +538,7 @@ abstract class ApiTestCase extends TestCase
     final protected function mockSubjectCall($numberOrId)
     {
         if (is_integer($numberOrId)) {
-            $id = "person{$numberOrId}";
+            $id = "subject{$numberOrId}";
         } else {
             $id = (string) $numberOrId;
         }
@@ -610,7 +610,7 @@ abstract class ApiTestCase extends TestCase
             'issue' => 1,
             'elocationId' => 'e'.$id,
             'pdf' => 'http://www.example.com/',
-            'subjects' => [$this->createSubjectJson(1, true)],
+            'subjects' => [$this->createSubjectJson('1', true)],
             'researchOrganisms' => ['Article '.$id.' research organism'],
             'copyright' => [
                 'license' => 'CC-BY-4.0',
@@ -1063,7 +1063,7 @@ abstract class ApiTestCase extends TestCase
                     'title' => 'Chapter title',
                     'time' => 0,
                     'impactStatement' => 'Chapter impact statement',
-                    'content' => [$this->createArticlePoAJson(1, true, $complete)],
+                    'content' => [$this->createArticlePoAJson('1', true, $complete)],
                 ],
             ],
         ];

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -1146,14 +1146,6 @@ abstract class ApiTestCase extends TestCase
                     ],
                 ],
             ],
-            /*
-            'sources' => [
-                [
-                    'mediaType' => 'audio/mpeg',
-                    'uri' => 'https://www.example.com/episode.mp3',
-                ],
-            ],
-             */
             'selectedCurator' => [
                 'id' => 'pjha',
                 'type' => 'senior-editor',

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -376,7 +376,7 @@ abstract class ApiTestCase extends TestCase
         string $type = null
     ) {
         $people = array_map(function (int $id) {
-            return $this->createPersonJson($id, true);
+            return $this->createPersonJson('person'.$id, true);
         }, $this->generateIdList($page, $perPage, $total));
 
         $subjectsQuery = implode('', array_map(function (string $subjectId) {
@@ -406,18 +406,26 @@ abstract class ApiTestCase extends TestCase
         );
     }
 
-    final protected function mockPersonCall(int $number, bool $complete = false)
+    /**
+     * @param string|integer $numberOrId
+     */
+    final protected function mockPersonCall($numberOrId, bool $complete = false)
     {
+        if (is_integer($numberOrId)) {
+            $id = "person{$numberOrId}";
+        } else {
+            $id = (string) $numberOrId;
+        }
         $this->storage->save(
             new Request(
                 'GET',
-                'http://api.elifesciences.org/people/person'.$number,
+                'http://api.elifesciences.org/people/'.$id,
                 ['Accept' => new MediaType(PeopleClient::TYPE_PERSON, 1)]
             ),
             new Response(
                 200,
                 ['Content-Type' => new MediaType(PeopleClient::TYPE_PERSON, 1)],
-                json_encode($this->createPersonJson($number, false, $complete))
+                json_encode($this->createPersonJson($id, false, $complete))
             )
         );
     }
@@ -925,14 +933,14 @@ abstract class ApiTestCase extends TestCase
         ];
     }
 
-    private function createPersonJson(int $number, bool $isSnippet = false, bool $complete = false) : array
+    private function createPersonJson(string $id, bool $isSnippet = false, bool $complete = false) : array
     {
         $person = [
-            'id' => 'person'.$number,
+            'id' => $id,
             'type' => 'senior-editor',
             'name' => [
-                'preferred' => 'Person '.$number.' preferred',
-                'index' => 'Person '.$number.' index',
+                'preferred' => $id.' preferred',
+                'index' => $id.' index',
             ],
             'orcid' => '0000-0002-1825-0097',
             'research' => [
@@ -952,10 +960,10 @@ abstract class ApiTestCase extends TestCase
             'profile' => [
                 [
                     'type' => 'paragraph',
-                    'text' => 'Person '.$number.' profile text',
+                    'text' => $id.' profile text',
                 ],
             ],
-            'competingInterests' => 'Person '.$number.' competing interests',
+            'competingInterests' => $id.' competing interests',
             'image' => [
                 'alt' => '',
                 'sizes' => [

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -1091,73 +1091,73 @@ abstract class ApiTestCase extends TestCase
                 ],
             ],
              */
-            "selectedCurator" => [
-                "id" => "pjha",
-                "type" => "senior-editor",
-                "name" => [
-                    "preferred" => "Prabhat Jha",
-                    "index" => "Jha, Prabhat"
+            'selectedCurator' => [
+                'id' => 'pjha',
+                'type' => 'senior-editor',
+                'name' => [
+                    'preferred' => 'Prabhat Jha',
+                    'index' => 'Jha, Prabhat',
                 ],
-                "image" => [
-                    "alt" => "",
-                    "sizes" => [
-                        "16:9" => [
-                            "250" => "https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=250&height=141",
-                            "500" => "https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=500&height=281"
+                'image' => [
+                    'alt' => '',
+                    'sizes' => [
+                        '16:9' => [
+                            '250' => 'https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=250&height=141',
+                            '500' => 'https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=500&height=281',
                         ],
-                        "1:1" => [
-                            "70" => "https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=70&height=70",
-                            "140" => "https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=140&height=140"
-                        ]
-                    ]
-                ],
-                "etAl" => true
-            ],
-            "curators" => [
-                [
-                    "id" => "bcooper",
-                    "type" => "reviewing-editor",
-                    "name" => [
-                        "preferred" => "Ben Cooper",
-                        "index" => "Cooper, Ben"
-                    ]
-                ],
-                [
-                    "id" => "pjha",
-                    "type" => "senior-editor",
-                    "name" => [
-                        "preferred" => "Prabhat Jha",
-                        "index" => "Jha, Prabhat"
+                        '1:1' => [
+                            '70' => 'https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=70&height=70',
+                            '140' => 'https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=140&height=140',
+                        ],
                     ],
-                    "image" => [
-                    "alt" => "",
-                        "sizes" => [
-                            "16:9" => [
-                                "250" => "https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=250&height=141",
-                                "500" => "https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=500&height=281"
-                            ],
-                            "1:1" => [
-                                "70" => "https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=70&height=70",
-                                "140" => "https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=140&height=140"
-                            ]
-                        ]
-                    ]
-                ]
+                ],
+                'etAl' => true,
             ],
-            "content" => [
+            'curators' => [
                 [
-                    "type" => "blog-article",
-                    "id" => "359325",
-                    "title" => "Media coverage => Slime can see",
-                    "impactStatement" => "In their research paper \u2013 Cyanobacteria use micro-optics to sense light direction \u2013 Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world\u2019s oldest and smallest camera eye, allowing them to \u2018see\u2019.",
-                    "published" => "2016-07-08T08:33:25+00:00",
-                    "subjects" => [
+                    'id' => 'bcooper',
+                    'type' => 'reviewing-editor',
+                    'name' => [
+                        'preferred' => 'Ben Cooper',
+                        'index' => 'Cooper, Ben',
+                    ],
+                ],
+                [
+                    'id' => 'pjha',
+                    'type' => 'senior-editor',
+                    'name' => [
+                        'preferred' => 'Prabhat Jha',
+                        'index' => 'Jha, Prabhat',
+                    ],
+                    'image' => [
+                    'alt' => '',
+                        'sizes' => [
+                            '16:9' => [
+                                '250' => 'https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=250&height=141',
+                                '500' => 'https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=500&height=281',
+                            ],
+                            '1:1' => [
+                                '70' => 'https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=70&height=70',
+                                '140' => 'https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=140&height=140',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'content' => [
+                [
+                    'type' => 'blog-article',
+                    'id' => '359325',
+                    'title' => 'Media coverage => Slime can see',
+                    'impactStatement' => "In their research paper \u2013 Cyanobacteria use micro-optics to sense light direction \u2013 Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world\u2019s oldest and smallest camera eye, allowing them to \u2018see\u2019.",
+                    'published' => '2016-07-08T08:33:25+00:00',
+                    'subjects' => [
                         [
-                            "id" => "biophysics-structural-biology",
-                            "name" => "Biophysics and Structural Biology",
-                        ]
-                    ]
-                ]
+                            'id' => 'biophysics-structural-biology',
+                            'name' => 'Biophysics and Structural Biology',
+                        ],
+                    ],
+                ],
             ],
             'subjects' => [$this->createSubjectJson(1, true)],
         ];

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -496,6 +496,38 @@ abstract class ApiTestCase extends TestCase
         );
     }
 
+    final protected function mockCollectionListCall(
+        int $page,
+        int $perPage,
+        int $total,
+        $descendingOrder = true,
+        array $subjects = []
+    ) {
+        $collections = array_map(function (int $id) {
+            return $this->createCollectionJson($id, true);
+        }, $this->generateIdList($page, $perPage, $total));
+
+        $subjectsQuery = implode('', array_map(function (string $subjectId) {
+            return '&subject[]='.$subjectId;
+        }, $subjects));
+
+        $this->storage->save(
+            new Request(
+                'GET',
+                'http://api.elifesciences.org/collections?page='.$page.'&per-page='.$perPage.'&order='.($descendingOrder ? 'desc' : 'asc').$subjectsQuery,
+                ['Accept' => new MediaType(CollectionsClient::TYPE_COLLECTION_LIST, 1)]
+            ),
+            new Response(
+                200,
+                ['Content-Type' => new MediaType(CollectionsClient::TYPE_COLLECTION_LIST, 1)],
+                json_encode([
+                    'total' => $total,
+                    'items' => $collections,
+                ])
+            )
+        );
+    }
+
     final protected function mockCollectionCall(string $id, bool $complete = true)
     {
         $this->storage->save(

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -1204,6 +1204,32 @@ abstract class ApiTestCase extends TestCase
                 ],
             ],
             'podcastEpisodes' => [
+                $podcastEpisode = [
+                    'number' => 29,
+                    'title' => 'April/May 2016',
+                    'published' => '2016-05-27T13:19:42+00:00',
+                    'image' => [
+                        'thumbnail' => [
+                            'alt' => '',
+                            'sizes' => [
+                                '16:9' => [
+                                    '250' => 'https://placehold.it/250x141',
+                                    '500' => 'https://placehold.it/500x281',
+                                ],
+                                '1:1' => [
+                                    '70' => 'https://placehold.it/70x70',
+                                    '140' => 'https://placehold.it/140x140',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'sources' => [
+                        [
+                            'mediaType' => 'audio/mpeg',
+                            'uri' => 'https://nakeddiscovery.com/scripts/mp3s/audio/eLife_Podcast_16.05.mp3',
+                        ],
+                    ],
+                ],
             ],
             'subjects' => [$this->createSubjectJson(1, true)],
         ];

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -6,6 +6,7 @@ use Csa\Bundle\GuzzleBundle\GuzzleHttp\Middleware\MockMiddleware;
 use eLife\ApiClient\ApiClient\AnnualReportsClient;
 use eLife\ApiClient\ApiClient\ArticlesClient;
 use eLife\ApiClient\ApiClient\BlogClient;
+use eLife\ApiClient\ApiClient\CollectionsClient;
 use eLife\ApiClient\ApiClient\EventsClient;
 use eLife\ApiClient\ApiClient\InterviewsClient;
 use eLife\ApiClient\ApiClient\LabsClient;
@@ -465,6 +466,22 @@ abstract class ApiTestCase extends TestCase
                 200,
                 ['Content-Type' => new MediaType(PodcastClient::TYPE_PODCAST_EPISODE, 1)],
                 json_encode($this->createPodcastEpisodeJson($number, false, $complete))
+            )
+        );
+    }
+
+    final protected function mockCollectionCall(string $id, bool $complete = true)
+    {
+        $this->storage->save(
+            new Request(
+                'GET',
+                'http://api.elifesciences.org/collections/'.$id,
+                ['Accept' => new MediaType(CollectionsClient::TYPE_COLLECTION, 1)]
+            ),
+            new Response(
+                200,
+                ['Content-Type' => new MediaType(CollectionsClient::TYPE_COLLECTION, 1)],
+                json_encode($this->createCollectionJson($id, false, $complete))
             )
         );
     }
@@ -1032,6 +1049,129 @@ abstract class ApiTestCase extends TestCase
         }
 
         return $podcastEpisode;
+    }
+
+    private function createCollectionJson(string $id, bool $isSnippet = false, bool $complete = false) : array
+    {
+        $collection = [
+            'id' => $id,
+            'title' => ucfirst($id),
+            'impactStatement' => ucfirst($id).' impact statement',
+            'updated' => '2000-01-01T00:00:00+00:00',
+            'image' => [
+                'banner' => [
+                    'alt' => '',
+                    'sizes' => [
+                        '2:1' => [
+                            '900' => 'https://placehold.it/900x450',
+                            '1800' => 'https://placehold.it/1800x900',
+                        ],
+                    ],
+                ],
+                'thumbnail' => [
+                    'alt' => '',
+                    'sizes' => [
+                        '16:9' => [
+                            '250' => 'https://placehold.it/250x141',
+                            '500' => 'https://placehold.it/500x281',
+                        ],
+                        '1:1' => [
+                            '70' => 'https://placehold.it/70x70',
+                            '140' => 'https://placehold.it/140x140',
+                        ],
+                    ],
+                ],
+            ],
+            /*
+            'sources' => [
+                [
+                    'mediaType' => 'audio/mpeg',
+                    'uri' => 'https://www.example.com/episode.mp3',
+                ],
+            ],
+             */
+            "selectedCurator" => [
+                "id" => "pjha",
+                "type" => "senior-editor",
+                "name" => [
+                    "preferred" => "Prabhat Jha",
+                    "index" => "Jha, Prabhat"
+                ],
+                "image" => [
+                    "alt" => "",
+                    "sizes" => [
+                        "16:9" => [
+                            "250" => "https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=250&height=141",
+                            "500" => "https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=500&height=281"
+                        ],
+                        "1:1" => [
+                            "70" => "https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=70&height=70",
+                            "140" => "https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=140&height=140"
+                        ]
+                    ]
+                ],
+                "etAl" => true
+            ],
+            "curators" => [
+                [
+                    "id" => "bcooper",
+                    "type" => "reviewing-editor",
+                    "name" => [
+                        "preferred" => "Ben Cooper",
+                        "index" => "Cooper, Ben"
+                    ]
+                ],
+                [
+                    "id" => "pjha",
+                    "type" => "senior-editor",
+                    "name" => [
+                        "preferred" => "Prabhat Jha",
+                        "index" => "Jha, Prabhat"
+                    ],
+                    "image" => [
+                    "alt" => "",
+                        "sizes" => [
+                            "16:9" => [
+                                "250" => "https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=250&height=141",
+                                "500" => "https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=500&height=281"
+                            ],
+                            "1:1" => [
+                                "70" => "https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=70&height=70",
+                                "140" => "https://demo--api-dummy.elifesciences.org/images/people/pjha/jpg?width=140&height=140"
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            "content" => [
+                [
+                    "type" => "blog-article",
+                    "id" => "359325",
+                    "title" => "Media coverage => Slime can see",
+                    "impactStatement" => "In their research paper \u2013 Cyanobacteria use micro-optics to sense light direction \u2013 Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world\u2019s oldest and smallest camera eye, allowing them to \u2018see\u2019.",
+                    "published" => "2016-07-08T08:33:25+00:00",
+                    "subjects" => [
+                        [
+                            "id" => "biophysics-structural-biology",
+                            "name" => "Biophysics and Structural Biology",
+                        ]
+                    ]
+                ]
+            ],
+            'subjects' => [$this->createSubjectJson(1, true)],
+        ];
+
+        if (!$complete) {
+            unset($collection['impactStatement']);
+            unset($collection['subjects']);
+        }
+
+        if ($isSnippet) {
+            unset($collection['image']['banner']);
+            unset($collection['content']);
+        }
+
+        return $collection;
     }
 
     final private function createSubjectJson(int $number, bool $isSnippet = false) : array

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -38,6 +38,372 @@ final class Builder
 {
     private $model;
     private $testData;
+    private static $defaults;
+    private static $sampleRecipes;
+
+    private function defaultTestData()
+    {
+        if (self::$defaults === null) {
+            self::$defaults = [
+                BlogArticle::class => function () {
+                    return [
+                        'id' => '359325',
+                        'title' => 'Media coverage: Slime can see',
+                        'published' => new DateTimeImmutable(),
+                        'impactStatement' => null,
+                        'content' => new PromiseSequence(promise_for([
+                            new Paragraph(''),
+                        ])),
+                        'subjects' => new ArraySequence([]),
+                    ];
+                },
+                Collection::class => function () {
+                    return [
+                        'id' => 'tropical-disease',
+                        'title' => 'Tropical disease',
+                        'subTitle' => promise_for(null),
+                        'impactStatement' => null,
+                        'publishedDate' => new DateTimeImmutable(),
+                        'banner' => promise_for(self::for(Image::class)->sample('banner')),
+                        'thumbnail' => self::for(Image::class)->sample('thumbnail'),
+                        'subjects' => new ArraySequence([]),
+                        'selectedCurator' => self::dummy(Person::class),
+                        'selectedCuratorEtAl' => false,
+                        'curators' => new ArraySequence([
+                            self::dummy(Person::class),
+                        ]),
+                        'content' => new ArraySequence([
+                        ]),
+                        'relatedContent' => $this->emptyPromiseSequence(),
+                        'podcastEpisodes' => $this->emptyPromiseSequence(),
+                    ];
+                },
+                Image::class => function () {
+                    return [
+                        'altText' => '',
+                        'sizes' => [],
+                    ];
+                },
+                Interview::class => function () {
+                    return [
+                        'id' => '1',
+                        'interviewee' => new Interviewee(
+                            new PersonDetails('Ramanath Hegde', 'Hegde, Ramanath'),
+                            new ArraySequence([])
+                        ),
+                        'title' => 'Controlling traffic',
+                        'published' => new DateTimeImmutable(),
+                        'impactStatement' => null,
+                        'content' => $this->rejectSequence(),
+                    ];
+                },
+                Subject::class => function () {
+                    return [
+                        'id' => 'subject1',
+                        'name' => 'Subject 1',
+                        'impactStatement' => promise_for('Impact statement'),
+                        'banner' => promise_for(self::for(Image::class)->sample('banner')),
+                        'thumbnail' => promise_for(self::for(Image::class)->sample('thumbnail')),
+                    ];
+                },
+                Person::class => function () {
+                    return [
+                        'id' => 'jqpublic',
+                        'details' => new PersonDetails('preferred name', 'index name'),
+                        'type' => 'senior-editor',
+                        'image' => null,
+                        'research' => promise_for(null),
+                        'profile' => new ArraySequence(),
+                        'competingInterests' => promise_for(null),
+                    ];
+                },
+                PodcastEpisode::class => function () {
+                    return [
+                        'number' => 4,
+                        'title' => 'September 2013',
+                        'impactStatement' => null,
+                        'published' => new DateTimeImmutable(),
+                        'banner' => rejection_for('No banner'),
+                        'thumbnail' => new Image('', [900 => 'https://placehold.it/900x450']),
+                        'sources' => [
+                            new PodcastEpisodeSource(
+                                'audio/mpeg',
+                                'http://example.com/podcast.mp3'
+                            ),
+                        ],
+                        'subjects' => new ArraySequence([]),
+                        'chapters' => new PromiseSequence(rejection_for('no chapters')),
+                    ];
+                },
+                ArticlePoA::class => $articlePoA = function () {
+                    return [
+                        'id' => '14107',
+                        'type' => 'research-article',
+                        'version' => 1,
+                        'doi' => '10.7554/eLife.14107',
+                        'authorLine' => 'Yongjian Huang et al',
+                        'title' => 'Molecular basis for multimerization in the activation of the epidermal growth factor',
+                        'titlePrefix' => null,
+                        'published' => new DateTimeImmutable('2016-03-28T00:00:00+00:00'),
+                        'statusDate' => new DateTimeImmutable('2016-03-28T00:00:00+00:00'),
+                        'volume' => 5,
+                        'elocationId' => 'e14107',
+                        'pdf' => null,
+                        'subjects' => new ArraySequence(),
+                        'researchOrganisms' => [],
+                        'abstract' => promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article 14107 abstract text')]))),
+                        'issue' => promise_for(1),
+                        'copyright' => promise_for(new Copyright('CC-BY-4.0', 'Statement', 'Author et al')),
+                        'authors' => new ArraySequence([new PersonAuthor(new PersonDetails('Author', 'Author'))]),
+                    ];
+                },
+                ArticleVoR::class => function () use ($articlePoA) {
+                    return array_merge(
+                        $articlePoA(),
+                        [
+                            'id' => '09560',
+                            'version' => 1,
+                            'type' => 'research-article',
+                            'doi' => '10.7554/eLife.09560',
+                            'authorLine' => 'Lee R Berger et al',
+                            'title' => '<i>Homo naledi</i>, a new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa',
+                            'titlePrefix' => null,
+                            'published' => new DateTimeImmutable('2015-09-10T00:00:00Z'),
+                            'statusDate' => new DateTimeImmutable('2015-09-10T00:00:00Z'),
+                            'volume' => 4,
+                            'elocationId' => 'e09560',
+                            'impactStatement' => 'A new hominin species has been unearthed in the Dinaledi Chamber of the Rising Star cave system in the largest assemblage of a single species of hominins yet discovered in Africa.',
+                            'banner' => promise_for(self::for(Image::class)->sample('banner')),
+                            'thumbnail' => self::for(Image::class)->sample('thumbnail'),
+                            'keywords' => new ArraySequence(['Article 09560 keyword']),
+                            'digest' => promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article 09560 digest')]), '10.7554/eLife.09560digest')),
+                            'content' => new ArraySequence([new Paragraph('content')]),
+                            'references' => $references = new ArraySequence([
+                                new BookReference(new ReferenceDate(2000),
+                                [new PersonAuthor(new PersonDetails('preferred name', 'index name'))], false, 'book title',
+                                new Place(null, null, ['publisher'])),
+                            ]),
+                            'decisionLetter' => promise_for(new ArticleSection(new ArraySequence([new Paragraph('Decision letter')]))),
+                            'decisionLetterDescription' => new ArraySequence([new Paragraph('Decision letter description')]),
+                            'authorResponse' => promise_for(new ArticleSection(new ArraySequence([new Paragraph('Author response')]))),
+                        ]
+                    );
+                },
+            ];
+        }
+
+        return self::$defaults;
+    }
+
+    private function sampleRecipes()
+    {
+        if (self::$sampleRecipes === null) {
+            self::$sampleRecipes = [
+                Image::class => [
+                    'banner' => function () {
+                        return new Image(
+                            '',
+                            [new ImageSize('2:1', [900 => 'https://placehold.it/900x450', 1800 => 'https://placehold.it/1800x900'])]
+                        );
+                    },
+                    'thumbnail' => function () {
+                        return new Image('', [
+                            new ImageSize('16:9', [
+                                250 => 'https://placehold.it/250x141',
+                                500 => 'https://placehold.it/500x281',
+                            ]),
+                            new ImageSize('1:1', [
+                                '70' => 'https://placehold.it/70x70',
+                                '140' => 'https://placehold.it/140x140',
+                            ]),
+                        ]);
+                    },
+                ],
+                ArticlePoA::class => [
+                    'growth-factor' => function ($builder) {
+                        return $builder
+                            ->withId('14107')
+                            ->withVersion(1)
+                            ->withDoi('10.7554/eLife.14107')
+                            ->withAuthorLine('Yongjian Huang et al')
+                            ->withTitle('Molecular basis for multimerization in the activation of the epidermal growth factor')
+                            ->withPublished(new DateTimeImmutable('2016-03-28T00:00:00+00:00'))
+                            ->withStatusDate(new DateTimeImmutable('2016-03-28T00:00:00+00:00'))
+                            ->withVolume(5)
+                            ->withElocationId('e14107')
+                            ->withSubjects(new ArraySequence([]));
+                    },
+                    '1' => function ($builder) {
+                        return $builder
+                            ->withId('1')
+                            ->withVersion(1)
+                            ->withDoi('10.7554/eLife.1')
+                            ->withAuthorLine('Author et al')
+                            ->withTitle('Article 1 title')
+                            ->withTitlePrefix('Article 1 title prefix')
+                            ->withPublished(new DateTimeImmutable('2000-01-01T00:00:00+00:00'))
+                            ->withStatusDate(new DateTimeImmutable('1999-12-31T00:00:00+00:00'))
+                            ->withVolume(1)
+                            ->withElocationId('e1')
+                            ->withPdf('http://www.example.com/')
+                            ->withSubjects(new ArraySequence([
+                                self::for(Subject::class)->sample('1'),
+                            ]))
+                            ->withResearchOrganisms([
+                                'Article 1 research organism',
+                            ])
+                            ->withPromiseOfAbstract(new ArticleSection(new ArraySequence([new Paragraph('Article 1 abstract text')])));
+                    },
+                ],
+                ArticleVoR::class => [
+                    'homo-naledi' => function ($builder) {
+                        return $builder
+                            ->withId('09560')
+                            ->withVersion(1)
+                            ->withDoi('10.7554/eLife.09560')
+                            ->withAuthorLine('Lee R Berger et al')
+                            ->withTitle('<i>Homo naledi</i>, a new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa')
+                            ->withPublished(new DateTimeImmutable('2015-09-10T00:00:00Z'))
+                            ->withStatusDate(new DateTimeImmutable('2015-09-10T00:00:00Z'))
+                            ->withVolume(4)
+                            ->withElocationId('e09560')
+                            ->withPdf('https://elifesciences.org/content/4/e09560.pdf')
+                            ->withSubjects(new ArraySequence([
+                                self::for(Subject::class)->sample('genomics-evolutionary-biology'),
+                            ]))
+                            ->withPromiseOfAbstract(new ArticleSection(new ArraySequence([new Paragraph('Article 09560 abstract text')]), '10.7554/eLife.09560abstract'))
+                            ->withImpactStatement('A new hominin species has been unearthed in the Dinaledi Chamber of the Rising Star cave system in the largest assemblage of a single species of hominins yet discovered in Africa.')
+                            ->withThumbnail(self::for(Image::class)->sample('thumbnail'))
+                            ->withContent(new ArraySequence([new Section('Article 09560 section title', 'article09560section', [new Paragraph('Article 09560 text')])]))
+                            ->withDecisionLetter(promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article 09560 decision letter text')]), '10.7554/eLife.09560decisionLetter')))
+                            ->withDecisionLetterDescription(new ArraySequence([new Paragraph('Article 09560 decision letter description')]))
+                            ->withAuthorResponse(promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article 09560 author response text')]), '10.7554/eLife.09560authorResponse')));
+                    },
+                ],
+                BlogArticle::class => [
+                    'slime' => function ($builder) {
+                        return $builder
+                            ->withId(359325)
+                            ->withTitle('Media coverage: Slime can see')
+                            ->withImpactStatement('In their research paper – Cyanobacteria use micro-optics to sense light direction – Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world’s oldest and smallest camera eye, allowing them to ‘see’.')
+                            ->withPublished(new DateTimeImmutable('2016-07-08T08:33:25+00:00'))
+                            ->withSubjects(new ArraySequence([
+                                self::for(Subject::class)->sample('biophysics-structural-biology'),
+                            ]))
+                            ->withContent(new ArraySequence([
+                                new Paragraph('Blog article 359325 text'),
+                            ]));
+                    },
+                ],
+                Interview::class => [
+                    'controlling-traffic' => function ($builder) {
+                        return $builder
+                            ->withId('1')
+                            ->withTitle('Controlling traffic')
+                            ->withInterviewee(new Interviewee(
+                                new PersonDetails('Ramanath Hegde', 'Hegde, Ramanath'),
+                                new ArraySequence([
+                                    new IntervieweeCvLine('date', 'text'),
+                                ])
+                            ))
+                            ->withImpactStatement('Ramanath Hegde is a Postdoctoral Fellow at the Institute of Protein Biochemistry in Naples, Italy, where he investigates ways of preventing cells from destroying mutant proteins.')
+                            ->withPublished(new DateTimeImmutable('2016-01-29T16:22:28+00:00'))
+                            ->withContent(new ArraySequence([new Paragraph('Interview 1 text')]));
+                    },
+                ],
+                Person::class => [
+                    'bcooper' => function ($builder, $context) {
+                        $person = $builder
+                            ->withId('bcooper')
+                            ->withType('reviewing-editor')
+                            ->withDetails(new PersonDetails(
+                                'Ben Cooper',
+                                'Cooper, Ben'
+                            ));
+
+                        if (!$context['snippet']) {
+                            $person
+                                ->withPromiseOfResearch('')
+                                ->withProfile(new ArraySequence([]))
+                                ->withPromiseOfCompetingInterests('');
+                        }
+
+                        return $person;
+                    },
+                    'pjha' => function ($builder, $context) {
+                        $person = $builder
+                            ->withId('pjha')
+                            ->withType('senior-editor')
+                            ->withDetails(new PersonDetails(
+                                'Prabhat Jha',
+                                'Jha, Prabhat'
+                            ));
+                        if (!$context['snippet']) {
+                            $person
+                                ->withPromiseOfResearch('')
+                                ->withProfile(new ArraySequence([]))
+                                ->withPromiseOfCompetingInterests('');
+                        }
+
+                        return $person;
+                    },
+                ],
+                PodcastEpisode::class => [
+                    '29' => function ($builder) {
+                        return $builder
+                            ->withNumber(29)
+                            ->withTitle('April/May 2016')
+                            ->withPublished(new DateTimeImmutable('2016-05-27T13:19:42+00:00'))
+                            ->withPromiseOfBanner(self::for(Image::class)->sample('banner'))
+                            ->withThumbnail(self::for(Image::class)->sample('thumbnail'))
+                            ->withSources([
+                                new PodcastEpisodeSource(
+                                    'audio/mpeg',
+                                    'https://nakeddiscovery.com/scripts/mp3s/audio/eLife_Podcast_16.05.mp3'
+                                ),
+                            ])
+                            ->withChapters(new ArraySequence([new PodcastEpisodeChapter(1, 'Chapter title', 0, 'Chapter impact statement', new ArraySequence([
+                                self::for(ArticlePoA::class)->sample('1'),
+                            ]))]));
+                    },
+                ],
+                Subject::class => [
+                    '1' => function ($builder) {
+                        return $builder
+                            ->withId('1')
+                            ->withName('Subject 1 name')
+                            ->withPromiseOfImpactStatement('Subject 1 impact statement');
+                    },
+                    'genomics-evolutionary-biology' => function ($builder) {
+                        return $builder
+                            ->withId('genomics-evolutionary-biology')
+                            ->withName('Genomics and Evolutionary Biology')
+                            ->withPromiseOfImpactStatement('Subject genomics-evolutionary-biology impact statement');
+                    },
+                    'biophysics-structural-biology' => function ($builder) {
+                        return $builder
+                            ->withId('biophysics-structural-biology')
+                            ->withName('Biophysics and Structural Biology')
+                            ->withPromiseOfImpactStatement('Subject biophysics-structural-biology impact statement');
+                    },
+                    'epidemiology-global-health' => function ($builder) {
+                        return $builder
+                            ->withId('epidemiology-global-health')
+                            ->withName('Epidemiology and Global Health')
+                            ->withPromiseOfImpactStatement('Subject epidemiology-global-health impact statement');
+                    },
+                    'microbiology-infectious-disease' => function ($builder) {
+                        return $builder
+                            ->withId('microbiology-infectious-disease')
+                            ->withName('Microbiology and Infectious Disease')
+                            ->withPromiseOfImpactStatement('Subject microbiology-infectious-disease impact statement');
+                    },
+                ],
+            ];
+        }
+
+        return self::$sampleRecipes;
+    }
 
     public static function for($model) : self
     {
@@ -55,7 +421,12 @@ final class Builder
     public function create($model) : self
     {
         $this->model = $model;
-        $this->testData = call_user_func($this->defaultTestDataFor($model));
+        $defaults = $this->defaultTestData($model);
+        if (!array_key_exists($model, $defaults)) {
+            throw new InvalidArgumentException("No defaults available for $model");
+        }
+
+        $this->testData = call_user_func($defaults[$model]);
 
         return $this;
     }
@@ -111,7 +482,7 @@ final class Builder
      */
     public function sample($sampleName, $context = [])
     {
-        $samples = $this->samples();
+        $samples = $this->sampleRecipes();
 
         if (!array_key_exists($sampleName, $samples[$this->model])) {
             throw new InvalidArgumentException("Sample $sampleName not found for {$this->model}");
@@ -130,370 +501,6 @@ final class Builder
         } else {
             return $sample;
         }
-    }
-
-    private function defaultTestDataFor($model)
-    {
-        // TODO: turn into private field
-        $defaults = [
-            BlogArticle::class => function () {
-                return [
-                    'id' => '359325',
-                    'title' => 'Media coverage: Slime can see',
-                    'published' => new DateTimeImmutable(),
-                    'impactStatement' => null,
-                    'content' => new PromiseSequence(promise_for([
-                        new Paragraph(''),
-                    ])),
-                    'subjects' => new ArraySequence([]),
-                ];
-            },
-            Collection::class => function () {
-                return [
-                    'id' => 'tropical-disease',
-                    'title' => 'Tropical disease',
-                    'subTitle' => promise_for(null),
-                    'impactStatement' => null,
-                    'publishedDate' => new DateTimeImmutable(),
-                    'banner' => promise_for(self::for(Image::class)->sample('banner')),
-                    'thumbnail' => self::for(Image::class)->sample('thumbnail'),
-                    'subjects' => new ArraySequence([]),
-                    'selectedCurator' => self::dummy(Person::class),
-                    'selectedCuratorEtAl' => false,
-                    'curators' => new ArraySequence([
-                        self::dummy(Person::class),
-                    ]),
-                    'content' => new ArraySequence([
-                    ]),
-                    'relatedContent' => $this->emptyPromiseSequence(),
-                    'podcastEpisodes' => $this->emptyPromiseSequence(),
-                ];
-            },
-            Image::class => function () {
-                return [
-                    'altText' => '',
-                    'sizes' => [],
-                ];
-            },
-            Interview::class => function () {
-                return [
-                    'id' => '1',
-                    'interviewee' => new Interviewee(
-                        new PersonDetails('Ramanath Hegde', 'Hegde, Ramanath'),
-                        new ArraySequence([])
-                    ),
-                    'title' => 'Controlling traffic',
-                    'published' => new DateTimeImmutable(),
-                    'impactStatement' => null,
-                    'content' => $this->rejectSequence(),
-                ];
-            },
-            Subject::class => function () {
-                return [
-                    'id' => 'subject1',
-                    'name' => 'Subject 1',
-                    'impactStatement' => promise_for('Impact statement'),
-                    'banner' => promise_for(self::for(Image::class)->sample('banner')),
-                    'thumbnail' => promise_for(self::for(Image::class)->sample('thumbnail')),
-                ];
-            },
-            Person::class => function () {
-                return [
-                    'id' => 'jqpublic',
-                    'details' => new PersonDetails('preferred name', 'index name'),
-                    'type' => 'senior-editor',
-                    'image' => null,
-                    'research' => promise_for(null),
-                    'profile' => new ArraySequence(),
-                    'competingInterests' => promise_for(null),
-                ];
-            },
-            PodcastEpisode::class => function () {
-                return [
-                    'number' => 4,
-                    'title' => 'September 2013',
-                    'impactStatement' => null,
-                    'published' => new DateTimeImmutable(),
-                    'banner' => rejection_for('No banner'),
-                    'thumbnail' => new Image('', [900 => 'https://placehold.it/900x450']),
-                    'sources' => [
-                        new PodcastEpisodeSource(
-                            'audio/mpeg',
-                            'http://example.com/podcast.mp3'
-                        ),
-                    ],
-                    'subjects' => new ArraySequence([]),
-                    'chapters' => new PromiseSequence(rejection_for('no chapters')),
-                ];
-            },
-            ArticlePoA::class => $articlePoA = function () {
-                return [
-                    'id' => '14107',
-                    'type' => 'research-article',
-                    'version' => 1,
-                    'doi' => '10.7554/eLife.14107',
-                    'authorLine' => 'Yongjian Huang et al',
-                    'title' => 'Molecular basis for multimerization in the activation of the epidermal growth factor',
-                    'titlePrefix' => null,
-                    'published' => new DateTimeImmutable('2016-03-28T00:00:00+00:00'),
-                    'statusDate' => new DateTimeImmutable('2016-03-28T00:00:00+00:00'),
-                    'volume' => 5,
-                    'elocationId' => 'e14107',
-                    'pdf' => null,
-                    'subjects' => new ArraySequence(),
-                    'researchOrganisms' => [],
-                    'abstract' => promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article 14107 abstract text')]))),
-                    'issue' => promise_for(1),
-                    'copyright' => promise_for(new Copyright('CC-BY-4.0', 'Statement', 'Author et al')),
-                    'authors' => new ArraySequence([new PersonAuthor(new PersonDetails('Author', 'Author'))]),
-                ];
-            },
-            ArticleVoR::class => function () use ($articlePoA) {
-                return array_merge(
-                    $articlePoA(),
-                    [
-                        'id' => '09560',
-                        'version' => 1,
-                        'type' => 'research-article',
-                        'doi' => '10.7554/eLife.09560',
-                        'authorLine' => 'Lee R Berger et al',
-                        'title' => '<i>Homo naledi</i>, a new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa',
-                        'titlePrefix' => null,
-                        'published' => new DateTimeImmutable('2015-09-10T00:00:00Z'),
-                        'statusDate' => new DateTimeImmutable('2015-09-10T00:00:00Z'),
-                        'volume' => 4,
-                        'elocationId' => 'e09560',
-                        'impactStatement' => 'A new hominin species has been unearthed in the Dinaledi Chamber of the Rising Star cave system in the largest assemblage of a single species of hominins yet discovered in Africa.',
-                        'banner' => promise_for(self::for(Image::class)->sample('banner')),
-                        'thumbnail' => self::for(Image::class)->sample('thumbnail'),
-                        'keywords' => new ArraySequence(['Article 09560 keyword']),
-                        'digest' => promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article 09560 digest')]), '10.7554/eLife.09560digest')),
-                        'content' => new ArraySequence([new Paragraph('content')]),
-                        'references' => $references = new ArraySequence([
-                            new BookReference(new ReferenceDate(2000),
-                            [new PersonAuthor(new PersonDetails('preferred name', 'index name'))], false, 'book title',
-                            new Place(null, null, ['publisher'])),
-                        ]),
-                        'decisionLetter' => promise_for(new ArticleSection(new ArraySequence([new Paragraph('Decision letter')]))),
-                        'decisionLetterDescription' => new ArraySequence([new Paragraph('Decision letter description')]),
-                        'authorResponse' => promise_for(new ArticleSection(new ArraySequence([new Paragraph('Author response')]))),
-                    ]
-                );
-            },
-        ];
-
-        if (!array_key_exists($model, $defaults)) {
-            throw new InvalidArgumentException("No defaults available for $model");
-        }
-
-        return $defaults[$model];
-    }
-
-    private function samples()
-    {
-        // TODO: turn into private field
-        return [
-            Image::class => [
-                'banner' => function () {
-                    return new Image(
-                        '',
-                        [new ImageSize('2:1', [900 => 'https://placehold.it/900x450', 1800 => 'https://placehold.it/1800x900'])]
-                    );
-                },
-                'thumbnail' => function () {
-                    return new Image('', [
-                        new ImageSize('16:9', [
-                            250 => 'https://placehold.it/250x141',
-                            500 => 'https://placehold.it/500x281',
-                        ]),
-                        new ImageSize('1:1', [
-                            '70' => 'https://placehold.it/70x70',
-                            '140' => 'https://placehold.it/140x140',
-                        ]),
-                    ]);
-                },
-            ],
-            ArticlePoA::class => [
-                'growth-factor' => function ($builder) {
-                    return $builder
-                        ->withId('14107')
-                        ->withVersion(1)
-                        ->withDoi('10.7554/eLife.14107')
-                        ->withAuthorLine('Yongjian Huang et al')
-                        ->withTitle('Molecular basis for multimerization in the activation of the epidermal growth factor')
-                        ->withPublished(new DateTimeImmutable('2016-03-28T00:00:00+00:00'))
-                        ->withStatusDate(new DateTimeImmutable('2016-03-28T00:00:00+00:00'))
-                        ->withVolume(5)
-                        ->withElocationId('e14107')
-                        ->withSubjects(new ArraySequence([]));
-                },
-                '1' => function ($builder) {
-                    return $builder
-                        ->withId('1')
-                        ->withVersion(1)
-                        ->withDoi('10.7554/eLife.1')
-                        ->withAuthorLine('Author et al')
-                        ->withTitle('Article 1 title')
-                        ->withTitlePrefix('Article 1 title prefix')
-                        ->withPublished(new DateTimeImmutable('2000-01-01T00:00:00+00:00'))
-                        ->withStatusDate(new DateTimeImmutable('1999-12-31T00:00:00+00:00'))
-                        ->withVolume(1)
-                        ->withElocationId('e1')
-                        ->withPdf('http://www.example.com/')
-                        ->withSubjects(new ArraySequence([
-                            self::for(Subject::class)->sample('1'),
-                        ]))
-                        ->withResearchOrganisms([
-                            'Article 1 research organism',
-                        ])
-                        ->withPromiseOfAbstract(new ArticleSection(new ArraySequence([new Paragraph('Article 1 abstract text')])));
-                },
-            ],
-            ArticleVoR::class => [
-                'homo-naledi' => function ($builder) {
-                    return $builder
-                        ->withId('09560')
-                        ->withVersion(1)
-                        ->withDoi('10.7554/eLife.09560')
-                        ->withAuthorLine('Lee R Berger et al')
-                        ->withTitle('<i>Homo naledi</i>, a new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa')
-                        ->withPublished(new DateTimeImmutable('2015-09-10T00:00:00Z'))
-                        ->withStatusDate(new DateTimeImmutable('2015-09-10T00:00:00Z'))
-                        ->withVolume(4)
-                        ->withElocationId('e09560')
-                        ->withPdf('https://elifesciences.org/content/4/e09560.pdf')
-                        ->withSubjects(new ArraySequence([
-                            self::for(Subject::class)->sample('genomics-evolutionary-biology'),
-                        ]))
-                        ->withPromiseOfAbstract(new ArticleSection(new ArraySequence([new Paragraph('Article 09560 abstract text')]), '10.7554/eLife.09560abstract'))
-                        ->withImpactStatement('A new hominin species has been unearthed in the Dinaledi Chamber of the Rising Star cave system in the largest assemblage of a single species of hominins yet discovered in Africa.')
-                        ->withThumbnail(self::for(Image::class)->sample('thumbnail'))
-                        ->withContent(new ArraySequence([new Section('Article 09560 section title', 'article09560section', [new Paragraph('Article 09560 text')])]))
-                        ->withDecisionLetter(promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article 09560 decision letter text')]), '10.7554/eLife.09560decisionLetter')))
-                        ->withDecisionLetterDescription(new ArraySequence([new Paragraph('Article 09560 decision letter description')]))
-                        ->withAuthorResponse(promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article 09560 author response text')]), '10.7554/eLife.09560authorResponse')));
-                },
-            ],
-            BlogArticle::class => [
-                'slime' => function ($builder) {
-                    return $builder
-                        ->withId(359325)
-                        ->withTitle('Media coverage: Slime can see')
-                        ->withImpactStatement('In their research paper – Cyanobacteria use micro-optics to sense light direction – Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world’s oldest and smallest camera eye, allowing them to ‘see’.')
-                        ->withPublished(new DateTimeImmutable('2016-07-08T08:33:25+00:00'))
-                        ->withSubjects(new ArraySequence([
-                            self::for(Subject::class)->sample('biophysics-structural-biology'),
-                        ]))
-                        ->withContent(new ArraySequence([
-                            new Paragraph('Blog article 359325 text'),
-                        ]));
-                },
-            ],
-            Interview::class => [
-                'controlling-traffic' => function ($builder) {
-                    return $builder
-                        ->withId('1')
-                        ->withTitle('Controlling traffic')
-                        ->withInterviewee(new Interviewee(
-                            new PersonDetails('Ramanath Hegde', 'Hegde, Ramanath'),
-                            new ArraySequence([
-                                new IntervieweeCvLine('date', 'text'),
-                            ])
-                        ))
-                        ->withImpactStatement('Ramanath Hegde is a Postdoctoral Fellow at the Institute of Protein Biochemistry in Naples, Italy, where he investigates ways of preventing cells from destroying mutant proteins.')
-                        ->withPublished(new DateTimeImmutable('2016-01-29T16:22:28+00:00'))
-                        ->withContent(new ArraySequence([new Paragraph('Interview 1 text')]));
-                },
-            ],
-            Person::class => [
-                'bcooper' => function ($builder, $context) {
-                    $person = $builder
-                        ->withId('bcooper')
-                        ->withType('reviewing-editor')
-                        ->withDetails(new PersonDetails(
-                            'Ben Cooper',
-                            'Cooper, Ben'
-                        ));
-
-                    if (!$context['snippet']) {
-                        $person
-                            ->withPromiseOfResearch('')
-                            ->withProfile(new ArraySequence([]))
-                            ->withPromiseOfCompetingInterests('');
-                    }
-
-                    return $person;
-                },
-                'pjha' => function ($builder, $context) {
-                    $person = $builder
-                        ->withId('pjha')
-                        ->withType('senior-editor')
-                        ->withDetails(new PersonDetails(
-                            'Prabhat Jha',
-                            'Jha, Prabhat'
-                        ));
-                    if (!$context['snippet']) {
-                        $person
-                            ->withPromiseOfResearch('')
-                            ->withProfile(new ArraySequence([]))
-                            ->withPromiseOfCompetingInterests('');
-                    }
-
-                    return $person;
-                },
-            ],
-            PodcastEpisode::class => [
-                '29' => function ($builder) {
-                    return $builder
-                        ->withNumber(29)
-                        ->withTitle('April/May 2016')
-                        ->withPublished(new DateTimeImmutable('2016-05-27T13:19:42+00:00'))
-                        ->withPromiseOfBanner(self::for(Image::class)->sample('banner'))
-                        ->withThumbnail(self::for(Image::class)->sample('thumbnail'))
-                        ->withSources([
-                            new PodcastEpisodeSource(
-                                'audio/mpeg',
-                                'https://nakeddiscovery.com/scripts/mp3s/audio/eLife_Podcast_16.05.mp3'
-                            ),
-                        ])
-                        ->withChapters(new ArraySequence([new PodcastEpisodeChapter(1, 'Chapter title', 0, 'Chapter impact statement', new ArraySequence([
-                            self::for(ArticlePoA::class)->sample('1'),
-                        ]))]));
-                },
-            ],
-            Subject::class => [
-                '1' => function ($builder) {
-                    return $builder
-                        ->withId('1')
-                        ->withName('Subject 1 name')
-                        ->withPromiseOfImpactStatement('Subject 1 impact statement');
-                },
-                'genomics-evolutionary-biology' => function ($builder) {
-                    return $builder
-                        ->withId('genomics-evolutionary-biology')
-                        ->withName('Genomics and Evolutionary Biology')
-                        ->withPromiseOfImpactStatement('Subject genomics-evolutionary-biology impact statement');
-                },
-                'biophysics-structural-biology' => function ($builder) {
-                    return $builder
-                        ->withId('biophysics-structural-biology')
-                        ->withName('Biophysics and Structural Biology')
-                        ->withPromiseOfImpactStatement('Subject biophysics-structural-biology impact statement');
-                },
-                'epidemiology-global-health' => function ($builder) {
-                    return $builder
-                        ->withId('epidemiology-global-health')
-                        ->withName('Epidemiology and Global Health')
-                        ->withPromiseOfImpactStatement('Subject epidemiology-global-health impact statement');
-                },
-                'microbiology-infectious-disease' => function ($builder) {
-                    return $builder
-                        ->withId('microbiology-infectious-disease')
-                        ->withName('Microbiology and Infectious Disease')
-                        ->withPromiseOfImpactStatement('Subject microbiology-infectious-disease impact statement');
-                },
-            ],
-        ];
     }
 
     private function ensureExistingField($field)

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -7,8 +7,8 @@ use DateTimeImmutable;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\ArticlePoA;
-use eLife\ApiSdk\Model\ArticleVoR;
 use eLife\ApiSdk\Model\ArticleSection;
+use eLife\ApiSdk\Model\ArticleVoR;
 use eLife\ApiSdk\Model\Block\Paragraph;
 use eLife\ApiSdk\Model\Block\Section;
 use eLife\ApiSdk\Model\BlogArticle;
@@ -252,7 +252,7 @@ final class Builder
                     'abstract' => promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article 14107 abstract text')]))),
                     'issue' => promise_for(1),
                     'copyright' => promise_for(new Copyright('CC-BY-4.0', 'Statement', 'Author et al')),
-                    'authors' => new ArraySequence([new PersonAuthor(new PersonDetails('Author', 'Author'))])
+                    'authors' => new ArraySequence([new PersonAuthor(new PersonDetails('Author', 'Author'))]),
                 ];
             },
             ArticleVoR::class => function () use ($articlePoA) {
@@ -351,7 +351,7 @@ final class Builder
                             self::for(Subject::class)->sample('1'),
                         ]))
                         ->withResearchOrganisms([
-                            'Article 1 research organism'
+                            'Article 1 research organism',
                         ])
                         ->withPromiseOfAbstract(new ArticleSection(new ArraySequence([new Paragraph('Article 1 abstract text')])));
                 },
@@ -392,7 +392,7 @@ final class Builder
                             self::for(Subject::class)->sample('biophysics-structural-biology'),
                         ]))
                         ->withContent(new ArraySequence([
-                            new Paragraph("Blog article 359325 text")
+                            new Paragraph('Blog article 359325 text'),
                         ]));
                 },
             ],
@@ -404,7 +404,7 @@ final class Builder
                         ->withInterviewee(new Interviewee(
                             new PersonDetails('Ramanath Hegde', 'Hegde, Ramanath'),
                             new ArraySequence([
-                                new IntervieweeCvLine('date', 'text')
+                                new IntervieweeCvLine('date', 'text'),
                             ])
                         ))
                         ->withImpactStatement('Ramanath Hegde is a Postdoctoral Fellow at the Institute of Protein Biochemistry in Naples, Italy, where he investigates ways of preventing cells from destroying mutant proteins.')
@@ -427,7 +427,6 @@ final class Builder
                             ->withPromiseOfResearch('')
                             ->withProfile(new ArraySequence([]))
                             ->withPromiseOfCompetingInterests('');
-                        
                     }
 
                     return $person;
@@ -445,8 +444,8 @@ final class Builder
                             ->withPromiseOfResearch('')
                             ->withProfile(new ArraySequence([]))
                             ->withPromiseOfCompetingInterests('');
-                        
                     }
+
                     return $person;
                 },
             ],
@@ -465,7 +464,7 @@ final class Builder
                             ),
                         ])
                         ->withChapters(new ArraySequence([new PodcastEpisodeChapter(1, 'Chapter title', 0, 'Chapter impact statement', new ArraySequence([
-                            self::for(ArticlePoA::class)->sample('1')
+                            self::for(ArticlePoA::class)->sample('1'),
                         ]))]));
                 },
             ],
@@ -501,7 +500,7 @@ final class Builder
                         ->withId('microbiology-infectious-disease')
                         ->withName('Microbiology and Infectious Disease')
                         ->withPromiseOfImpactStatement('Subject microbiology-infectious-disease impact statement');
-                }
+                },
             ],
         ];
     }

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -39,17 +39,20 @@ final class Builder
     private $model;
     private $testData;
 
-    public static function for($model)
+    public static function for($model) : self
     {
         return (new self())->create($model);
     }
 
+    /**
+     * @return object  instance of $model
+     */
     public static function dummy($model)
     {
         return self::for($model)->__invoke();
     }
 
-    public function create($model)
+    public function create($model) : self
     {
         $this->model = $model;
         $this->testData = call_user_func($this->defaultTestDataFor($model));
@@ -59,8 +62,9 @@ final class Builder
 
     /**
      * @method with...($value)  e.g. withImpactStatement('a string')
+     * @method withPromiseOf...($value)  e.g. withPromiseOfBanner(new Image(...))
      */
-    public function __call($name, $args)
+    public function __call($name, $args) : self
     {
         if (preg_match('/^withPromiseOf(.*)$/', $name, $matches)) {
             $field = lcfirst($matches[1]);
@@ -79,6 +83,9 @@ final class Builder
         return $this;
     }
 
+    /**
+     * @return object  instance of $this->model
+     */
     public function __invoke()
     {
         $class = new \ReflectionClass($this->model);
@@ -99,6 +106,9 @@ final class Builder
         return $instance;
     }
 
+    /**
+     * @return object  instance of $this->model
+     */
     public function sample($sampleName, $context = [])
     {
         $samples = $this->samples();
@@ -193,21 +203,6 @@ final class Builder
                     'details' => new PersonDetails('preferred name', 'index name'),
                     'type' => 'senior-editor',
                     'image' => null,
-                    /*
-                     * new Image(
-                        '',
-                        [
-                            '16:9' => [
-                                '250' => 'https://placehold.it/250x141',
-                                '500' => 'https://placehold.it/500x281',
-                            ],
-                            '1:1' => [
-                                '70' => 'https://placehold.it/70x70',
-                                '140' => 'https://placehold.it/140x140',
-                            ],
-                        ]
-                    ),
-                     */
                     'research' => promise_for(null),
                     'profile' => new ArraySequence(),
                     'competingInterests' => promise_for(null),
@@ -245,9 +240,7 @@ final class Builder
                     'volume' => 5,
                     'elocationId' => 'e14107',
                     'pdf' => null,
-                    'subjects' => new ArraySequence([
-              //          self::for(Subject::class)->sample('genomics-evolutionary-biology')
-                    ]),
+                    'subjects' => new ArraySequence(),
                     'researchOrganisms' => [],
                     'abstract' => promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article 14107 abstract text')]))),
                     'issue' => promise_for(1),

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -97,6 +97,7 @@ final class Builder
                     'subjects' => new ArraySequence([]),
                     'selectedCurator' => self::dummy(Person::class),
                     'selectedCuratorEtAl' => false,
+                    'curators' => new PromiseSequence(rejection_for('no curators')),
                 ];
             },
             'eLife\ApiSdk\Model\Image' => function() {

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -6,6 +6,7 @@ use BadMethodCallException;
 use DateTimeImmutable;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
+use eLife\ApiSdk\Model\ArticlePoA;
 use eLife\ApiSdk\Model\ArticleVoR;
 use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Collection;
@@ -92,6 +93,9 @@ final class Builder
     {
         $samples = $this->samples();
 
+        if (!array_key_exists($sampleName, $samples[$this->model])) {
+            throw new InvalidArgumentException("Sample $sampleName not found for {$this->model}");
+        }
         $sample = call_user_func(
             $samples[$this->model][$sampleName],
             $this
@@ -192,6 +196,30 @@ final class Builder
                     'chapters' => new PromiseSequence(rejection_for('no chapters')),
                 ];
             },
+            ArticlePoA::class => function() {
+                return [
+                    'id' => '14107',
+                    'type' => 'research-article',
+                    'version' => 1,
+                    'doi' => '10.7554/eLife.14107',
+                    'authorLine' => 'Yongjian Huang et al',
+                    'title' => 'Molecular basis for multimerization in the activation of the epidermal growth factor',
+                    'titlePrefix' => null,
+                    'published' => new DateTimeImmutable('2016-03-28T00:00:00+00:00'),
+                    'statusDate' => new DateTimeImmutable('2016-03-28T00:00:00+00:00'),
+                    'volume' => 5,
+                    'elocationId' => 'e14107',
+                    'pdf' => null,
+                    'subjects' => new ArraySequence([
+              //          self::for(Subject::class)->sample('genomics-evolutionary-biology')
+                    ]),
+                    'researchOrganisms' => [],
+                    'abstract' => rejection_for('no abstract'),
+                    'issue' => rejection_for('no issue'),
+                    'copyright' => rejection_for('copyright'),
+                    'authors' => $this->rejectSequence(),
+                ];
+            },
             ArticleVoR::class => function() {
                 return [
                     'id' => '09560',
@@ -257,6 +285,22 @@ final class Builder
                             '140' => 'https://placehold.it/140x140',
                         ]),
                     ]);
+                },
+            ],
+            ArticlePoA::class => [
+                'growth-factor' => function($builder) {
+                    return $builder
+                        ->withId('14107')
+                        ->withVersion(1)
+                        ->withDoi('10.7554/eLife.14107')
+                        ->withAuthorLine('Yongjian Huang et al')
+                        ->withTitle('Molecular basis for multimerization in the activation of the epidermal growth factor')
+                        ->withPublished(new DateTimeImmutable('2016-03-28T00:00:00+00:00'))
+                        ->withStatusDate(new DateTimeImmutable('2016-03-28T00:00:00+00:00'))
+                        ->withVolume(5)
+                        ->withElocationId('e14107')
+                        // why doesn't this override 'subjects' in the defaults?
+                        ->withSubjects(new ArraySequence([]));
                 },
             ],
             ArticleVoR::class => [

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -12,6 +12,8 @@ use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\ImageSize;
 use eLife\ApiSdk\Model\Person;
 use eLife\ApiSdk\Model\PersonDetails;
+use eLife\ApiSdk\Model\PodcastEpisode;
+use eLife\ApiSdk\Model\PodcastEpisodeSource;
 use eLife\ApiSdk\Model\Subject;
 use InvalidArgumentException;
 use function GuzzleHttp\Promise\promise_for;
@@ -113,6 +115,7 @@ final class Builder
                     'curators' => new PromiseSequence(rejection_for('no curators')),
                     'content' => new PromiseSequence(rejection_for('no content')),
                     'relatedContent' => new PromiseSequence(rejection_for('no related content')),
+                    'podcastEpisodes' => new PromiseSequence(rejection_for('no podcast episodes')),
                 ];
             },
             Image::class => function() {
@@ -139,6 +142,24 @@ final class Builder
                     'research' => rejection_for('Research should not be unwrapped'),
                     'profile' => new PromiseSequence(rejection_for('Profile should not be unwrapped')),
                     'competingInterests' => rejection_for('Competing interests should not be unwrapped'),
+                ];
+            },
+            PodcastEpisode::class => function() {
+                return [
+                    'number' => 4,
+                    'title' => 'September 2013',
+                    'impactStatement' => null,
+                    'published' => new DateTimeImmutable(),
+                    'banner' => rejection_for('No banner'),
+                    'thumbnail' => new Image('', [900 => 'https://placehold.it/900x450']),
+                    'sources' => [
+                        new PodcastEpisodeSource(
+                            'audio/mpeg',
+                            'http://example.com/podcast.mp3'
+                        ),
+                    ],
+                    'subjects' => new ArraySequence([]),
+                    'chapters' => new PromiseSequence(rejection_for('no chapters')),
                 ];
             },
         ];

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -357,8 +357,8 @@ final class Builder
                 },
             ],
             ArticleVoR::class => [
-                'homo-naledi' => function () {
-                    return self::for(ArticleVoR::class)
+                'homo-naledi' => function ($builder) {
+                    return $builder
                         ->withId('09560')
                         ->withVersion(1)
                         ->withDoi('10.7554/eLife.09560')
@@ -475,28 +475,26 @@ final class Builder
                         ->withName('Subject 1 name')
                         ->withPromiseOfImpactStatement('Subject 1 impact statement');
                 },
-                'genomics-evolutionary-biology' => function () {
-                    // TODO: maybe pass in a ready Builder::for(SomeModel::class)?
-                    return self::for(Subject::class)
+                'genomics-evolutionary-biology' => function ($builder) {
+                    return $builder
                         ->withId('genomics-evolutionary-biology')
                         ->withName('Genomics and Evolutionary Biology')
                         ->withPromiseOfImpactStatement('Subject genomics-evolutionary-biology impact statement');
                 },
-                'biophysics-structural-biology' => function () {
-                    // TODO: maybe pass in a ready Builder::for(SomeModel::class)?
-                    return self::for(Subject::class)
+                'biophysics-structural-biology' => function ($builder) {
+                    return $builder
                         ->withId('biophysics-structural-biology')
                         ->withName('Biophysics and Structural Biology')
                         ->withPromiseOfImpactStatement('Subject biophysics-structural-biology impact statement');
                 },
-                'epidemiology-global-health' => function () {
-                    return self::for(Subject::class)
+                'epidemiology-global-health' => function ($builder) {
+                    return $builder
                         ->withId('epidemiology-global-health')
                         ->withName('Epidemiology and Global Health')
                         ->withPromiseOfImpactStatement('Subject epidemiology-global-health impact statement');
                 },
-                'microbiology-infectious-disease' => function () {
-                    return self::for(Subject::class)
+                'microbiology-infectious-disease' => function ($builder) {
+                    return $builder
                         ->withId('microbiology-infectious-disease')
                         ->withName('Microbiology and Infectious Disease')
                         ->withPromiseOfImpactStatement('Subject microbiology-infectious-disease impact statement');

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -85,6 +85,16 @@ final class Builder
     {
         // TODO: turn into private field
         $defaults = [
+            'eLife\ApiSdk\Model\BlogArticle' => function() {
+                return [
+                    'id' => '359325',
+                    'title' => 'Media coverage: Slime can see',
+                    'published' => new DateTimeImmutable(),
+                    'impactStatement' => null,
+                    'content' => new PromiseSequence(rejection_for('no content')),
+                    'subjects' => new ArraySequence([]),
+                ];
+            },
             'eLife\ApiSdk\Model\Collection' => function() {
                 return [
                     'id' => 'tropical-disease',
@@ -98,6 +108,7 @@ final class Builder
                     'selectedCurator' => self::dummy(Person::class),
                     'selectedCuratorEtAl' => false,
                     'curators' => new PromiseSequence(rejection_for('no curators')),
+                    'content' => new PromiseSequence(rejection_for('no content')),
                 ];
             },
             'eLife\ApiSdk\Model\Image' => function() {

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -31,6 +31,7 @@ use eLife\ApiSdk\Model\Reference\ReferenceDate;
 use eLife\ApiSdk\Model\Subject;
 use InvalidArgumentException;
 use LogicException;
+use ReflectionClass;
 use function GuzzleHttp\Promise\promise_for;
 use function GuzzleHttp\Promise\rejection_for;
 
@@ -485,7 +486,7 @@ final class Builder
      */
     public function __invoke()
     {
-        $class = new \ReflectionClass($this->model);
+        $class = new ReflectionClass($this->model);
         $constructorArgumentNames = array_map(function ($p) {
             return $p->getName();
         }, $class->getConstructor()->getParameters());

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -52,7 +52,7 @@ final class Builder
                         'published' => new DateTimeImmutable(),
                         'impactStatement' => null,
                         'content' => new ArraySequence([
-                            new Paragraph(''),
+                            new Paragraph('blogArticle 359325 content'),
                         ]),
                         'subjects' => new ArraySequence([]),
                     ];
@@ -79,7 +79,7 @@ final class Builder
                 },
                 Image::class => function () {
                     return [
-                        'altText' => '',
+                        'altText' => 'Image alt text',
                         'sizes' => [],
                     ];
                 },
@@ -123,7 +123,7 @@ final class Builder
                         'impactStatement' => null,
                         'published' => new DateTimeImmutable(),
                         'banner' => rejection_for('No banner'),
-                        'thumbnail' => new Image('', [900 => 'https://placehold.it/900x450']),
+                        'thumbnail' => new Image('thumbnail', [900 => 'https://placehold.it/900x450']),
                         'sources' => [
                             new PodcastEpisodeSource(
                                 'audio/mpeg',
@@ -496,8 +496,7 @@ final class Builder
             throw new InvalidArgumentException("Sample $sampleName not found for {$this->model}");
         }
         if (!array_key_exists('snippet', $context)) {
-            // what should be the default?
-            $context['snippet'] = true;
+            $context['snippet'] = false;
         }
         $sample = call_user_func(
             $samples[$this->model][$sampleName],
@@ -505,7 +504,7 @@ final class Builder
             $context
         );
         if ($sample instanceof self) {
-            return $sample->__invoke();
+            return $sample();
         } else {
             return $sample;
         }

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace test\eLife\ApiSdk;
+
+use BadMethodCallException;
+use DateTimeImmutable;
+use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Model\Image;
+use eLife\ApiSdk\Model\Collection;
+use function GuzzleHttp\Promise\promise_for;
+use function GuzzleHttp\Promise\rejection_for;
+
+class Builder
+{
+    private $model;
+    private $testData;
+
+    public function create($model)
+    {
+        $this->model = $model;
+        $this->testData = [
+            'id' => 'tropical-disease',
+            'title' => 'Tropical disease',
+            'subTitle' => rejection_for('Tropical disease subtitle'),
+            'impactStatement' => null,
+            'publishedDate' => new DateTimeImmutable(),
+            'banner' => rejection_for('No banner'),
+            'thumbnail' => new Image('', [900 => 'https://placehold.it/900x450']),
+            'subjects' => new ArraySequence([]),
+        ];
+        return $this;
+    }
+
+    /**
+     * @method with...($value)  e.g. withImpactStatement('a string')
+     */
+    public function __call($name, $args)
+    {
+        if (preg_match('/^withPromiseOf(.*)$/', $name, $matches)) {
+            $field = lcfirst($matches[1]);
+            $this->ensureExistingField($field);
+            $this->ensureSingleArgument($args);
+            $this->testData[$field] = promise_for($args[0]);
+        } elseif (preg_match('/^with(.*)$/', $name, $matches)) {
+            $field = lcfirst($matches[1]);
+            $this->ensureExistingField($field);
+            $this->ensureSingleArgument($args);
+            $this->testData[$field] = $args[0];
+        } else {
+            throw BadMethodCallException($name);
+        }
+        return $this;
+    }
+
+    public function __invoke()
+    {
+        $class = new \ReflectionClass($this->model);
+        $constructorArgumentNames = array_map(function($p) { return $p->getName(); } , $class->getConstructor()->getParameters());
+        $constructorArguments = [];
+        foreach ($constructorArgumentNames as $name) {
+            $constructorArguments[] = $this->testData[$name];
+        }
+        $instance = $class->newInstanceArgs($constructorArguments);
+        return $instance;
+    }
+
+    private function ensureExistingField($field)
+    {
+        $allowedFields = array_keys($this->testData);
+        if (!in_array($field, $allowedFields)) {
+            throw new BadMethodCallException("Field $field is not allowed for {$this->model}. Allowed fields: " . implode(', ', $allowedFields));
+        }
+    }
+
+    private function ensureSingleArgument($args)
+    {
+        if (count($args) > 1) {
+            throw BadMethodCallException("Too many arguments: " . var_export($args, true));
+        }
+    }
+}

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -8,6 +8,7 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\ArticlePoA;
 use eLife\ApiSdk\Model\ArticleVoR;
+use eLife\ApiSdk\Model\Block\Paragraph;
 use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Collection;
 use eLife\ApiSdk\Model\Image;
@@ -122,7 +123,9 @@ final class Builder
                     'title' => 'Media coverage: Slime can see',
                     'published' => new DateTimeImmutable(),
                     'impactStatement' => null,
-                    'content' => new PromiseSequence(rejection_for('no content')),
+                    'content' => new PromiseSequence(promise_for([
+                        new Paragraph(''),
+                    ])),
                     'subjects' => new ArraySequence([]),
                 ];
             },
@@ -167,9 +170,9 @@ final class Builder
                 return [
                     'id' => 'subject1',
                     'name' => 'Subject 1',
-                    'impactStatement' => rejection_for('No impact statement'),
-                    'banner' => rejection_for('No banner'),
-                    'thumbnail' => rejection_for('No thumbnail'),
+                    'impactStatement' => promise_for('Impact statement'),
+                    'banner' => promise_for(self::for(Image::class)->sample('banner')),
+                    'thumbnail' => promise_for(self::for(Image::class)->sample('thumbnail')),
                 ];
             },
             Person::class => function () {
@@ -178,6 +181,21 @@ final class Builder
                     'details' => new PersonDetails('preferred name', 'index name'),
                     'type' => 'senior-editor',
                     'image' => null,
+                    /*
+                     * new Image(
+                        '',
+                        [
+                            '16:9' => [
+                                '250' => 'https://placehold.it/250x141',
+                                '500' => 'https://placehold.it/500x281',
+                            ],
+                            '1:1' => [
+                                '70' => 'https://placehold.it/70x70',
+                                '140' => 'https://placehold.it/140x140',
+                            ],
+                        ]
+                    ),
+                     */
                     'research' => rejection_for('Research should not be unwrapped'),
                     'profile' => new PromiseSequence(rejection_for('Profile should not be unwrapped')),
                     'competingInterests' => rejection_for('Competing interests should not be unwrapped'),
@@ -331,12 +349,15 @@ final class Builder
             BlogArticle::class => [
                 'slime' => function ($builder) {
                     return $builder
-                        ->withId(1)
+                        ->withId(359325)
                         ->withTitle('Media coverage: Slime can see')
                         ->withImpactStatement('In their research paper – Cyanobacteria use micro-optics to sense light direction – Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world’s oldest and smallest camera eye, allowing them to ‘see’.')
                         ->withPublished(new DateTimeImmutable('2016-07-08T08:33:25+00:00'))
                         ->withSubjects(new ArraySequence([
                             self::for(Subject::class)->sample('biophysics-structural-biology'),
+                        ]))
+                        ->withContent(new ArraySequence([
+                            new Paragraph("Blog article 359325 text")
                         ]));
                 },
             ],
@@ -355,14 +376,24 @@ final class Builder
                 },
             ],
             Person::class => [
-                'bcooper' => function ($builder) {
-                    return $builder
+                'bcooper' => function ($builder, $context) {
+                    $person = $builder
                         ->withId('bcooper')
                         ->withType('reviewing-editor')
                         ->withDetails(new PersonDetails(
                             'Ben Cooper',
                             'Cooper, Ben'
                         ));
+
+                    if (!$context['snippet']) {
+                        $person
+                            ->withPromiseOfResearch('')
+                            ->withProfile(new ArraySequence([]))
+                            ->withPromiseOfCompetingInterests('');
+                        
+                    }
+
+                    return $person;
                 },
                 'pjha' => function ($builder, $context) {
                     $person = $builder
@@ -408,7 +439,8 @@ final class Builder
                     // TODO: maybe pass in a ready Builder::for(SomeModel::class)?
                     return self::for(Subject::class)
                         ->withId('biophysics-structural-biology')
-                        ->withName('Biophysics and Structural Biology');
+                        ->withName('Biophysics and Structural Biology')
+                        ->withPromiseOfImpactStatement('Subject biophysics-structural-biology impact statement');
                 },
             ],
         ];

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -28,6 +28,16 @@ class Builder
             'thumbnail' => new Image('', [900 => 'https://placehold.it/900x450']),
             'subjects' => new ArraySequence([]),
         ];
+    
+        if (strstr($model, 'Subject')) {
+            $this->testData = [
+                'id' => 'subject1',
+                'name' => 'Subject 1',
+                'impactStatement' => rejection_for('No impact statement'),
+                'banner' => rejection_for('No banner'),
+                'thumbnail' => rejection_for('No thumbnail'),
+            ];
+        }
         return $this;
     }
 
@@ -47,7 +57,7 @@ class Builder
             $this->ensureSingleArgument($args);
             $this->testData[$field] = $args[0];
         } else {
-            throw BadMethodCallException($name);
+            throw new BadMethodCallException($name);
         }
         return $this;
     }
@@ -75,7 +85,7 @@ class Builder
     private function ensureSingleArgument($args)
     {
         if (count($args) > 1) {
-            throw BadMethodCallException("Too many arguments: " . var_export($args, true));
+            throw new BadMethodCallException("Too many arguments: " . var_export($args, true));
         }
     }
 }

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -6,10 +6,13 @@ use BadMethodCallException;
 use DateTimeImmutable;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
+use eLife\ApiSdk\Model\BlogArticle;
+use eLife\ApiSdk\Model\Collection;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\ImageSize;
 use eLife\ApiSdk\Model\Person;
 use eLife\ApiSdk\Model\PersonDetails;
+use eLife\ApiSdk\Model\Subject;
 use InvalidArgumentException;
 use function GuzzleHttp\Promise\promise_for;
 use function GuzzleHttp\Promise\rejection_for;
@@ -85,7 +88,7 @@ final class Builder
     {
         // TODO: turn into private field
         $defaults = [
-            'eLife\ApiSdk\Model\BlogArticle' => function() {
+            BlogArticle::class => function() {
                 return [
                     'id' => '359325',
                     'title' => 'Media coverage: Slime can see',
@@ -95,7 +98,7 @@ final class Builder
                     'subjects' => new ArraySequence([]),
                 ];
             },
-            'eLife\ApiSdk\Model\Collection' => function() {
+            Collection::class => function() {
                 return [
                     'id' => 'tropical-disease',
                     'title' => 'Tropical disease',
@@ -111,13 +114,13 @@ final class Builder
                     'content' => new PromiseSequence(rejection_for('no content')),
                 ];
             },
-            'eLife\ApiSdk\Model\Image' => function() {
+            Image::class => function() {
                 return [
                     'altText' => '',
                     'sizes' => [],
                 ];
             },
-            'eLife\ApiSdk\Model\Subject' => function() {
+            Subject::class => function() {
                 return [
                     'id' => 'subject1',
                     'name' => 'Subject 1',
@@ -126,7 +129,7 @@ final class Builder
                     'thumbnail' => rejection_for('No thumbnail'),
                 ];
             },
-            'eLife\ApiSdk\Model\Person' => function() {
+            Person::class => function() {
                 return [
                     'id' => 'jqpublic',
                     'details' => new PersonDetails('preferred name', 'index name'),

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -125,7 +125,7 @@ final class Builder
                 return [
                     'id' => 'tropical-disease',
                     'title' => 'Tropical disease',
-                    'subTitle' => rejection_for('Tropical disease subtitle'),
+                    'subTitle' => promise_for(null),
                     'impactStatement' => null,
                     'publishedDate' => new DateTimeImmutable(),
                     'banner' => rejection_for('No banner'),
@@ -135,8 +135,8 @@ final class Builder
                     'selectedCuratorEtAl' => false,
                     'curators' => new PromiseSequence(rejection_for('no curators')),
                     'content' => new PromiseSequence(rejection_for('no content')),
-                    'relatedContent' => new PromiseSequence(rejection_for('no related content')),
-                    'podcastEpisodes' => new PromiseSequence(rejection_for('no podcast episodes')),
+                    'relatedContent' => $this->emptyPromiseSequence(),
+                    'podcastEpisodes' => $this->emptyPromiseSequence(),
                 ];
             },
             Image::class => function () {
@@ -349,6 +349,26 @@ final class Builder
                                                 ;
                 },
             ],
+            Person::class => [
+                'bcooper' => function($builder) {
+                    return $builder
+                        ->withId('bcooper')
+                        ->withType('reviewing-editor')
+                        ->withDetails(new PersonDetails(
+                            'Ben Cooper',
+                            'Cooper, Ben'
+                        ));
+                },
+                'pjha' => function($builder) {
+                    return $builder
+                        ->withId('pjha')
+                        ->withType('senior-editor')
+                        ->withDetails(new PersonDetails(
+                            'Prabhat Jha',
+                            'Jha, Prabhat'
+                        ));
+                },
+            ],
             PodcastEpisode::class => [
                 '29' => function($builder) {
                     return $builder
@@ -399,5 +419,10 @@ final class Builder
     private function rejectSequence()
     {
         return new PromiseSequence(rejection_for('rejecting this sequence'));
+    }
+
+    private function emptyPromiseSequence()
+    {
+        return new PromiseSequence(promise_for([]));
     }
 }

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -89,16 +89,21 @@ final class Builder
         return $instance;
     }
 
-    public function sample($sampleName)
+    public function sample($sampleName, $context = [])
     {
         $samples = $this->samples();
 
         if (!array_key_exists($sampleName, $samples[$this->model])) {
             throw new InvalidArgumentException("Sample $sampleName not found for {$this->model}");
         }
+        if (!array_key_exists('snippet', $context)) {
+            // what should be the default?
+            $context['snippet'] = true;
+        }
         $sample = call_user_func(
             $samples[$this->model][$sampleName],
-            $this
+            $this,
+            $context
         );
         if ($sample instanceof self) {
             return $sample->__invoke();
@@ -128,7 +133,7 @@ final class Builder
                     'subTitle' => promise_for(null),
                     'impactStatement' => null,
                     'publishedDate' => new DateTimeImmutable(),
-                    'banner' => rejection_for('No banner'),
+                    'banner' => rejection_for('No banner. Builder'),
                     'thumbnail' => new Image('', [900 => 'https://placehold.it/900x450']),
                     'subjects' => new ArraySequence([]),
                     'selectedCurator' => self::dummy(Person::class),
@@ -359,14 +364,22 @@ final class Builder
                             'Cooper, Ben'
                         ));
                 },
-                'pjha' => function ($builder) {
-                    return $builder
+                'pjha' => function ($builder, $context) {
+                    $person = $builder
                         ->withId('pjha')
                         ->withType('senior-editor')
                         ->withDetails(new PersonDetails(
                             'Prabhat Jha',
                             'Jha, Prabhat'
                         ));
+                    if (!$context['snippet']) {
+                        $person
+                            ->withPromiseOfResearch('')
+                            ->withProfile(new ArraySequence([]))
+                            ->withPromiseOfCompetingInterests('');
+                        
+                    }
+                    return $person;
                 },
             ],
             PodcastEpisode::class => [

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -8,14 +8,17 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\ArticlePoA;
 use eLife\ApiSdk\Model\ArticleVoR;
+use eLife\ApiSdk\Model\ArticleSection;
 use eLife\ApiSdk\Model\Block\Paragraph;
 use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Collection;
+use eLife\ApiSdk\Model\Copyright;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\ImageSize;
 use eLife\ApiSdk\Model\Interview;
 use eLife\ApiSdk\Model\Interviewee;
 use eLife\ApiSdk\Model\Person;
+use eLife\ApiSdk\Model\PersonAuthor;
 use eLife\ApiSdk\Model\PersonDetails;
 use eLife\ApiSdk\Model\PodcastEpisode;
 use eLife\ApiSdk\Model\PodcastEpisodeSource;
@@ -237,10 +240,10 @@ final class Builder
               //          self::for(Subject::class)->sample('genomics-evolutionary-biology')
                     ]),
                     'researchOrganisms' => [],
-                    'abstract' => rejection_for('no abstract'),
-                    'issue' => rejection_for('no issue'),
-                    'copyright' => rejection_for('copyright'),
-                    'authors' => $this->rejectSequence(),
+                    'abstract' => promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article 14107 abstract text')]))),
+                    'issue' => promise_for(1),
+                    'copyright' => promise_for(new Copyright('CC-BY-4.0', 'Statement', 'Author et al')),
+                    'authors' => new ArraySequence([new PersonAuthor(new PersonDetails('Author', 'Author'))])
                 ];
             },
             ArticleVoR::class => function () {

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -82,7 +82,7 @@ final class Builder
             unset($testDataRemainingToUse[$name]);
         }
         if ($testDataRemainingToUse) {
-            throw new LogicException("Some defaults were specified, but not used by the constructor of $this->model: " . var_export($testDataRemainingToUse, true));
+            throw new LogicException("Some defaults were specified, but not used by the constructor of $this->model: ".var_export($testDataRemainingToUse, true));
         }
         $instance = $class->newInstanceArgs($constructorArguments);
 
@@ -145,17 +145,17 @@ final class Builder
                     'sizes' => [],
                 ];
             },
-            Interview::class => function() {
+            Interview::class => function () {
                 return [
                     'id' => '1',
                     'interviewee' => new Interviewee(
-                        new PersonDetails("Ramanath Hegde", "Hegde, Ramanath"),
+                        new PersonDetails('Ramanath Hegde', 'Hegde, Ramanath'),
                         $this->rejectSequence()
                     ),
                     'title' => 'Controlling traffic',
                     'published' => new DateTimeImmutable(),
                     'impactStatement' => null,
-                    'content' => $this->rejectSequence()
+                    'content' => $this->rejectSequence(),
                 ];
             },
             Subject::class => function () {
@@ -196,7 +196,7 @@ final class Builder
                     'chapters' => new PromiseSequence(rejection_for('no chapters')),
                 ];
             },
-            ArticlePoA::class => function() {
+            ArticlePoA::class => function () {
                 return [
                     'id' => '14107',
                     'type' => 'research-article',
@@ -220,7 +220,7 @@ final class Builder
                     'authors' => $this->rejectSequence(),
                 ];
             },
-            ArticleVoR::class => function() {
+            ArticleVoR::class => function () {
                 return [
                     'id' => '09560',
                     'version' => 1,
@@ -235,7 +235,7 @@ final class Builder
                     'elocationId' => 'e09560',
                     'pdf' => 'https://elifesciences.org/content/4/e09560.pdf',
                     'subjects' => new ArraySequence([
-                        self::for(Subject::class)->sample('genomics-evolutionary-biology')
+                        self::for(Subject::class)->sample('genomics-evolutionary-biology'),
                     ]),
                     'impactStatement' => 'A new hominin species has been unearthed in the Dinaledi Chamber of the Rising Star cave system in the largest assemblage of a single species of hominins yet discovered in Africa.',
                     'thumbnail' => self::for(Image::class)->sample('thumbnail'),
@@ -288,7 +288,7 @@ final class Builder
                 },
             ],
             ArticlePoA::class => [
-                'growth-factor' => function($builder) {
+                'growth-factor' => function ($builder) {
                     return $builder
                         ->withId('14107')
                         ->withVersion(1)
@@ -317,40 +317,40 @@ final class Builder
                         ->withElocationId('e09560')
                         ->withPdf('https://elifesciences.org/content/4/e09560.pdf')
                         ->withSubjects(new ArraySequence([
-                            self::for(Subject::class)->sample('genomics-evolutionary-biology')
+                            self::for(Subject::class)->sample('genomics-evolutionary-biology'),
                         ]))
                         ->withImpactStatement('A new hominin species has been unearthed in the Dinaledi Chamber of the Rising Star cave system in the largest assemblage of a single species of hominins yet discovered in Africa.')
                         ->withThumbnail(self::for(Image::class)->sample('thumbnail'));
                 },
             ],
             BlogArticle::class => [
-                'slime' => function($builder) {
+                'slime' => function ($builder) {
                     return $builder
                         ->withId(1)
                         ->withTitle('Media coverage: Slime can see')
                         ->withImpactStatement('In their research paper – Cyanobacteria use micro-optics to sense light direction – Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world’s oldest and smallest camera eye, allowing them to ‘see’.')
                         ->withPublished(new DateTimeImmutable('2016-07-08T08:33:25+00:00'))
                         ->withSubjects(new ArraySequence([
-                            self::for(Subject::class)->sample('biophysics-structural-biology')
+                            self::for(Subject::class)->sample('biophysics-structural-biology'),
                         ]));
                 },
             ],
             Interview::class => [
-                'controlling-traffic' => function($builder) {
+                'controlling-traffic' => function ($builder) {
                     return $builder
                         ->withId('1')
                         ->withTitle('Controlling traffic')
                         ->withInterviewee(new Interviewee(
-                                new PersonDetails("Ramanath Hegde", "Hegde, Ramanath"),
+                                new PersonDetails('Ramanath Hegde', 'Hegde, Ramanath'),
                                 $this->rejectSequence()
                         ))
-                        ->withImpactStatement("Ramanath Hegde is a Postdoctoral Fellow at the Institute of Protein Biochemistry in Naples, Italy, where he investigates ways of preventing cells from destroying mutant proteins.")
-                        ->withPublished(new DateTimeImmutable("2016-01-29T16:22:28+00:00"))
+                        ->withImpactStatement('Ramanath Hegde is a Postdoctoral Fellow at the Institute of Protein Biochemistry in Naples, Italy, where he investigates ways of preventing cells from destroying mutant proteins.')
+                        ->withPublished(new DateTimeImmutable('2016-01-29T16:22:28+00:00'))
                                                 ;
                 },
             ],
             Person::class => [
-                'bcooper' => function($builder) {
+                'bcooper' => function ($builder) {
                     return $builder
                         ->withId('bcooper')
                         ->withType('reviewing-editor')
@@ -359,7 +359,7 @@ final class Builder
                             'Cooper, Ben'
                         ));
                 },
-                'pjha' => function($builder) {
+                'pjha' => function ($builder) {
                     return $builder
                         ->withId('pjha')
                         ->withType('senior-editor')
@@ -370,7 +370,7 @@ final class Builder
                 },
             ],
             PodcastEpisode::class => [
-                '29' => function($builder) {
+                '29' => function ($builder) {
                     return $builder
                         ->withNumber(29)
                         ->withTitle('April/May 2016')
@@ -380,18 +380,18 @@ final class Builder
                             new PodcastEpisodeSource(
                                 'audio/mpeg',
                                 'https://nakeddiscovery.com/scripts/mp3s/audio/eLife_Podcast_16.05.mp3'
-                            )
+                            ),
                         ]);
                 },
             ],
             Subject::class => [
-                'genomics-evolutionary-biology' => function() {
+                'genomics-evolutionary-biology' => function () {
                     // TODO: maybe pass in a ready Builder::for(SomeModel::class)?
                     return self::for(Subject::class)
                         ->withId('genomics-evolutionary-biology')
                         ->withName('Genomics and Evolutionary Biology');
                 },
-                'biophysics-structural-biology' => function() {
+                'biophysics-structural-biology' => function () {
                     // TODO: maybe pass in a ready Builder::for(SomeModel::class)?
                     return self::for(Subject::class)
                         ->withId('biophysics-structural-biology')

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -184,7 +184,7 @@ final class Builder
                                         new PersonAuthor(new PersonDetails(
                                             'preferred name',
                                             'index name'
-                                        ))
+                                        )),
                                     ],
                                     false,
                                     'book title',
@@ -419,7 +419,7 @@ final class Builder
     }
 
     /**
-     * @return object  instance of $model
+     * @return object instance of $model
      */
     public static function dummy($model)
     {
@@ -463,7 +463,7 @@ final class Builder
     }
 
     /**
-     * @return object  instance of $this->model
+     * @return object instance of $this->model
      */
     public function __invoke()
     {
@@ -486,7 +486,7 @@ final class Builder
     }
 
     /**
-     * @return object  instance of $this->model
+     * @return object instance of $this->model
      */
     public function sample($sampleName, $context = [])
     {

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -51,9 +51,9 @@ final class Builder
                         'title' => 'Media coverage: Slime can see',
                         'published' => new DateTimeImmutable(),
                         'impactStatement' => null,
-                        'content' => new PromiseSequence(promise_for([
+                        'content' => new ArraySequence([
                             new Paragraph(''),
-                        ])),
+                        ]),
                         'subjects' => new ArraySequence([]),
                     ];
                 },
@@ -72,10 +72,9 @@ final class Builder
                         'curators' => new ArraySequence([
                             self::dummy(Person::class),
                         ]),
-                        'content' => new ArraySequence([
-                        ]),
-                        'relatedContent' => $this->emptyPromiseSequence(),
-                        'podcastEpisodes' => $this->emptyPromiseSequence(),
+                        'content' => new ArraySequence(),
+                        'relatedContent' => new ArraySequence(),
+                        'podcastEpisodes' => new ArraySequence(),
                     ];
                 },
                 Image::class => function () {
@@ -131,7 +130,7 @@ final class Builder
                                 'http://example.com/podcast.mp3'
                             ),
                         ],
-                        'subjects' => new ArraySequence([]),
+                        'subjects' => new ArraySequence(),
                         'chapters' => new PromiseSequence(rejection_for('no chapters')),
                     ];
                 },
@@ -179,9 +178,18 @@ final class Builder
                             'digest' => promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article 09560 digest')]), '10.7554/eLife.09560digest')),
                             'content' => new ArraySequence([new Paragraph('content')]),
                             'references' => $references = new ArraySequence([
-                                new BookReference(new ReferenceDate(2000),
-                                [new PersonAuthor(new PersonDetails('preferred name', 'index name'))], false, 'book title',
-                                new Place(null, null, ['publisher'])),
+                                new BookReference(
+                                    new ReferenceDate(2000),
+                                    [
+                                        new PersonAuthor(new PersonDetails(
+                                            'preferred name',
+                                            'index name'
+                                        ))
+                                    ],
+                                    false,
+                                    'book title',
+                                    new Place(null, null, ['publisher'])
+                                ),
                             ]),
                             'decisionLetter' => promise_for(new ArticleSection(new ArraySequence([new Paragraph('Decision letter')]))),
                             'decisionLetterDescription' => new ArraySequence([new Paragraph('Decision letter description')]),
@@ -521,10 +529,5 @@ final class Builder
     private function rejectSequence()
     {
         return new PromiseSequence(rejection_for('rejecting this sequence'));
-    }
-
-    private function emptyPromiseSequence()
-    {
-        return new PromiseSequence(promise_for([]));
     }
 }

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -146,7 +146,7 @@ final class Builder
                     'impactStatement' => null,
                     'publishedDate' => new DateTimeImmutable(),
                     'banner' => promise_for(self::for(Image::class)->sample('banner')),
-                    'thumbnail' => new Image('', [900 => 'https://placehold.it/900x450']),
+                    'thumbnail' => self::for(Image::class)->sample('thumbnail'),
                     'subjects' => new ArraySequence([]),
                     'selectedCurator' => self::dummy(Person::class),
                     'selectedCuratorEtAl' => false,

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -6,7 +6,9 @@ use BadMethodCallException;
 use DateTimeImmutable;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Model\Image;
+use eLife\ApiSdk\Model\ImageSize;
 use eLife\ApiSdk\Model\Collection;
+use InvalidArgumentException;
 use function GuzzleHttp\Promise\promise_for;
 use function GuzzleHttp\Promise\rejection_for;
 
@@ -15,29 +17,15 @@ class Builder
     private $model;
     private $testData;
 
+    public static function for($model)
+    {
+        return (new self())->create($model);
+    }
+    
     public function create($model)
     {
         $this->model = $model;
-        $this->testData = [
-            'id' => 'tropical-disease',
-            'title' => 'Tropical disease',
-            'subTitle' => rejection_for('Tropical disease subtitle'),
-            'impactStatement' => null,
-            'publishedDate' => new DateTimeImmutable(),
-            'banner' => rejection_for('No banner'),
-            'thumbnail' => new Image('', [900 => 'https://placehold.it/900x450']),
-            'subjects' => new ArraySequence([]),
-        ];
-    
-        if (strstr($model, 'Subject')) {
-            $this->testData = [
-                'id' => 'subject1',
-                'name' => 'Subject 1',
-                'impactStatement' => rejection_for('No impact statement'),
-                'banner' => rejection_for('No banner'),
-                'thumbnail' => rejection_for('No thumbnail'),
-            ];
-        }
+        $this->testData = $this->defaultTestDataFor($model);
         return $this;
     }
 
@@ -72,6 +60,73 @@ class Builder
         }
         $instance = $class->newInstanceArgs($constructorArguments);
         return $instance;
+    }
+
+    public function sample($sampleName)
+    {
+        $samples = $this->samples();
+        return call_user_func($samples[$this->model][$sampleName]);
+    }
+
+    private function defaultTestDataFor($model)
+    {
+        // TODO: turn into private field
+        $defaults = [
+            'eLife\ApiSdk\Model\Collection' => [
+                'id' => 'tropical-disease',
+                'title' => 'Tropical disease',
+                'subTitle' => rejection_for('Tropical disease subtitle'),
+                'impactStatement' => null,
+                'publishedDate' => new DateTimeImmutable(),
+                'banner' => rejection_for('No banner'),
+                'thumbnail' => new Image('', [900 => 'https://placehold.it/900x450']),
+                'subjects' => new ArraySequence([]),
+            ],
+            'eLife\ApiSdk\Model\Image' => [
+                'altText' => '',
+                'sizes' => [],
+            ],
+            'eLife\ApiSdk\Model\Subject' => [
+                'id' => 'subject1',
+                'name' => 'Subject 1',
+                'impactStatement' => rejection_for('No impact statement'),
+                'banner' => rejection_for('No banner'),
+                'thumbnail' => rejection_for('No thumbnail'),
+            ],
+        ];
+
+        if (!array_key_exists($model, $defaults)) {
+            throw new InvalidArgumentException("No defaults available for $model");
+        }
+
+        return $defaults[$model];
+    }
+
+    private function samples()
+    {
+        // TODO: turn into private field
+        return [
+            'eLife\ApiSdk\Model\Image' => [
+                'banner' => function() {
+                    return new Image(
+                        '',
+                        [new ImageSize('2:1', [900 => 'https://placehold.it/900x450', 1800 => 'https://placehold.it/1800x900'])]
+                    );
+                },
+                'thumbnail' => function() {
+                    return new Image('', [
+                        new ImageSize('16:9', [
+                            250 => 'https://placehold.it/250x141',
+                            500 => 'https://placehold.it/500x281',
+                        ]),
+                        new ImageSize('1:1', [
+                            '70' => 'https://placehold.it/70x70',
+                            '140' => 'https://placehold.it/140x140',
+                        ]),
+                    ]);
+                }
+            ]
+        ];
     }
 
     private function ensureExistingField($field)

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -139,13 +139,16 @@ final class Builder
                     'subTitle' => promise_for(null),
                     'impactStatement' => null,
                     'publishedDate' => new DateTimeImmutable(),
-                    'banner' => rejection_for('No banner. Builder'),
+                    'banner' => promise_for(self::for(Image::class)->sample('banner')),
                     'thumbnail' => new Image('', [900 => 'https://placehold.it/900x450']),
                     'subjects' => new ArraySequence([]),
                     'selectedCurator' => self::dummy(Person::class),
                     'selectedCuratorEtAl' => false,
-                    'curators' => new PromiseSequence(rejection_for('no curators')),
-                    'content' => new PromiseSequence(rejection_for('no content')),
+                    'curators' => new ArraySequence([
+                        self::dummy(Person::class),
+                    ]),
+                    'content' => new ArraySequence([
+                    ]),
                     'relatedContent' => $this->emptyPromiseSequence(),
                     'podcastEpisodes' => $this->emptyPromiseSequence(),
                 ];
@@ -199,9 +202,9 @@ final class Builder
                         ]
                     ),
                      */
-                    'research' => rejection_for('Research should not be unwrapped'),
-                    'profile' => new PromiseSequence(rejection_for('Profile should not be unwrapped')),
-                    'competingInterests' => rejection_for('Competing interests should not be unwrapped'),
+                    'research' => promise_for(null),
+                    'profile' => new ArraySequence(),
+                    'competingInterests' => promise_for(null),
                 ];
             },
             PodcastEpisode::class => function () {
@@ -445,6 +448,18 @@ final class Builder
                         ->withName('Biophysics and Structural Biology')
                         ->withPromiseOfImpactStatement('Subject biophysics-structural-biology impact statement');
                 },
+                'epidemiology-global-health' => function () {
+                    return self::for(Subject::class)
+                        ->withId('epidemiology-global-health')
+                        ->withName('Epidemiology and Global Health')
+                        ->withPromiseOfImpactStatement('Subject epidemiology-global-health impact statement');
+                },
+                'microbiology-infectious-disease' => function () {
+                    return self::for(Subject::class)
+                        ->withId('microbiology-infectious-disease')
+                        ->withName('Microbiology and Infectious Disease')
+                        ->withPromiseOfImpactStatement('Subject microbiology-infectious-disease impact statement');
+                }
             ],
         ];
     }

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -112,6 +112,7 @@ final class Builder
                     'selectedCuratorEtAl' => false,
                     'curators' => new PromiseSequence(rejection_for('no curators')),
                     'content' => new PromiseSequence(rejection_for('no content')),
+                    'relatedContent' => new PromiseSequence(rejection_for('no related content')),
                 ];
             },
             Image::class => function() {

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -7,7 +7,6 @@ use DateTimeImmutable;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\ImageSize;
-use eLife\ApiSdk\Model\Collection;
 use InvalidArgumentException;
 use function GuzzleHttp\Promise\promise_for;
 use function GuzzleHttp\Promise\rejection_for;
@@ -21,11 +20,12 @@ class Builder
     {
         return (new self())->create($model);
     }
-    
+
     public function create($model)
     {
         $this->model = $model;
         $this->testData = $this->defaultTestDataFor($model);
+
         return $this;
     }
 
@@ -47,24 +47,29 @@ class Builder
         } else {
             throw new BadMethodCallException($name);
         }
+
         return $this;
     }
 
     public function __invoke()
     {
         $class = new \ReflectionClass($this->model);
-        $constructorArgumentNames = array_map(function($p) { return $p->getName(); } , $class->getConstructor()->getParameters());
+        $constructorArgumentNames = array_map(function ($p) {
+            return $p->getName();
+        }, $class->getConstructor()->getParameters());
         $constructorArguments = [];
         foreach ($constructorArgumentNames as $name) {
             $constructorArguments[] = $this->testData[$name];
         }
         $instance = $class->newInstanceArgs($constructorArguments);
+
         return $instance;
     }
 
     public function sample($sampleName)
     {
         $samples = $this->samples();
+
         return call_user_func($samples[$this->model][$sampleName]);
     }
 
@@ -107,13 +112,13 @@ class Builder
         // TODO: turn into private field
         return [
             'eLife\ApiSdk\Model\Image' => [
-                'banner' => function() {
+                'banner' => function () {
                     return new Image(
                         '',
                         [new ImageSize('2:1', [900 => 'https://placehold.it/900x450', 1800 => 'https://placehold.it/1800x900'])]
                     );
                 },
-                'thumbnail' => function() {
+                'thumbnail' => function () {
                     return new Image('', [
                         new ImageSize('16:9', [
                             250 => 'https://placehold.it/250x141',
@@ -124,8 +129,8 @@ class Builder
                             '140' => 'https://placehold.it/140x140',
                         ]),
                     ]);
-                }
-            ]
+                },
+            ],
         ];
     }
 
@@ -133,14 +138,14 @@ class Builder
     {
         $allowedFields = array_keys($this->testData);
         if (!in_array($field, $allowedFields)) {
-            throw new BadMethodCallException("Field $field is not allowed for {$this->model}. Allowed fields: " . implode(', ', $allowedFields));
+            throw new BadMethodCallException("Field $field is not allowed for {$this->model}. Allowed fields: ".implode(', ', $allowedFields));
         }
     }
 
     private function ensureSingleArgument($args)
     {
         if (count($args) > 1) {
-            throw new BadMethodCallException("Too many arguments: " . var_export($args, true));
+            throw new BadMethodCallException('Too many arguments: '.var_export($args, true));
         }
     }
 }

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -349,6 +349,21 @@ final class Builder
                                                 ;
                 },
             ],
+            PodcastEpisode::class => [
+                '29' => function($builder) {
+                    return $builder
+                        ->withNumber(29)
+                        ->withTitle('April/May 2016')
+                        ->withPublished(new DateTimeImmutable('2016-05-27T13:19:42+00:00'))
+                        ->withThumbnail(self::for(Image::class)->sample('thumbnail'))
+                        ->withSources([
+                            new PodcastEpisodeSource(
+                                'audio/mpeg',
+                                'https://nakeddiscovery.com/scripts/mp3s/audio/eLife_Podcast_16.05.mp3'
+                            )
+                        ]);
+                },
+            ],
             Subject::class => [
                 'genomics-evolutionary-biology' => function() {
                     // TODO: maybe pass in a ready Builder::for(SomeModel::class)?

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -303,6 +303,24 @@ final class Builder
                             ]));
                     },
                 ],
+                Collection::class => [
+                    'tropical-disease' => function ($builder) {
+                        return $builder
+                            ->withId('tropical-disease')
+                            ->withTitle('Tropical disease')
+                            ->withPublishedDate(new DateTimeImmutable('2000-01-01T00:00:00+00:00'))
+                            ->withThumbnail(Builder::for(Image::class)->sample('thumbnail'))
+                            ->withSelectedCurator($pjha = Builder::for(Person::class)->sample('pjha'))
+                            ->withCurators(new ArraySequence([
+                                Builder::for(Person::class)->sample('bcooper'),
+                                $pjha,
+                            ]))
+                            ->withContent(new ArraySequence([
+                                Builder::for(BlogArticle::class)
+                                    ->sample('slime'),
+                            ]));
+                    },
+                ],
                 Interview::class => [
                     'controlling-traffic' => function ($builder) {
                         return $builder

--- a/test/Client/ArticlesTest.php
+++ b/test/Client/ArticlesTest.php
@@ -80,7 +80,7 @@ final class ArticlesTest extends ApiTestCase
      */
     public function it_gets_an_article()
     {
-        $this->mockArticleCall(7, true, true);
+        $this->mockArticleCall('article7', true, true);
 
         $article = $this->articles->get('article7')->wait();
 
@@ -88,9 +88,9 @@ final class ArticlesTest extends ApiTestCase
         $this->assertSame('article7', $article->getId());
 
         $this->assertInstanceOf(Section::class, $article->getContent()->toArray()[0]);
-        $this->assertSame('Article 7 section title', $article->getContent()->toArray()[0]->getTitle());
+        $this->assertSame('Article article7 section title', $article->getContent()->toArray()[0]->getTitle());
         $this->assertInstanceOf(Paragraph::class, $article->getContent()->toArray()[0]->getContent()[0]);
-        $this->assertSame('Article 7 text', $article->getContent()->toArray()[0]->getContent()[0]->getText());
+        $this->assertSame('Article article7 text', $article->getContent()->toArray()[0]->getContent()[0]->getText());
 
         $this->mockSubjectCall(1);
 
@@ -113,10 +113,10 @@ final class ArticlesTest extends ApiTestCase
         $this->assertInstanceOf(ArticleVersion::class, $article);
         $this->assertSame('article1', $article->getId());
 
-        $this->mockArticleCall(1, false, true);
+        $this->mockArticleCall('article1', false, true);
 
         $this->assertInstanceOf(Section::class, $article->getContent()->toArray()[0]);
-        $this->assertSame('Article 1 section title', $article->getContent()->toArray()[0]->getTitle());
+        $this->assertSame('Article article1 section title', $article->getContent()->toArray()[0]->getTitle());
     }
 
     /**

--- a/test/Client/BlogArticlesTest.php
+++ b/test/Client/BlogArticlesTest.php
@@ -87,12 +87,12 @@ final class BlogArticlesTest extends ApiTestCase
         $this->assertSame('blogArticle7', $blogArticle->getId());
 
         $this->assertInstanceOf(Paragraph::class, $blogArticle->getContent()->toArray()[0]);
-        $this->assertSame('Blog article 7 text', $blogArticle->getContent()->toArray()[0]->getText());
+        $this->assertSame('Blog article blogArticle7 text', $blogArticle->getContent()->toArray()[0]->getText());
 
         $this->assertInstanceOf(Subject::class, $blogArticle->getSubjects()->toArray()[0]);
         $this->assertSame('Subject 1 name', $blogArticle->getSubjects()->toArray()[0]->getName());
 
-        $this->mockSubjectCall(1);
+        $this->mockSubjectCall('1');
 
         $this->assertSame('Subject 1 impact statement',
             $blogArticle->getSubjects()->toArray()[0]->getImpactStatement());
@@ -116,7 +116,7 @@ final class BlogArticlesTest extends ApiTestCase
         $this->mockBlogArticleCall(1);
 
         $this->assertInstanceOf(Paragraph::class, $blogArticle->getContent()->toArray()[0]);
-        $this->assertSame('Blog article 1 text', $blogArticle->getContent()->toArray()[0]->getText());
+        $this->assertSame('Blog article blogArticle1 text', $blogArticle->getContent()->toArray()[0]->getText());
     }
 
     /**

--- a/test/Client/CollectionsTest.php
+++ b/test/Client/CollectionsTest.php
@@ -4,6 +4,7 @@ namespace test\eLife\ApiSdk\Client;
 
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Client\Collections;
+use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\ArticleVoR;
 use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Collection;
@@ -21,6 +22,29 @@ final class CollectionsTest extends ApiTestCase
     protected function setUpCollections()
     {
         $this->collections = (new ApiSdk($this->getHttpClient()))->collections();
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_a_sequence()
+    {
+        $this->assertInstanceOf(Sequence::class, $this->collections);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_traversed()
+    {
+        $this->mockCollectionListCall(1, 1, 200);
+        $this->mockCollectionListCall(1, 100, 200);
+        $this->mockCollectionListCall(2, 100, 200);
+
+        foreach ($this->collections as $i => $collection) {
+            $this->assertInstanceOf(Collection::class, $collection);
+            $this->assertSame((string) $i, $collection->getId());
+        }
     }
 
     /**

--- a/test/Client/CollectionsTest.php
+++ b/test/Client/CollectionsTest.php
@@ -31,18 +31,19 @@ final class CollectionsTest extends ApiTestCase
         $collection = $this->collections->get('tropical-disease')->wait();
 
         $this->markTestIncomplete();
-        $this->assertInstanceOf(PodcastEpisode::class, $podcastEpisode);
-        $this->assertSame(7, $podcastEpisode->getNumber());
 
-        $this->assertInstanceOf(PodcastEpisodeChapter::class, $podcastEpisode->getChapters()->toArray()[0]);
-        $this->assertSame('Chapter title', $podcastEpisode->getChapters()->toArray()[0]->getTitle());
+        //$this->assertInstanceOf(PodcastEpisode::class, $podcastEpisode);
+        //$this->assertSame(7, $podcastEpisode->getNumber());
 
-        $this->assertInstanceOf(Subject::class, $podcastEpisode->getSubjects()->toArray()[0]);
-        $this->assertSame('Subject 1 name', $podcastEpisode->getSubjects()->toArray()[0]->getName());
+        //$this->assertInstanceOf(PodcastEpisodeChapter::class, $podcastEpisode->getChapters()->toArray()[0]);
+        //$this->assertSame('Chapter title', $podcastEpisode->getChapters()->toArray()[0]->getTitle());
 
-        $this->mockSubjectCall(1);
+        //$this->assertInstanceOf(Subject::class, $podcastEpisode->getSubjects()->toArray()[0]);
+        //$this->assertSame('Subject 1 name', $podcastEpisode->getSubjects()->toArray()[0]->getName());
 
-        $this->assertSame('Subject 1 impact statement',
-            $podcastEpisode->getSubjects()->toArray()[0]->getImpactStatement());
+        //$this->mockSubjectCall(1);
+
+        //$this->assertSame('Subject 1 impact statement',
+        //    $podcastEpisode->getSubjects()->toArray()[0]->getImpactStatement());
     }
 }

--- a/test/Client/CollectionsTest.php
+++ b/test/Client/CollectionsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace test\eLife\ApiSdk\Client;
+
+use eLife\ApiSdk\ApiSdk;
+use eLife\ApiSdk\Client\Collections;
+#use eLife\ApiSdk\Collection;
+use eLife\ApiSdk\Model\Collection;
+use eLife\ApiSdk\Model\Subject;
+use test\eLife\ApiSdk\ApiTestCase;
+
+final class CollectionsTest extends ApiTestCase
+{
+    /** @var Collections */
+    private $collections;
+
+    /**
+     * @before
+     */
+    protected function setUpCollections()
+    {
+        $this->collections = (new ApiSdk($this->getHttpClient()))->collections();
+    }
+
+    /**
+     * @test
+     */
+    public function it_gets_a_collection()
+    {
+        $this->mockCollectionCall('tropical-disease', true);
+        return;
+
+        $podcastEpisode = $this->podcastEpisodes->get(7)->wait();
+
+        $this->assertInstanceOf(PodcastEpisode::class, $podcastEpisode);
+        $this->assertSame(7, $podcastEpisode->getNumber());
+
+        $this->assertInstanceOf(PodcastEpisodeChapter::class, $podcastEpisode->getChapters()->toArray()[0]);
+        $this->assertSame('Chapter title', $podcastEpisode->getChapters()->toArray()[0]->getTitle());
+
+        $this->assertInstanceOf(Subject::class, $podcastEpisode->getSubjects()->toArray()[0]);
+        $this->assertSame('Subject 1 name', $podcastEpisode->getSubjects()->toArray()[0]->getName());
+
+        $this->mockSubjectCall(1);
+
+        $this->assertSame('Subject 1 impact statement',
+            $podcastEpisode->getSubjects()->toArray()[0]->getImpactStatement());
+    }
+}

--- a/test/Client/CollectionsTest.php
+++ b/test/Client/CollectionsTest.php
@@ -50,6 +50,34 @@ final class CollectionsTest extends ApiTestCase
     /**
      * @test
      */
+    public function it_can_be_counted()
+    {
+        $this->mockCollectionListCall(1, 1, 10);
+
+        $this->assertSame(10, $this->collections->count());
+    }
+
+    /**
+     * @test
+     */
+    public function it_casts_to_an_array()
+    {
+        $this->mockCollectionListCall(1, 1, 10);
+        $this->mockCollectionListCall(1, 100, 10);
+
+        $array = $this->collections->toArray();
+
+        $this->assertCount(10, $array);
+
+        foreach ($array as $i => $collection) {
+            $this->assertInstanceOf(Collection::class, $collection);
+            $this->assertSame((string) ($i + 1), $collection->getId());
+        }
+    }
+
+    /**
+     * @test
+     */
     public function it_gets_a_collection()
     {
         $this->mockCollectionCall('tropical-disease', true);
@@ -70,5 +98,230 @@ final class CollectionsTest extends ApiTestCase
 
         $this->assertSame('Subject 1 impact statement',
             $collection->getSubjects()->toArray()[0]->getImpactStatement());
+    }
+
+    /**
+     * @test
+     */
+    public function it_reuses_already_known_collections()
+    {
+        $this->mockCollectionListCall(1, 1, 1);
+        $this->mockCollectionListCall(1, 100, 1);
+
+        $this->collections->toArray();
+
+        $collection = $this->collections->get(1)->wait();
+
+        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertSame('1', $collection->getId());
+
+        $this->mockCollectionCall(1);
+
+        $this->assertInstanceOf(BlogArticle::class, $collection->getContent()->toArray()[0]);
+        $this->assertSame('Media coverage: Slime can see', $collection->getContent()->toArray()[0]->getTitle());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_filtered_by_subject()
+    {
+        $this->mockCollectionListCall(1, 1, 5, true, ['subject']);
+        $this->mockCollectionListCall(1, 100, 5, true, ['subject']);
+
+        foreach ($this->collections->forSubject('subject') as $i => $collection) {
+            $this->assertSame((string) $i, $collection->getId());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function it_recounts_when_filtering_by_subject()
+    {
+        $this->mockCollectionListCall(1, 1, 10);
+
+        $this->collections->count();
+
+        $this->mockCollectionListCall(1, 1, 4, true, ['subject']);
+
+        $this->assertSame(4, $this->collections->forSubject('subject')->count());
+    }
+
+    /**
+     * @test
+     */
+    public function it_fetches_pages_again_when_filtering_by_subject()
+    {
+        $this->mockCollectionListCall(1, 1, 200);
+        $this->mockCollectionListCall(1, 100, 200);
+        $this->mockCollectionListCall(2, 100, 200);
+
+        $this->collections->toArray();
+
+        $this->mockCollectionListCall(1, 1, 200, true, ['subject']);
+        $this->mockCollectionListCall(1, 100, 200, true, ['subject']);
+        $this->mockCollectionListCall(2, 100, 200, true, ['subject']);
+
+        $this->collections->forSubject('subject')->toArray();
+    }
+
+    /**
+     * @test
+     * @dataProvider sliceProvider
+     */
+    public function it_can_be_sliced(int $offset, int $length = null, array $expected, array $calls)
+    {
+        foreach ($calls as $call) {
+            $this->mockCollectionListCall($call['page'], $call['per-page'], 5);
+        }
+
+        foreach ($this->collections->slice($offset, $length) as $i => $collection) {
+            $this->assertInstanceOf(Collection::class, $collection);
+            $this->assertSame($expected[$i], $collection->getId());
+        }
+    }
+
+    public function sliceProvider() : array
+    {
+        return [
+            'offset 1, length 1' => [
+                1,
+                1,
+                ['2'],
+                [
+                    ['page' => 2, 'per-page' => 1],
+                ],
+            ],
+            'offset -2, no length' => [
+                -2,
+                null,
+                ['4', '5'],
+                [
+                    ['page' => 1, 'per-page' => 1],
+                    ['page' => 1, 'per-page' => 100],
+                ],
+            ],
+            'offset 6, no length' => [
+                6,
+                null,
+                [],
+                [
+                    ['page' => 1, 'per-page' => 1],
+                    ['page' => 1, 'per-page' => 100],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider sliceProvider
+     */
+    public function it_can_be_mapped()
+    {
+        $this->mockCollectionListCall(1, 1, 3);
+        $this->mockCollectionListCall(1, 100, 3);
+
+        $map = function (Collection $collection) {
+            return $collection->getId();
+        };
+
+        $this->assertSame(
+            ['1', '2', '3'],
+            $this->collections->map($map)->toArray()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_filtered()
+    {
+        $this->mockCollectionListCall(1, 1, 5);
+        $this->mockCollectionListCall(1, 100, 5);
+
+        $filter = function (Collection $podcastEpisode) {
+            return $podcastEpisode->getId() > 3;
+        };
+
+        foreach ($this->collections->filter($filter) as $i => $podcastEpisode) {
+            $this->assertSame((string) ($i + 4), $podcastEpisode->getId());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_reduced()
+    {
+        $this->mockCollectionListCall(1, 1, 5);
+        $this->mockCollectionListCall(1, 100, 5);
+
+        $reduce = function (int $carry = null, Collection $podcastEpisode) {
+            return $carry + $podcastEpisode->getId();
+        };
+
+        $this->assertSame(115, $this->collections->reduce($reduce, 100)->wait());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_sorted()
+    {
+        $this->mockCollectionListCall(1, 1, 5);
+        $this->mockCollectionListCall(1, 100, 5);
+
+        $sort = function (Collection $a, Collection $b) {
+            return $b->getId() <=> $a->getId();
+        };
+
+        foreach ($this->collections->sort($sort) as $i => $podcastEpisode) {
+            $this->assertSame((string) (5 - $i), $podcastEpisode->getId());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_reversed()
+    {
+        $this->mockCollectionListCall(1, 1, 5, false);
+        $this->mockCollectionListCall(1, 100, 5, false);
+
+        foreach ($this->collections->reverse() as $i => $podcastEpisode) {
+            $this->assertSame((string) $i, $podcastEpisode->getId());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_recount_when_reversed()
+    {
+        $this->mockCollectionListCall(1, 1, 10);
+
+        $this->collections->count();
+
+        $this->assertSame(10, $this->collections->reverse()->count());
+    }
+
+    /**
+     * @test
+     */
+    public function it_fetches_pages_again_when_reversed()
+    {
+        $this->mockCollectionListCall(1, 1, 200);
+        $this->mockCollectionListCall(1, 100, 200);
+        $this->mockCollectionListCall(2, 100, 200);
+
+        $this->collections->toArray();
+
+        $this->mockCollectionListCall(1, 1, 200, false);
+        $this->mockCollectionListCall(1, 100, 200, false);
+        $this->mockCollectionListCall(2, 100, 200, false);
+
+        $this->collections->reverse()->toArray();
     }
 }

--- a/test/Client/CollectionsTest.php
+++ b/test/Client/CollectionsTest.php
@@ -28,10 +28,10 @@ final class CollectionsTest extends ApiTestCase
     public function it_gets_a_collection()
     {
         $this->mockCollectionCall('tropical-disease', true);
+
+        $collection = $this->collections->get('tropical-disease')->wait();
+
         return;
-
-        $podcastEpisode = $this->podcastEpisodes->get(7)->wait();
-
         $this->assertInstanceOf(PodcastEpisode::class, $podcastEpisode);
         $this->assertSame(7, $podcastEpisode->getNumber());
 

--- a/test/Client/CollectionsTest.php
+++ b/test/Client/CollectionsTest.php
@@ -5,7 +5,6 @@ namespace test\eLife\ApiSdk\Client;
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Client\Collections;
 use eLife\ApiSdk\Collection\Sequence;
-use eLife\ApiSdk\Model\ArticleVoR;
 use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Collection;
 use eLife\ApiSdk\Model\Subject;

--- a/test/Client/CollectionsTest.php
+++ b/test/Client/CollectionsTest.php
@@ -4,8 +4,7 @@ namespace test\eLife\ApiSdk\Client;
 
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Client\Collections;
-#use eLife\ApiSdk\Collection;
-use eLife\ApiSdk\Model\Collection;
+//use eLife\ApiSdk\Collection;
 use eLife\ApiSdk\Model\Subject;
 use test\eLife\ApiSdk\ApiTestCase;
 

--- a/test/Client/CollectionsTest.php
+++ b/test/Client/CollectionsTest.php
@@ -4,7 +4,9 @@ namespace test\eLife\ApiSdk\Client;
 
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Client\Collections;
-//use eLife\ApiSdk\Collection;
+use eLife\ApiSdk\Model\ArticleVoR;
+use eLife\ApiSdk\Model\BlogArticle;
+use eLife\ApiSdk\Model\Collection;
 use eLife\ApiSdk\Model\Subject;
 use test\eLife\ApiSdk\ApiTestCase;
 
@@ -30,20 +32,19 @@ final class CollectionsTest extends ApiTestCase
 
         $collection = $this->collections->get('tropical-disease')->wait();
 
-        $this->markTestIncomplete();
+        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertSame('tropical-disease', $collection->getId());
 
-        //$this->assertInstanceOf(PodcastEpisode::class, $podcastEpisode);
-        //$this->assertSame(7, $podcastEpisode->getNumber());
+        $this->assertInstanceOf(BlogArticle::class, $collection->getContent()->toArray()[0]);
+        $this->assertSame('Media coverage: Slime can see', $collection->getContent()->toArray()[0]->getTitle());
 
-        //$this->assertInstanceOf(PodcastEpisodeChapter::class, $podcastEpisode->getChapters()->toArray()[0]);
-        //$this->assertSame('Chapter title', $podcastEpisode->getChapters()->toArray()[0]->getTitle());
+        $this->assertInstanceOf(Subject::class, $collection->getSubjects()->toArray()[0]);
+        $this->assertSame('Subject 1 name', $collection->getSubjects()->toArray()[0]->getName());
 
-        //$this->assertInstanceOf(Subject::class, $podcastEpisode->getSubjects()->toArray()[0]);
-        //$this->assertSame('Subject 1 name', $podcastEpisode->getSubjects()->toArray()[0]->getName());
+        $this->mockSubjectCall('1');
+        $this->mockSubjectCall('biophysics-structural-biology');
 
-        //$this->mockSubjectCall(1);
-
-        //$this->assertSame('Subject 1 impact statement',
-        //    $podcastEpisode->getSubjects()->toArray()[0]->getImpactStatement());
+        $this->assertSame('Subject 1 impact statement',
+            $collection->getSubjects()->toArray()[0]->getImpactStatement());
     }
 }

--- a/test/Client/CollectionsTest.php
+++ b/test/Client/CollectionsTest.php
@@ -31,7 +31,7 @@ final class CollectionsTest extends ApiTestCase
 
         $collection = $this->collections->get('tropical-disease')->wait();
 
-        return;
+        $this->markTestIncomplete();
         $this->assertInstanceOf(PodcastEpisode::class, $podcastEpisode);
         $this->assertSame(7, $podcastEpisode->getNumber());
 

--- a/test/Client/InterviewsTest.php
+++ b/test/Client/InterviewsTest.php
@@ -78,7 +78,7 @@ final class InterviewsTest extends ApiTestCase
      */
     public function it_gets_an_interview()
     {
-        $this->mockInterviewCall(7);
+        $this->mockInterviewCall('interview7');
 
         $interview = $this->interviews->get('interview7')->wait();
 
@@ -86,7 +86,7 @@ final class InterviewsTest extends ApiTestCase
         $this->assertSame('interview7', $interview->getId());
 
         $this->assertInstanceOf(Paragraph::class, $interview->getContent()->toArray()[0]);
-        $this->assertSame('Interview 7 text', $interview->getContent()->toArray()[0]->getText());
+        $this->assertSame('Interview interview7 text', $interview->getContent()->toArray()[0]->getText());
     }
 
     /**
@@ -104,10 +104,10 @@ final class InterviewsTest extends ApiTestCase
         $this->assertInstanceOf(Interview::class, $interview);
         $this->assertSame('interview1', $interview->getId());
 
-        $this->mockInterviewCall(1);
+        $this->mockInterviewCall('interview1');
 
         $this->assertInstanceOf(Paragraph::class, $interview->getContent()->toArray()[0]);
-        $this->assertSame('Interview 1 text', $interview->getContent()->toArray()[0]->getText());
+        $this->assertSame('Interview interview1 text', $interview->getContent()->toArray()[0]->getText());
     }
 
     /**

--- a/test/Client/PeopleTest.php
+++ b/test/Client/PeopleTest.php
@@ -87,14 +87,14 @@ final class PeopleTest extends ApiTestCase
         $this->assertSame('person7', $person->getId());
 
         $this->assertInstanceOf(Paragraph::class, $person->getProfile()->toArray()[0]);
-        $this->assertSame('Person 7 profile text', $person->getProfile()->toArray()[0]->getText());
+        $this->assertSame('person7 profile text', $person->getProfile()->toArray()[0]->getText());
 
         $this->assertInstanceOf(Subject::class, $person->getResearch()->getExpertises()->toArray()[0]);
         $this->assertSame('Subject 1 name', $person->getResearch()->getExpertises()->toArray()[0]->getName());
 
         $this->mockSubjectCall(1);
 
-        $this->assertSame('Subject 1 impact statement',
+        $this->assertSame('Subject subject1 impact statement',
             $person->getResearch()->getExpertises()->toArray()[0]->getImpactStatement());
     }
 
@@ -116,7 +116,7 @@ final class PeopleTest extends ApiTestCase
         $this->mockPersonCall(1, true);
 
         $this->assertInstanceOf(Paragraph::class, $person->getProfile()->toArray()[0]);
-        $this->assertSame('Person 1 profile text', $person->getProfile()->toArray()[0]->getText());
+        $this->assertSame('person1 profile text', $person->getProfile()->toArray()[0]->getText());
     }
 
     /**

--- a/test/Client/PodcastEpisodesTest.php
+++ b/test/Client/PodcastEpisodesTest.php
@@ -92,7 +92,7 @@ final class PodcastEpisodesTest extends ApiTestCase
         $this->assertInstanceOf(Subject::class, $podcastEpisode->getSubjects()->toArray()[0]);
         $this->assertSame('Subject 1 name', $podcastEpisode->getSubjects()->toArray()[0]->getName());
 
-        $this->mockSubjectCall(1);
+        $this->mockSubjectCall('1');
 
         $this->assertSame('Subject 1 impact statement',
             $podcastEpisode->getSubjects()->toArray()[0]->getImpactStatement());

--- a/test/Client/PodcastEpisodesTest.php
+++ b/test/Client/PodcastEpisodesTest.php
@@ -141,9 +141,9 @@ final class PodcastEpisodesTest extends ApiTestCase
 
         $this->podcastEpisodes->count();
 
-        $this->mockPodcastEpisodeListCall(1, 1, 10, true, ['subject']);
+        $this->mockPodcastEpisodeListCall(1, 1, 4, true, ['subject']);
 
-        $this->assertSame(10, $this->podcastEpisodes->forSubject('subject')->count());
+        $this->assertSame(4, $this->podcastEpisodes->forSubject('subject')->count());
     }
 
     /**

--- a/test/Model/CollectionTest.php
+++ b/test/Model/CollectionTest.php
@@ -16,9 +16,11 @@ use test\eLife\ApiSdk\Builder;
 
 final class CollectionTest extends PHPUnit_Framework_TestCase
 {
+    private $builder;
+
     public function setUp()
     {
-        $this->builder = new Builder();
+        $this->builder = Builder::for(Collection::class);
     }
 
     /**
@@ -27,7 +29,6 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
     public function it_has_an_id()
     {
         $collection = $this->builder
-            ->create(Collection::class)
             ->withId('tropical-disease')
             ->__invoke();
         $this->assertSame('tropical-disease', $collection->getId());
@@ -39,7 +40,6 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
     public function it_has_a_title()
     {
         $collection = $this->builder
-            ->create(Collection::class)
             ->withTitle('Tropical disease')
             ->__invoke();
         $this->assertSame('Tropical disease', $collection->getTitle());
@@ -48,13 +48,17 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_has_a_sub_title()
+    public function it_may_have_a_sub_title()
     {
-        $collection = $this->builder
-            ->create(Collection::class)
+        $with = $this->builder
             ->withPromiseOfSubTitle('Tropical disease subtitle')
             ->__invoke();
-        $this->assertSame('Tropical disease subtitle', $collection->getSubTitle());
+        $without = $this->builder
+            ->withPromiseOfSubTitle(null)
+            ->__invoke();
+
+        $this->assertSame('Tropical disease subtitle', $with->getSubTitle());
+        $this->assertNull($without->getSubTitle());
     }
 
     /**
@@ -63,11 +67,9 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
     public function it_may_have_an_impact_statement()
     {
         $with = $this->builder
-            ->create(Collection::class)
             ->withImpactStatement('Tropical disease impact statement')
             ->__invoke();
         $withOut = $this->builder
-            ->create(Collection::class)
             ->withImpactStatement(null)
             ->__invoke();
 
@@ -81,7 +83,6 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
     public function it_has_a_published_date()
     {
         $collection = $this->builder
-            ->create(Collection::class)
             ->withPublishedDate($publishedDate = new DateTimeImmutable())
             ->__invoke();
 
@@ -94,7 +95,6 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
     public function it_has_a_banner()
     {
         $collection = $this->builder
-            ->create(Collection::class)
             ->withPromiseOfBanner(
                 $image = new Image('', [900 => 'https://placehold.it/900x450'])
             )
@@ -109,7 +109,6 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
     public function it_has_a_thumbnail()
     {
         $collection = $this->builder
-            ->create(Collection::class)
             ->withThumbnail(
                 $image = new Image('', [70 => 'https://placehold.it/70x140'])
             )
@@ -125,7 +124,6 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
     public function it_may_have_subjects(Sequence $subjects = null, array $expected)
     {
         $collection = $this->builder
-            ->create(Collection::class)
             ->withSubjects($subjects)
             ->__invoke()
         ;
@@ -135,14 +133,11 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
 
     public function subjectsProvider() : array
     {
-        $this->builder = new Builder();
         $subjects = [
-            $this->builder
-                ->create(Subject::class)
+            Builder::for(Subject::class)
                 ->withId('subject1')
                 ->__invoke(),
-            $this->builder
-                ->create(Subject::class)
+            Builder::for(Subject::class)
                 ->withId('subject2')
                 ->__invoke(),
         ];
@@ -165,7 +160,6 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
     public function it_has_a_selected_curator()
     {
         $collection = $this->builder
-            ->create(Collection::class)
             ->withSelectedCurator($person = Builder::dummy(Person::class))
             ->withSelectedCuratorEtAl(true)
             ->__invoke()
@@ -181,7 +175,6 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
     public function it_has_curators()
     {
         $collection = $this->builder
-            ->create(Collection::class)
             ->withCurators($curators = new ArraySequence([Builder::dummy(Person::class)]))
             ->__invoke()
         ;
@@ -195,7 +188,6 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
     public function it_has_content()
     {
         $collection = $this->builder
-            ->create(Collection::class)
             ->withContent($content = new ArraySequence([
                 Builder::dummy(BlogArticle::class),
             ]))
@@ -211,7 +203,6 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
     public function it_has_related_content()
     {
         $collection = $this->builder
-            ->create(Collection::class)
             ->withRelatedContent($relatedContent = new ArraySequence([
                 Builder::dummy(BlogArticle::class),
             ]))
@@ -227,7 +218,6 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
     public function it_has_podcast_episodes()
     {
         $collection = $this->builder
-            ->create(Collection::class)
             ->withPodcastEpisodes($podcastEpisodes = new ArraySequence([
                 Builder::dummy(PodcastEpisode::class),
             ]))

--- a/test/Model/CollectionTest.php
+++ b/test/Model/CollectionTest.php
@@ -6,6 +6,7 @@ use DateTimeImmutable;
 use eLife\ApiSdk\Collection\ArraySequence;
 //use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
+use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Collection;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\Person;
@@ -188,5 +189,21 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
         ;
 
         $this->assertEquals($curators, $collection->getCurators());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_content()
+    {
+        $collection = $this->builder
+            ->create(Collection::class)
+            ->withContent($content = new ArraySequence([
+                Builder::dummy(BlogArticle::class),
+            ]))
+            ->__invoke()
+        ;
+
+        $this->assertEquals($content, $collection->getContent());
     }
 }

--- a/test/Model/CollectionTest.php
+++ b/test/Model/CollectionTest.php
@@ -4,32 +4,30 @@ namespace test\eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
 use eLife\ApiSdk\Collection\ArraySequence;
-#use eLife\ApiSdk\Collection\PromiseSequence;
+//use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
-use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\Collection;
-#use eLife\ApiSdk\Model\PodcastEpisodeChapter;
-#use eLife\ApiSdk\Model\PodcastEpisodeSource;
+use eLife\ApiSdk\Model\Image;
+//use eLife\ApiSdk\Model\PodcastEpisodeChapter;
+//use eLife\ApiSdk\Model\PodcastEpisodeSource;
 use eLife\ApiSdk\Model\Subject;
 use PHPUnit_Framework_TestCase;
 use test\eLife\ApiSdk\Builder;
-use function GuzzleHttp\Promise\promise_for;
-use function GuzzleHttp\Promise\rejection_for;
 
 final class CollectionTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->builder = new Builder;
+        $this->builder = new Builder();
     }
-    
+
     /**
      * @test
      */
     public function it_has_an_id()
     {
         $collection = $this->builder
-            ->create(Collection::CLASS)
+            ->create(Collection::class)
             ->withId('tropical-disease')
             ->__invoke();
         $this->assertSame('tropical-disease', $collection->getId());
@@ -41,7 +39,7 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
     public function it_has_a_title()
     {
         $collection = $this->builder
-            ->create(Collection::CLASS)
+            ->create(Collection::class)
             ->withTitle('Tropical disease')
             ->__invoke();
         $this->assertSame('Tropical disease', $collection->getTitle());
@@ -52,8 +50,8 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_a_sub_title()
     {
-        $collection = $this->builder 
-            ->create(Collection::CLASS)
+        $collection = $this->builder
+            ->create(Collection::class)
             ->withPromiseOfSubTitle('Tropical disease subtitle')
             ->__invoke();
         $this->assertSame('Tropical disease subtitle', $collection->getSubTitle());
@@ -64,12 +62,12 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_may_have_an_impact_statement()
     {
-        $with = $this->builder 
-            ->create(Collection::CLASS)
+        $with = $this->builder
+            ->create(Collection::class)
             ->withImpactStatement('Tropical disease impact statement')
             ->__invoke();
         $withOut = $this->builder
-            ->create(Collection::CLASS)
+            ->create(Collection::class)
             ->withImpactStatement(null)
             ->__invoke();
 
@@ -82,8 +80,8 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_a_published_date()
     {
-        $collection = $this->builder 
-            ->create(Collection::CLASS)
+        $collection = $this->builder
+            ->create(Collection::class)
             ->withPublishedDate($publishedDate = new DateTimeImmutable())
             ->__invoke();
 
@@ -95,8 +93,8 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_a_banner()
     {
-        $collection = $this->builder 
-            ->create(Collection::CLASS)
+        $collection = $this->builder
+            ->create(Collection::class)
             ->withPromiseOfBanner(
                 $image = new Image('', [900 => 'https://placehold.it/900x450'])
             )
@@ -110,8 +108,8 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_a_thumbnail()
     {
-        $collection = $this->builder 
-            ->create(Collection::CLASS)
+        $collection = $this->builder
+            ->create(Collection::class)
             ->withThumbnail(
                 $image = new Image('', [70 => 'https://placehold.it/70x140'])
             )
@@ -127,7 +125,7 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
     public function it_may_have_subjects(Sequence $subjects = null, array $expected)
     {
         $collection = $this->builder
-            ->create(Collection::CLASS)
+            ->create(Collection::class)
             ->withSubjects($subjects)
             ->__invoke()
         ;
@@ -137,14 +135,14 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
 
     public function subjectsProvider() : array
     {
-        $this->builder = new Builder;
+        $this->builder = new Builder();
         $subjects = [
             $this->builder
-                ->create(Subject::CLASS)
+                ->create(Subject::class)
                 ->withId('subject1')
                 ->__invoke(),
             $this->builder
-                ->create(Subject::CLASS)
+                ->create(Subject::class)
                 ->withId('subject2')
                 ->__invoke(),
         ];

--- a/test/Model/CollectionTest.php
+++ b/test/Model/CollectionTest.php
@@ -35,8 +35,20 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
         $this->assertSame('Tropical disease', $collection->getTitle());
     }
 
-    private function anEmptyCollection($id = 'tropical-disease', $title = 'Tropical disease')
+    /**
+     * @test
+     */
+    public function it_may_have_an_impact_statement()
     {
-        return new Collection('tropical-disease', 'Tropical disease');
+        $with = $this->anEmptyCollection('tropical-disease', 'Tropical disease', 'impact statement');
+        $withOut = $this->anEmptyCollection('tropical-disease', 'Tropical disease', null);
+
+        $this->assertSame('impact statement', $with->getImpactStatement());
+        $this->assertNull($withOut->getImpactStatement());
+    }
+
+    private function anEmptyCollection($id = 'tropical-disease', $title = 'Tropical disease', $impactStatement = null)
+    {
+        return new Collection($id, $title, $impactStatement);
     }
 }

--- a/test/Model/CollectionTest.php
+++ b/test/Model/CollectionTest.php
@@ -126,9 +126,10 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_may_have_subjects(Sequence $subjects = null, array $expected)
     {
-        $collection = $this
-            ->anEmptyCollection('tropical-disease', 'Tropical disease', promise_for('Tropical disease subtitle'), null, new DateTimeImmutable(), null, $image = new Image('', [900 => 'https://placehold.it/900x450']))
+        $collection = $this->builder
+            ->create(Collection::CLASS)
             ->withSubjects($subjects)
+            ->__invoke()
         ;
 
         $this->assertEquals($expected, $collection->getSubjects()->toArray());
@@ -136,11 +137,16 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
 
     public function subjectsProvider() : array
     {
+        $this->builder = new Builder;
         $subjects = [
-            new Subject('subject1', 'Subject 1', rejection_for('Subject impact statement should not be unwrapped'),
-                rejection_for('No banner'), rejection_for('Subject image should not be unwrapped')),
-            new Subject('subject2', 'Subject 2', rejection_for('Subject impact statement should not be unwrapped'),
-                rejection_for('No banner'), rejection_for('Subject image should not be unwrapped')),
+            $this->builder
+                ->create(Subject::CLASS)
+                ->withId('subject1')
+                ->__invoke(),
+            $this->builder
+                ->create(Subject::CLASS)
+                ->withId('subject2')
+                ->__invoke(),
         ];
 
         return [
@@ -153,22 +159,5 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
                 $subjects,
             ],
         ];
-    }
-
-    private function anEmptyCollection($id = 'tropical-disease', $title = 'Tropical disease', $subTitle = null, $impactStatement = null, $published = null, $banner = null, $thumbnail = null)
-    {
-        if ($subTitle === null) {
-            $subTitle = promise_for('Tropical disease subtitle');
-        }
-        if ($published === null) {
-            $published = new DateTimeImmutable();
-        }
-        if ($banner === null) {
-            $banner = rejection_for('No banner');
-        }
-        if ($thumbnail === null) {
-            $thumbnail = new Image('', [900 => 'https://placehold.it/900x450']);
-        }
-        return new Collection($id, $title, $subTitle, $impactStatement, $published, $banner, $thumbnail);
     }
 }

--- a/test/Model/CollectionTest.php
+++ b/test/Model/CollectionTest.php
@@ -12,8 +12,8 @@ use eLife\ApiSdk\Model\Collection;
 #use eLife\ApiSdk\Model\PodcastEpisodeSource;
 #use eLife\ApiSdk\Model\Subject;
 use PHPUnit_Framework_TestCase;
-#use function GuzzleHttp\Promise\promise_for;
-#use function GuzzleHttp\Promise\rejection_for;
+use function GuzzleHttp\Promise\promise_for;
+use function GuzzleHttp\Promise\rejection_for;
 
 final class CollectionTest extends PHPUnit_Framework_TestCase
 {
@@ -60,21 +60,35 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function it_has_a_banner()
+    {
+        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease', null, new DateTimeImmutable(), promise_for($image = new Image('', [900 => 'https://placehold.it/900x450'])));
+
+        $this->assertEquals($image, $collection->getBanner());
+    }
+
+
+    /**
+     * @test
+     */
     public function it_has_a_thumbnail()
     {
-        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease', null, new DateTimeImmutable(), $image = new Image('', [900 => 'https://placehold.it/900x450']));
+        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease', null, new DateTimeImmutable(), null, $image = new Image('', [900 => 'https://placehold.it/900x450']));
 
         $this->assertEquals($image, $collection->getThumbnail());
     }
 
-    private function anEmptyCollection($id = 'tropical-disease', $title = 'Tropical disease', $impactStatement = null, $published = null, $thumbnail = null)
+    private function anEmptyCollection($id = 'tropical-disease', $title = 'Tropical disease', $impactStatement = null, $published = null, $banner = null, $thumbnail = null)
     {
         if ($published === null) {
             $published = new DateTimeImmutable();
         }
+        if ($banner === null) {
+            $banner = rejection_for('No banner');
+        }
         if ($thumbnail === null) {
             $thumbnail = new Image('', [900 => 'https://placehold.it/900x450']);
         }
-        return new Collection($id, $title, $impactStatement, $published, $thumbnail);
+        return new Collection($id, $title, $impactStatement, $published, $banner, $thumbnail);
     }
 }

--- a/test/Model/CollectionTest.php
+++ b/test/Model/CollectionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace test\eLife\ApiSdk\Model;
+
+#use DateTimeImmutable;
+#use eLife\ApiSdk\Collection\ArraySequence;
+#use eLife\ApiSdk\Collection\PromiseSequence;
+#use eLife\ApiSdk\Collection\Sequence;
+#use eLife\ApiSdk\Model\Image;
+use eLife\ApiSdk\Model\Collection;
+#use eLife\ApiSdk\Model\PodcastEpisodeChapter;
+#use eLife\ApiSdk\Model\PodcastEpisodeSource;
+#use eLife\ApiSdk\Model\Subject;
+use PHPUnit_Framework_TestCase;
+#use function GuzzleHttp\Promise\promise_for;
+#use function GuzzleHttp\Promise\rejection_for;
+
+final class CollectionTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_has_an_id()
+    {
+        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease');
+        $this->assertSame('tropical-disease', $collection->getId());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_title()
+    {
+        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease');
+        $this->assertSame('Tropical disease', $collection->getTitle());
+    }
+
+    private function anEmptyCollection($id = 'tropical-disease', $title = 'Tropical disease')
+    {
+        return new Collection('tropical-disease', 'Tropical disease');
+    }
+}

--- a/test/Model/CollectionTest.php
+++ b/test/Model/CollectionTest.php
@@ -38,10 +38,19 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function it_has_a_sub_title()
+    {
+        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease');
+        $this->assertSame('Tropical disease', $collection->getTitle());
+    }
+
+    /**
+     * @test
+     */
     public function it_may_have_an_impact_statement()
     {
-        $with = $this->anEmptyCollection('tropical-disease', 'Tropical disease', 'impact statement');
-        $withOut = $this->anEmptyCollection('tropical-disease', 'Tropical disease', null);
+        $with = $this->anEmptyCollection('tropical-disease', 'Tropical disease', promise_for('Tropical disease subtitle'), 'impact statement');
+        $withOut = $this->anEmptyCollection('tropical-disease', 'Tropical disease', promise_for('Tropical disease subtitle'), null);
 
         $this->assertSame('impact statement', $with->getImpactStatement());
         $this->assertNull($withOut->getImpactStatement());
@@ -52,7 +61,7 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_a_published_date()
     {
-        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease', null, $published = new DateTimeImmutable());
+        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease', promise_for('Tropical disease subtitle'), null, $published = new DateTimeImmutable());
 
         $this->assertEquals($published, $collection->getPublishedDate());
     }
@@ -62,7 +71,7 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_a_banner()
     {
-        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease', null, new DateTimeImmutable(), promise_for($image = new Image('', [900 => 'https://placehold.it/900x450'])));
+        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease', promise_for('Tropical disease subtitle'), null, new DateTimeImmutable(), promise_for($image = new Image('', [900 => 'https://placehold.it/900x450'])));
 
         $this->assertEquals($image, $collection->getBanner());
     }
@@ -73,7 +82,7 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_a_thumbnail()
     {
-        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease', null, new DateTimeImmutable(), null, $image = new Image('', [900 => 'https://placehold.it/900x450']));
+        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease', promise_for('Tropical disease subtitle'), null, new DateTimeImmutable(), null, $image = new Image('', [900 => 'https://placehold.it/900x450']));
 
         $this->assertEquals($image, $collection->getThumbnail());
     }
@@ -85,7 +94,7 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
     public function it_may_have_subjects(Sequence $subjects = null, array $expected)
     {
         $collection = $this
-            ->anEmptyCollection('tropical-disease', 'Tropical disease', null, new DateTimeImmutable(), null, $image = new Image('', [900 => 'https://placehold.it/900x450']))
+            ->anEmptyCollection('tropical-disease', 'Tropical disease', promise_for('Tropical disease subtitle'), null, new DateTimeImmutable(), null, $image = new Image('', [900 => 'https://placehold.it/900x450']))
             ->withSubjects($subjects)
         ;
 
@@ -113,8 +122,11 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
         ];
     }
 
-    private function anEmptyCollection($id = 'tropical-disease', $title = 'Tropical disease', $impactStatement = null, $published = null, $banner = null, $thumbnail = null)
+    private function anEmptyCollection($id = 'tropical-disease', $title = 'Tropical disease', $subTitle = null, $impactStatement = null, $published = null, $banner = null, $thumbnail = null)
     {
+        if ($subTitle === null) {
+            $subTitle = promise_for('Tropical disease subtitle');
+        }
         if ($published === null) {
             $published = new DateTimeImmutable();
         }
@@ -124,6 +136,6 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
         if ($thumbnail === null) {
             $thumbnail = new Image('', [900 => 'https://placehold.it/900x450']);
         }
-        return new Collection($id, $title, $impactStatement, $published, $banner, $thumbnail);
+        return new Collection($id, $title, $subTitle, $impactStatement, $published, $banner, $thumbnail);
     }
 }

--- a/test/Model/CollectionTest.php
+++ b/test/Model/CollectionTest.php
@@ -6,7 +6,7 @@ use DateTimeImmutable;
 #use eLife\ApiSdk\Collection\ArraySequence;
 #use eLife\ApiSdk\Collection\PromiseSequence;
 #use eLife\ApiSdk\Collection\Sequence;
-#use eLife\ApiSdk\Model\Image;
+use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\Collection;
 #use eLife\ApiSdk\Model\PodcastEpisodeChapter;
 #use eLife\ApiSdk\Model\PodcastEpisodeSource;
@@ -57,12 +57,24 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($published, $collection->getPublishedDate());
     }
 
+    /**
+     * @test
+     */
+    public function it_has_a_thumbnail()
+    {
+        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease', null, new DateTimeImmutable(), $image = new Image('', [900 => 'https://placehold.it/900x450']));
 
-    private function anEmptyCollection($id = 'tropical-disease', $title = 'Tropical disease', $impactStatement = null, $published = null)
+        $this->assertEquals($image, $collection->getThumbnail());
+    }
+
+    private function anEmptyCollection($id = 'tropical-disease', $title = 'Tropical disease', $impactStatement = null, $published = null, $thumbnail = null)
     {
         if ($published === null) {
             $published = new DateTimeImmutable();
         }
-        return new Collection($id, $title, $impactStatement, $published);
+        if ($thumbnail === null) {
+            $thumbnail = new Image('', [900 => 'https://placehold.it/900x450']);
+        }
+        return new Collection($id, $title, $impactStatement, $published, $thumbnail);
     }
 }

--- a/test/Model/CollectionTest.php
+++ b/test/Model/CollectionTest.php
@@ -4,14 +4,12 @@ namespace test\eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
 use eLife\ApiSdk\Collection\ArraySequence;
-//use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Collection;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\Person;
-//use eLife\ApiSdk\Model\PodcastEpisodeChapter;
-//use eLife\ApiSdk\Model\PodcastEpisodeSource;
+use eLife\ApiSdk\Model\PodcastEpisode;
 use eLife\ApiSdk\Model\Subject;
 use PHPUnit_Framework_TestCase;
 use test\eLife\ApiSdk\Builder;
@@ -221,5 +219,21 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
         ;
 
         $this->assertEquals($relatedContent, $collection->getRelatedContent());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_podcast_episodes()
+    {
+        $collection = $this->builder
+            ->create(Collection::class)
+            ->withPodcastEpisodes($podcastEpisodes = new ArraySequence([
+                Builder::dummy(PodcastEpisode::class),
+            ]))
+            ->__invoke()
+        ;
+
+        $this->assertEquals($podcastEpisodes, $collection->getPodcastEpisodes());
     }
 }

--- a/test/Model/CollectionTest.php
+++ b/test/Model/CollectionTest.php
@@ -8,6 +8,7 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Collection;
 use eLife\ApiSdk\Model\Image;
+use eLife\ApiSdk\Model\Person;
 //use eLife\ApiSdk\Model\PodcastEpisodeChapter;
 //use eLife\ApiSdk\Model\PodcastEpisodeSource;
 use eLife\ApiSdk\Model\Subject;
@@ -157,5 +158,21 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
                 $subjects,
             ],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_selected_curator()
+    {
+        $collection = $this->builder
+            ->create(Collection::class)
+            ->withSelectedCurator($person = Builder::dummy(Person::class))
+            ->withSelectedCuratorEtAl(true)
+            ->__invoke()
+        ;
+
+        $this->assertEquals($person, $collection->getSelectedCurator());
+        $this->assertTrue($collection->selectedCuratorEtAl());
     }
 }

--- a/test/Model/CollectionTest.php
+++ b/test/Model/CollectionTest.php
@@ -2,7 +2,7 @@
 
 namespace test\eLife\ApiSdk\Model;
 
-#use DateTimeImmutable;
+use DateTimeImmutable;
 #use eLife\ApiSdk\Collection\ArraySequence;
 #use eLife\ApiSdk\Collection\PromiseSequence;
 #use eLife\ApiSdk\Collection\Sequence;
@@ -47,8 +47,22 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
         $this->assertNull($withOut->getImpactStatement());
     }
 
-    private function anEmptyCollection($id = 'tropical-disease', $title = 'Tropical disease', $impactStatement = null)
+    /**
+     * @test
+     */
+    public function it_has_a_published_date()
     {
-        return new Collection($id, $title, $impactStatement);
+        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease', null, $published = new DateTimeImmutable());
+
+        $this->assertEquals($published, $collection->getPublishedDate());
+    }
+
+
+    private function anEmptyCollection($id = 'tropical-disease', $title = 'Tropical disease', $impactStatement = null, $published = null)
+    {
+        if ($published === null) {
+            $published = new DateTimeImmutable();
+        }
+        return new Collection($id, $title, $impactStatement, $published);
     }
 }

--- a/test/Model/CollectionTest.php
+++ b/test/Model/CollectionTest.php
@@ -3,14 +3,14 @@
 namespace test\eLife\ApiSdk\Model;
 
 use DateTimeImmutable;
-#use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\ArraySequence;
 #use eLife\ApiSdk\Collection\PromiseSequence;
-#use eLife\ApiSdk\Collection\Sequence;
+use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\Collection;
 #use eLife\ApiSdk\Model\PodcastEpisodeChapter;
 #use eLife\ApiSdk\Model\PodcastEpisodeSource;
-#use eLife\ApiSdk\Model\Subject;
+use eLife\ApiSdk\Model\Subject;
 use PHPUnit_Framework_TestCase;
 use function GuzzleHttp\Promise\promise_for;
 use function GuzzleHttp\Promise\rejection_for;
@@ -76,6 +76,41 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
         $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease', null, new DateTimeImmutable(), null, $image = new Image('', [900 => 'https://placehold.it/900x450']));
 
         $this->assertEquals($image, $collection->getThumbnail());
+    }
+
+    /**
+     * @test
+     * @dataProvider subjectsProvider
+     */
+    public function it_may_have_subjects(Sequence $subjects = null, array $expected)
+    {
+        $collection = $this
+            ->anEmptyCollection('tropical-disease', 'Tropical disease', null, new DateTimeImmutable(), null, $image = new Image('', [900 => 'https://placehold.it/900x450']))
+            ->withSubjects($subjects)
+        ;
+
+        $this->assertEquals($expected, $collection->getSubjects()->toArray());
+    }
+
+    public function subjectsProvider() : array
+    {
+        $subjects = [
+            new Subject('subject1', 'Subject 1', rejection_for('Subject impact statement should not be unwrapped'),
+                rejection_for('No banner'), rejection_for('Subject image should not be unwrapped')),
+            new Subject('subject2', 'Subject 2', rejection_for('Subject impact statement should not be unwrapped'),
+                rejection_for('No banner'), rejection_for('Subject image should not be unwrapped')),
+        ];
+
+        return [
+            'none' => [
+                new ArraySequence([]),
+                [],
+            ],
+            'collection' => [
+                new ArraySequence($subjects),
+                $subjects,
+            ],
+        ];
     }
 
     private function anEmptyCollection($id = 'tropical-disease', $title = 'Tropical disease', $impactStatement = null, $published = null, $banner = null, $thumbnail = null)

--- a/test/Model/CollectionTest.php
+++ b/test/Model/CollectionTest.php
@@ -206,4 +206,20 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($content, $collection->getContent());
     }
+
+    /**
+     * @test
+     */
+    public function it_has_related_content()
+    {
+        $collection = $this->builder
+            ->create(Collection::class)
+            ->withRelatedContent($relatedContent = new ArraySequence([
+                Builder::dummy(BlogArticle::class),
+            ]))
+            ->__invoke()
+        ;
+
+        $this->assertEquals($relatedContent, $collection->getRelatedContent());
+    }
 }

--- a/test/Model/CollectionTest.php
+++ b/test/Model/CollectionTest.php
@@ -175,4 +175,18 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($person, $collection->getSelectedCurator());
         $this->assertTrue($collection->selectedCuratorEtAl());
     }
+
+    /**
+     * @test
+     */
+    public function it_has_curators()
+    {
+        $collection = $this->builder
+            ->create(Collection::class)
+            ->withCurators($curators = new ArraySequence([Builder::dummy(Person::class)]))
+            ->__invoke()
+        ;
+
+        $this->assertEquals($curators, $collection->getCurators());
+    }
 }

--- a/test/Model/CollectionTest.php
+++ b/test/Model/CollectionTest.php
@@ -12,17 +12,26 @@ use eLife\ApiSdk\Model\Collection;
 #use eLife\ApiSdk\Model\PodcastEpisodeSource;
 use eLife\ApiSdk\Model\Subject;
 use PHPUnit_Framework_TestCase;
+use test\eLife\ApiSdk\Builder;
 use function GuzzleHttp\Promise\promise_for;
 use function GuzzleHttp\Promise\rejection_for;
 
 final class CollectionTest extends PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        $this->builder = new Builder;
+    }
+    
     /**
      * @test
      */
     public function it_has_an_id()
     {
-        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease');
+        $collection = $this->builder
+            ->create(Collection::CLASS)
+            ->withId('tropical-disease')
+            ->__invoke();
         $this->assertSame('tropical-disease', $collection->getId());
     }
 
@@ -31,7 +40,10 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_a_title()
     {
-        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease');
+        $collection = $this->builder
+            ->create(Collection::CLASS)
+            ->withTitle('Tropical disease')
+            ->__invoke();
         $this->assertSame('Tropical disease', $collection->getTitle());
     }
 
@@ -40,8 +52,11 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_a_sub_title()
     {
-        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease');
-        $this->assertSame('Tropical disease', $collection->getTitle());
+        $collection = $this->builder 
+            ->create(Collection::CLASS)
+            ->withPromiseOfSubTitle('Tropical disease subtitle')
+            ->__invoke();
+        $this->assertSame('Tropical disease subtitle', $collection->getSubTitle());
     }
 
     /**
@@ -49,10 +64,16 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_may_have_an_impact_statement()
     {
-        $with = $this->anEmptyCollection('tropical-disease', 'Tropical disease', promise_for('Tropical disease subtitle'), 'impact statement');
-        $withOut = $this->anEmptyCollection('tropical-disease', 'Tropical disease', promise_for('Tropical disease subtitle'), null);
+        $with = $this->builder 
+            ->create(Collection::CLASS)
+            ->withImpactStatement('Tropical disease impact statement')
+            ->__invoke();
+        $withOut = $this->builder
+            ->create(Collection::CLASS)
+            ->withImpactStatement(null)
+            ->__invoke();
 
-        $this->assertSame('impact statement', $with->getImpactStatement());
+        $this->assertSame('Tropical disease impact statement', $with->getImpactStatement());
         $this->assertNull($withOut->getImpactStatement());
     }
 
@@ -61,9 +82,12 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_a_published_date()
     {
-        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease', promise_for('Tropical disease subtitle'), null, $published = new DateTimeImmutable());
+        $collection = $this->builder 
+            ->create(Collection::CLASS)
+            ->withPublishedDate($publishedDate = new DateTimeImmutable())
+            ->__invoke();
 
-        $this->assertEquals($published, $collection->getPublishedDate());
+        $this->assertEquals($publishedDate, $collection->getPublishedDate());
     }
 
     /**
@@ -71,18 +95,27 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_a_banner()
     {
-        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease', promise_for('Tropical disease subtitle'), null, new DateTimeImmutable(), promise_for($image = new Image('', [900 => 'https://placehold.it/900x450'])));
+        $collection = $this->builder 
+            ->create(Collection::CLASS)
+            ->withPromiseOfBanner(
+                $image = new Image('', [900 => 'https://placehold.it/900x450'])
+            )
+            ->__invoke();
 
         $this->assertEquals($image, $collection->getBanner());
     }
-
 
     /**
      * @test
      */
     public function it_has_a_thumbnail()
     {
-        $collection = $this->anEmptyCollection('tropical-disease', 'Tropical disease', promise_for('Tropical disease subtitle'), null, new DateTimeImmutable(), null, $image = new Image('', [900 => 'https://placehold.it/900x450']));
+        $collection = $this->builder 
+            ->create(Collection::CLASS)
+            ->withThumbnail(
+                $image = new Image('', [70 => 'https://placehold.it/70x140'])
+            )
+            ->__invoke();
 
         $this->assertEquals($image, $collection->getThumbnail());
     }

--- a/test/Serializer/ArticlePoANormalizerTest.php
+++ b/test/Serializer/ArticlePoANormalizerTest.php
@@ -118,7 +118,7 @@ final class ArticlePoANormalizerTest extends ApiTestCase
 
         $actual = $this->normalizer->denormalize($json, ArticlePoA::class, null, $context);
 
-        $this->mockSubjectCall(1);
+        $this->mockSubjectCall('subject1');
 
         $this->assertObjectsAreEqual($expected, $actual);
     }
@@ -139,7 +139,7 @@ final class ArticlePoANormalizerTest extends ApiTestCase
         ]);
         $date = new DateTimeImmutable();
         $statusDate = new DateTimeImmutable('-1 day');
-        $subject = new Subject('subject1', 'Subject 1 name', promise_for('Subject 1 impact statement'),
+        $subject = new Subject('subject1', 'Subject 1 name', promise_for('Subject subject1 impact statement'),
             promise_for($banner), promise_for($thumbnail));
 
         return [
@@ -230,7 +230,7 @@ final class ArticlePoANormalizerTest extends ApiTestCase
                 new ArticlePoA('article1', 1, 'research-article', '10.7554/eLife1', 'Author et al',
                     'Article 1 title prefix', 'Article 1 title', $date, $statusDate, 1, 'e1', 'http://www.example.com/',
                     new ArraySequence([$subject]), ['Article 1 research organism'],
-                    promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article 1 abstract text')]))),
+                    promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article article1 abstract text')]))),
                     promise_for(1), promise_for(new Copyright('CC-BY-4.0', 'Statement', 'Author et al')),
                     new ArraySequence([new PersonAuthor(new PersonDetails('Author', 'Author'))])),
                 ['snippet' => true],
@@ -254,7 +254,7 @@ final class ArticlePoANormalizerTest extends ApiTestCase
                     'status' => 'poa',
                 ],
                 function (ApiTestCase $test) {
-                    $test->mockArticleCall(1, true);
+                    $test->mockArticleCall('article1', true);
                 },
             ],
             'minimum snippet' => [
@@ -277,7 +277,7 @@ final class ArticlePoANormalizerTest extends ApiTestCase
                     'status' => 'poa',
                 ],
                 function (ApiTestCase $test) {
-                    $test->mockArticleCall(1);
+                    $test->mockArticleCall('article1');
                 },
             ],
         ];

--- a/test/Serializer/ArticleVoRNormalizerTest.php
+++ b/test/Serializer/ArticleVoRNormalizerTest.php
@@ -125,7 +125,7 @@ final class ArticleVoRNormalizerTest extends ApiTestCase
 
         $actual = $this->normalizer->denormalize($json, ArticleVoR::class, null, $context);
 
-        $this->mockSubjectCall(1);
+        $this->mockSubjectCall('subject1');
 
         $this->assertObjectsAreEqual($expected, $actual);
     }
@@ -144,7 +144,7 @@ final class ArticleVoRNormalizerTest extends ApiTestCase
                 '140' => 'https://placehold.it/140x140',
             ]),
         ]);
-        $subject = new Subject('subject1', 'Subject 1 name', promise_for('Subject 1 impact statement'),
+        $subject = new Subject('subject1', 'Subject 1 name', promise_for('Subject subject1 impact statement'),
             promise_for($banner), promise_for($thumbnail));
         $date = new DateTimeImmutable();
         $statusDate = new DateTimeImmutable('-1 day');
@@ -363,25 +363,25 @@ final class ArticleVoRNormalizerTest extends ApiTestCase
                 new ArticleVoR('article1', 1, 'research-article', '10.7554/eLife1', 'Author et al',
                     'Article 1 title prefix', 'Article 1 title', $date, $statusDate, 1, 'e1', 'http://www.example.com/',
                     new ArraySequence([$subject]), ['Article 1 research organism'],
-                    promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article 1 abstract text')]),
-                        '10.7554/eLife.1abstract')), promise_for(1),
+                    promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article article1 abstract text')]),
+                        '10.7554/eLife.article1abstract')), promise_for(1),
                     promise_for(new Copyright('CC-BY-4.0', 'Statement', 'Author et al')),
                     new ArraySequence([new PersonAuthor(new PersonDetails('Author', 'Author'))]),
                     'Article 1 impact statement', promise_for($banner), $thumbnail,
-                    new ArraySequence(['Article 1 keyword']),
-                    promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article 1 digest')]),
-                        '10.7554/eLife.1digest')), new ArraySequence([
-                        new Section('Article 1 section title', 'article1section', [new Paragraph('Article 1 text')]),
+                    new ArraySequence(['Article article1 keyword']),
+                    promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article article1 digest')]),
+                        '10.7554/eLife.article1digest')), new ArraySequence([
+                        new Section('Article article1 section title', 'articlearticle1section', [new Paragraph('Article article1 text')]),
                     ]), new ArraySequence([
                         new BookReference(ReferenceDate::fromString('2000'),
                             [new PersonAuthor(new PersonDetails('preferred name', 'index name'))], false, 'book title',
                             new Place(null, null, ['publisher'])),
                     ]),
-                    promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article 1 decision letter text')]),
-                        '10.7554/eLife.1decisionLetter')),
-                    new ArraySequence([new Paragraph('Article 1 decision letter description')]),
-                    promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article 1 author response text')]),
-                        '10.7554/eLife.1authorResponse'))),
+                    promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article article1 decision letter text')]),
+                        '10.7554/eLife.article1decisionLetter')),
+                    new ArraySequence([new Paragraph('Article article1 decision letter description')]),
+                    promise_for(new ArticleSection(new ArraySequence([new Paragraph('Article article1 author response text')]),
+                        '10.7554/eLife.article1authorResponse'))),
                 ['snippet' => true],
                 [
                     'id' => 'article1',
@@ -419,7 +419,7 @@ final class ArticleVoRNormalizerTest extends ApiTestCase
                     ],
                 ],
                 function (ApiTestCase $test) {
-                    $test->mockArticleCall(1, true, true);
+                    $test->mockArticleCall('article1', true, true);
                 },
             ],
             'minimum snippet' => [
@@ -428,11 +428,12 @@ final class ArticleVoRNormalizerTest extends ApiTestCase
                     promise_for(null), promise_for(new Copyright('CC-BY-4.0', 'Statement', 'Author et al')),
                     new ArraySequence([new PersonAuthor(new PersonDetails('Author', 'Author'))]), null,
                     promise_for(null), null, new ArraySequence([]), promise_for(null), new ArraySequence([
-                        new Section('Article 1 section title', 'article1section', [new Paragraph('Article 1 text')]),
+                        new Section('Article article1 section title', 'articlearticle1section', [new Paragraph('Article article1 text')]),
                     ]), new ArraySequence([
-                        new BookReference(ReferenceDate::fromString('2000'),
-                            [new PersonAuthor(new PersonDetails('preferred name', 'index name'))], false, 'book title',
-                            new Place(null, null, ['publisher'])),
+                        // minimum article-vor does not have reference, according to api-raml model
+                        //new BookReference(ReferenceDate::fromString('2000'),
+                        //    [new PersonAuthor(new PersonDetails('preferred name', 'index name'))], false, 'book title',
+                        //    new Place(null, null, ['publisher'])),
                     ]), promise_for(null), new ArraySequence([]), promise_for(null)),
                 ['snippet' => true],
                 [
@@ -449,7 +450,7 @@ final class ArticleVoRNormalizerTest extends ApiTestCase
                     'status' => 'vor',
                 ],
                 function (ApiTestCase $test) {
-                    $test->mockArticleCall(1, false, true);
+                    $test->mockArticleCall('article1', false, true);
                 },
             ],
         ];

--- a/test/Serializer/ArticleVoRNormalizerTest.php
+++ b/test/Serializer/ArticleVoRNormalizerTest.php
@@ -429,12 +429,7 @@ final class ArticleVoRNormalizerTest extends ApiTestCase
                     new ArraySequence([new PersonAuthor(new PersonDetails('Author', 'Author'))]), null,
                     promise_for(null), null, new ArraySequence([]), promise_for(null), new ArraySequence([
                         new Section('Article article1 section title', 'articlearticle1section', [new Paragraph('Article article1 text')]),
-                    ]), new ArraySequence([
-                        // minimum article-vor does not have reference, according to api-raml model
-                        //new BookReference(ReferenceDate::fromString('2000'),
-                        //    [new PersonAuthor(new PersonDetails('preferred name', 'index name'))], false, 'book title',
-                        //    new Place(null, null, ['publisher'])),
-                    ]), promise_for(null), new ArraySequence([]), promise_for(null)),
+                    ]), new ArraySequence([]), promise_for(null), new ArraySequence([]), promise_for(null)),
                 ['snippet' => true],
                 [
                     'id' => 'article1',

--- a/test/Serializer/BlogArticleNormalizerTest.php
+++ b/test/Serializer/BlogArticleNormalizerTest.php
@@ -136,7 +136,7 @@ final class BlogArticleNormalizerTest extends ApiTestCase
                 '140' => 'https://placehold.it/140x140',
             ]),
         ]);
-        $subject = new Subject('subject1', 'Subject 1 name', promise_for('Subject 1 impact statement'),
+        $subject = new Subject('subject1', 'Subject 1 name', promise_for('Subject subject1 impact statement'),
             promise_for($banner), promise_for($thumbnail));
 
         return [
@@ -178,7 +178,7 @@ final class BlogArticleNormalizerTest extends ApiTestCase
             ],
             'complete snippet' => [
                 new BlogArticle('blogArticle1', 'Blog article 1 title', $date, 'Blog article 1 impact statement',
-                    new ArraySequence([new Paragraph('Blog article 1 text')]), new ArraySequence([$subject])),
+                    new ArraySequence([new Paragraph('Blog article blogArticle1 text')]), new ArraySequence([$subject])),
                 ['snippet' => true],
                 [
                     'id' => 'blogArticle1',
@@ -195,7 +195,7 @@ final class BlogArticleNormalizerTest extends ApiTestCase
             ],
             'minimum snippet' => [
                 new BlogArticle('blogArticle1', 'Blog article 1 title', $date, null,
-                    new ArraySequence([new Paragraph('Blog article 1 text')]), new ArraySequence([])),
+                    new ArraySequence([new Paragraph('Blog article blogArticle1 text')]), new ArraySequence([])),
                 ['snippet' => true],
                 [
                     'id' => 'blogArticle1',

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -6,24 +6,21 @@ use DateTimeImmutable;
 use eLife\ApiClient\ApiClient\CollectionsClient;
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Collection\ArraySequence;
-#use eLife\ApiSdk\Collection\PromiseSequence;
-#use eLife\ApiSdk\Model\ArticlePoA;
-#use eLife\ApiSdk\Model\ArticleSection;
-#use eLife\ApiSdk\Model\Block\Paragraph;
-#use eLife\ApiSdk\Model\Copyright;
-use eLife\ApiSdk\Model\Image;
-use eLife\ApiSdk\Model\ImageSize;
-#use eLife\ApiSdk\Model\Person;
-#use eLife\ApiSdk\Model\PersonAuthor;
+//use eLife\ApiSdk\Collection\PromiseSequence;
+//use eLife\ApiSdk\Model\ArticlePoA;
+//use eLife\ApiSdk\Model\ArticleSection;
+//use eLife\ApiSdk\Model\Block\Paragraph;
+//use eLife\ApiSdk\Model\Copyright;
 use eLife\ApiSdk\Model\Collection;
+//use eLife\ApiSdk\Model\Person;
+//use eLife\ApiSdk\Model\PersonAuthor;
+use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\Subject;
 use eLife\ApiSdk\Serializer\CollectionNormalizer;
-#use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+//use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use test\eLife\ApiSdk\ApiTestCase;
 use test\eLife\ApiSdk\Builder;
-use function GuzzleHttp\Promise\promise_for;
-use function GuzzleHttp\Promise\rejection_for;
 
 final class CollectionNormalizerTest extends ApiTestCase
 {
@@ -60,7 +57,7 @@ final class CollectionNormalizerTest extends ApiTestCase
 
     public function canNormalizeProvider() : array
     {
-        $collection = Builder::for(Collection::CLASS)->__invoke();
+        $collection = Builder::for(Collection::class)->__invoke();
 
         return [
             'collection' => [$collection, null, true],
@@ -99,18 +96,18 @@ final class CollectionNormalizerTest extends ApiTestCase
 
     public function normalizeProvider() : array
     {
-        $this->builder = Builder::for(Collection::CLASS);
+        $this->builder = Builder::for(Collection::class);
         $date = new DateTimeImmutable();
-        $banner = Builder::for(Image::CLASS)
+        $banner = Builder::for(Image::class)
             ->sample('banner');
-        $thumbnail = Builder::for(Image::CLASS)
+        $thumbnail = Builder::for(Image::class)
             ->sample('thumbnail');
         $subject = Builder::for(Subject::class)
             ->withId('subject1')
             ->withName('Subject 1 name')
             ->withPromiseOfImpactStatement('Subject 1 impact statement')
             ->withPromiseOfBanner($banner)
-            ->withPromiseOfThumbnail($thumbnail); 
+            ->withPromiseOfThumbnail($thumbnail);
 
         return [
             'complete' => [

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -499,7 +499,6 @@ final class CollectionNormalizerTest extends ApiTestCase
                 Builder::for(Collection::class)
                     ->withId('1')
                     ->withTitle('Tropical disease')
-                    ->withPromiseOfSubTitle('1 subtitle')
                     ->withPublishedDate(new DateTimeImmutable('2015-09-16T11:19:26+00:00'))
                     ->withSelectedCurator(
                         $selectedCurator = Builder::for(Person::class)

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -108,51 +108,248 @@ final class CollectionNormalizerTest extends ApiTestCase
             ->withPromiseOfImpactStatement('Subject 1 impact statement')
             ->withPromiseOfBanner($banner)
             ->withPromiseOfThumbnail($thumbnail);
-
+        $subjects = new ArraySequence([
+            Builder::for(Subject::class)
+                ->withId('epidemiology-global-health')
+                ->withName('Epidemiology and Global Health')
+                ->__invoke(),
+            Builder::for(Subject::class)
+                ->withId('microbiology-infectious-disease')
+                ->withName('Microbiology and Infectious Disease')
+                ->__invoke(),
+        ]);
         return [
             'complete' => [
                 $this->builder
-                    ->withId('tropical-disease')
+                    ->withId('1')
                     ->withTitle('Tropical disease')
-                    ->withPromiseOfSubTitle('Tropical disease subtitle')
-                    ->withImpactStatement('Tropical disease impact statement')
-                    ->withPublishedDate($date)
+                    ->withPromiseOfSubTitle('A selection of papers')
+                    ->withImpactStatement('eLife has published papers on many...')
+                    ->withPublishedDate(new DateTimeImmutable('2015-09-16T11:19:26+00:00'))
                     ->withPromiseOfBanner($banner)
                     ->withThumbnail($thumbnail)
-                    ->withSubjects(new ArraySequence([$subject]))
+                    ->withSubjects($subjects)
                     ->__invoke(),
                 ['complete' => true],
-                [
-                    'id' => 'tropical-disease',
-                    'title' => 'Tropical disease',
-                    'subTitle' => 'Tropical disease subtitle',
-                    'impactStatement' => 'Tropical disease impact statement',
-                    'updated' => $date->format(DATE_ATOM),
-                    'image' => [
-                        'thumbnail' => [
-                            'alt' => '',
-                            'sizes' => [
-                                '16:9' => [
-                                    250 => 'https://placehold.it/250x141',
-                                    500 => 'https://placehold.it/500x281',
-                                ],
-                                '1:1' => [
-                                    70 => 'https://placehold.it/70x70',
-                                    140 => 'https://placehold.it/140x140',
-                                ],
-                            ],
-                        ],
-                        'banner' => [
-                            'alt' => '',
-                            'sizes' => [
-                                '2:1' => [
-                                    900 => 'https://placehold.it/900x450',
-                                    1800 => 'https://placehold.it/1800x900',
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
+array (
+  'id' => '1',
+  'title' => 'Tropical disease',
+  'subTitle' => 'A selection of papers',
+  'impactStatement' => 'eLife has published papers on many...',
+  'updated' => '2015-09-16T11:19:26+00:00',
+  'image' => 
+  array (
+    'banner' => 
+    array (
+      'alt' => '',
+      'sizes' => 
+      array (
+        '2:1' => 
+        array (
+          900 => 'https://placehold.it/900x450',
+          1800 => 'https://placehold.it/1800x900',
+        ),
+      ),
+    ),
+    'thumbnail' => 
+    array (
+      'alt' => '',
+      'sizes' => 
+      array (
+        '16:9' => 
+        array (
+          250 => 'https://placehold.it/250x141',
+          500 => 'https://placehold.it/500x281',
+        ),
+        '1:1' => 
+        array (
+          70 => 'https://placehold.it/70x70',
+          140 => 'https://placehold.it/140x140',
+        ),
+      ),
+    ),
+  ),
+  'subjects' => 
+  array (
+    0 => 
+    array (
+      'id' => 'epidemiology-global-health',
+      'name' => 'Epidemiology and Global Health',
+    ),
+    1 => 
+    array (
+      'id' => 'microbiology-infectious-disease',
+      'name' => 'Microbiology and Infectious Disease',
+    ),
+  ),
+  'selectedCurator' => 
+  array (
+    'id' => 'pjha',
+    'type' => 'senior-editor',
+    'name' => 
+    array (
+      'preferred' => 'Prabhat Jha',
+      'index' => 'Jha, Prabhat',
+    ),
+    'etAl' => true,
+  ),
+  'curators' => 
+  array (
+    0 => 
+    array (
+      'id' => 'bcooper',
+      'type' => 'reviewing-editor',
+      'name' => 
+      array (
+        'preferred' => 'Ben Cooper',
+        'index' => 'Cooper, Ben',
+      ),
+    ),
+    1 => 
+    array (
+      'id' => 'pjha',
+      'type' => 'senior-editor',
+      'name' => 
+      array (
+        'preferred' => 'Prabhat Jha',
+        'index' => 'Jha, Prabhat',
+      ),
+    ),
+  ),
+  'content' => 
+  array (
+    0 => 
+    array (
+      'type' => 'research-article',
+      'status' => 'vor',
+      'id' => '09560',
+      'version' => 1,
+      'doi' => '10.7554/eLife.09560',
+      'authorLine' => 'Lee R Berger et al',
+      'title' => '<i>Homo naledi</i>, a new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa',
+      'published' => '2015-09-10T00:00:00Z',
+      'statusDate' => '2015-09-10T00:00:00Z',
+      'volume' => 4,
+      'elocationId' => 'e09560',
+      'pdf' => 'https://elifesciences.org/content/4/e09560.pdf',
+      'subjects' => 
+      array (
+        0 => 
+        array (
+          'id' => 'genomics-evolutionary-biology',
+          'name' => 'Genomics and Evolutionary Biology',
+        ),
+      ),
+      'impactStatement' => 'A new hominin species has been unearthed in the Dinaledi Chamber of the Rising Star cave system in the largest assemblage of a single species of hominins yet discovered in Africa.',
+      'image' => 
+      array (
+        'thumbnail' => 
+        array (
+          'alt' => '',
+          'sizes' => 
+          array (
+            '16:9' => 
+            array (
+              250 => 'https://placehold.it/250x141',
+              500 => 'https://placehold.it/500x281',
+            ),
+            '1:1' => 
+            array (
+              70 => 'https://placehold.it/70x70',
+              140 => 'https://placehold.it/140x140',
+            ),
+          ),
+        ),
+      ),
+    ),
+    1 => 
+    array (
+      'type' => 'blog-article',
+      'id' => '1',
+      'title' => 'Media coverage: Slime can see',
+      'impactStatement' => 'In their research paper – Cyanobacteria use micro-optics to sense light direction – Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world’s oldest and smallest camera eye, allowing them to ‘see’.',
+      'published' => '2016-07-08T08:33:25+00:00',
+      'subjects' => 
+      array (
+        0 => 
+        array (
+          'id' => 'biophysics-structural-biology',
+          'name' => 'Biophysics and Structural Biology',
+        ),
+      ),
+    ),
+    2 => 
+    array (
+      'type' => 'interview',
+      'id' => '1',
+      'interviewee' => 
+      array (
+        'name' => 
+        array (
+          'preferred' => 'Ramanath Hegde',
+          'index' => 'Hegde, Ramanath',
+        ),
+      ),
+      'title' => 'Controlling traffic',
+      'impactStatement' => 'Ramanath Hegde is a Postdoctoral Fellow at the Institute of Protein Biochemistry in Naples, Italy, where he investigates ways of preventing cells from destroying mutant proteins.',
+      'published' => '2016-01-29T16:22:28+00:00',
+    ),
+  ),
+  'relatedContent' => 
+  array (
+    0 => 
+    array (
+      'type' => 'research-article',
+      'status' => 'poa',
+      'id' => '14107',
+      'version' => 1,
+      'doi' => '10.7554/eLife.14107',
+      'authorLine' => 'Yongjian Huang et al',
+      'title' => 'Molecular basis for multimerization in the activation of the epidermal growth factor',
+      'published' => '2016-03-28T00:00:00Z',
+      'statusDate' => '2016-03-28T00:00:00Z',
+      'volume' => 5,
+      'elocationId' => 'e14107',
+    ),
+  ),
+  'podcastEpisodes' => 
+  array (
+    0 => 
+    array (
+      'number' => 29,
+      'title' => 'April/May 2016',
+      'published' => '2016-05-27T13:19:42+00:00',
+      'image' => 
+      array (
+        'thumbnail' => 
+        array (
+          'alt' => '',
+          'sizes' => 
+          array (
+            '16:9' => 
+            array (
+              250 => 'https://placehold.it/250x141',
+              500 => 'https://placehold.it/500x281',
+            ),
+            '1:1' => 
+            array (
+              70 => 'https://placehold.it/70x70',
+              140 => 'https://placehold.it/140x140',
+            ),
+          ),
+        ),
+      ),
+      'sources' => 
+      array (
+        0 => 
+        array (
+          'mediaType' => 'audio/mpeg',
+          'uri' => 'https://nakeddiscovery.com/scripts/mp3s/audio/eLife_Podcast_16.05.mp3',
+        ),
+      ),
+    ),
+  ),
+)
             ],
         ];
     }

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -418,6 +418,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                 Builder::for(Collection::class)
                     ->withId('1')
                     ->withTitle('Tropical disease')
+                    ->withPromiseOfSubTitle('1 subtitle')
                     ->withImpactStatement('eLife has published papers on many...')
                     ->withPublishedDate(new DateTimeImmutable('2015-09-16T11:19:26+00:00'))
                     ->withSubjects(new ArraySequence([
@@ -500,6 +501,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                 Builder::for(Collection::class)
                     ->withId('1')
                     ->withTitle('Tropical disease')
+                    ->withPromiseOfSubTitle('1 subtitle')
                     ->withPublishedDate(new DateTimeImmutable('2015-09-16T11:19:26+00:00'))
                     ->withSelectedCurator(
                         $selectedCurator = Builder::for(Person::class)

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace test\eLife\ApiSdk\Serializer;
+
+#use DateTimeImmutable;
+use eLife\ApiClient\ApiClient\CollectionsClient;
+use eLife\ApiSdk\ApiSdk;
+#use eLife\ApiSdk\Collection\ArraySequence;
+#use eLife\ApiSdk\Collection\PromiseSequence;
+#use eLife\ApiSdk\Model\ArticlePoA;
+#use eLife\ApiSdk\Model\ArticleSection;
+#use eLife\ApiSdk\Model\Block\Paragraph;
+#use eLife\ApiSdk\Model\Copyright;
+#use eLife\ApiSdk\Model\Image;
+#use eLife\ApiSdk\Model\ImageSize;
+#use eLife\ApiSdk\Model\Person;
+#use eLife\ApiSdk\Model\PersonAuthor;
+#use eLife\ApiSdk\Model\CollectionEpisode;
+#use eLife\ApiSdk\Model\Subject;
+use eLife\ApiSdk\Serializer\CollectionNormalizer;
+#use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use test\eLife\ApiSdk\ApiTestCase;
+#use function GuzzleHttp\Promise\promise_for;
+#use function GuzzleHttp\Promise\rejection_for;
+
+final class CollectionNormalizerTest extends ApiTestCase
+{
+    /** @var CollectionNormalizer */
+    private $normalizer;
+
+    /**
+     * @before
+     */
+    protected function setUpNormalizer()
+    {
+        $apiSdk = new ApiSdk($this->getHttpClient());
+        $this->normalizer = new CollectionNormalizer(new CollectionsClient($this->getHttpClient()));
+        $this->normalizer->setNormalizer($apiSdk->getSerializer());
+        $this->normalizer->setDenormalizer($apiSdk->getSerializer());
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_a_normalizer()
+    {
+        $this->assertInstanceOf(NormalizerInterface::class, $this->normalizer);
+    }
+}

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -174,181 +174,181 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ]))
                     ->__invoke(),
                 ['complete' => true],
-array(
-  'id' => '1',
-  'title' => 'Tropical disease',
-  'subTitle' => 'A selection of papers',
-  'impactStatement' => 'eLife has published papers on many...',
-  'updated' => '2015-09-16T11:19:26+00:00',
-  'image' => array(
-    'banner' => array(
-      'alt' => '',
-      'sizes' => array(
-        '2:1' => array(
-          900 => 'https://placehold.it/900x450',
-          1800 => 'https://placehold.it/1800x900',
-        ),
-      ),
-    ),
-    'thumbnail' => array(
-      'alt' => '',
-      'sizes' => array(
-        '16:9' => array(
-          250 => 'https://placehold.it/250x141',
-          500 => 'https://placehold.it/500x281',
-        ),
-        '1:1' => array(
-          70 => 'https://placehold.it/70x70',
-          140 => 'https://placehold.it/140x140',
-        ),
-      ),
-    ),
-  ),
-  'subjects' => array(
-    0 => array(
-      'id' => 'epidemiology-global-health',
-      'name' => 'Epidemiology and Global Health',
-    ),
-    1 => array(
-      'id' => 'microbiology-infectious-disease',
-      'name' => 'Microbiology and Infectious Disease',
-    ),
-  ),
-  'selectedCurator' => array(
-    'id' => 'pjha',
-    'type' => 'senior-editor',
-    'name' => array(
-      'preferred' => 'Prabhat Jha',
-      'index' => 'Jha, Prabhat',
-    ),
-    'etAl' => true,
-  ),
-  'curators' => array(
-    0 => array(
-      'id' => 'bcooper',
-      'type' => 'reviewing-editor',
-      'name' => array(
-        'preferred' => 'Ben Cooper',
-        'index' => 'Cooper, Ben',
-      ),
-    ),
-    1 => array(
-      'id' => 'pjha',
-      'type' => 'senior-editor',
-      'name' => array(
-        'preferred' => 'Prabhat Jha',
-        'index' => 'Jha, Prabhat',
-      ),
-    ),
-  ),
-  'content' => array(
-    0 => array(
-      'type' => 'research-article',
-      'status' => 'vor',
-      'id' => '09560',
-      'version' => 1,
-      'doi' => '10.7554/eLife.09560',
-      'authorLine' => 'Lee R Berger et al',
-      'title' => '<i>Homo naledi</i>, a new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa',
-      'published' => '2015-09-10T00:00:00+00:00',
-      'statusDate' => '2015-09-10T00:00:00+00:00',
-      'volume' => 4,
-      'elocationId' => 'e09560',
-      'pdf' => 'https://elifesciences.org/content/4/e09560.pdf',
-      'subjects' => array(
-        0 => array(
-          'id' => 'genomics-evolutionary-biology',
-          'name' => 'Genomics and Evolutionary Biology',
-        ),
-      ),
-      'impactStatement' => 'A new hominin species has been unearthed in the Dinaledi Chamber of the Rising Star cave system in the largest assemblage of a single species of hominins yet discovered in Africa.',
-      'image' => array(
-        'thumbnail' => array(
-          'alt' => '',
-          'sizes' => array(
-            '16:9' => array(
-              250 => 'https://placehold.it/250x141',
-              500 => 'https://placehold.it/500x281',
-            ),
-            '1:1' => array(
-              70 => 'https://placehold.it/70x70',
-              140 => 'https://placehold.it/140x140',
-            ),
-          ),
-        ),
-      ),
-    ),
-    1 => array(
-      'type' => 'blog-article',
-      'id' => '1',
-      'title' => 'Media coverage: Slime can see',
-      'impactStatement' => 'In their research paper – Cyanobacteria use micro-optics to sense light direction – Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world’s oldest and smallest camera eye, allowing them to ‘see’.',
-      'published' => '2016-07-08T08:33:25+00:00',
-      'subjects' => array(
-        0 => array(
-          'id' => 'biophysics-structural-biology',
-          'name' => 'Biophysics and Structural Biology',
-        ),
-      ),
-    ),
-    2 => array(
-      'type' => 'interview',
-      'id' => '1',
-      'interviewee' => array(
-        'name' => array(
-          'preferred' => 'Ramanath Hegde',
-          'index' => 'Hegde, Ramanath',
-        ),
-      ),
-      'title' => 'Controlling traffic',
-      'impactStatement' => 'Ramanath Hegde is a Postdoctoral Fellow at the Institute of Protein Biochemistry in Naples, Italy, where he investigates ways of preventing cells from destroying mutant proteins.',
-      'published' => '2016-01-29T16:22:28+00:00',
-    ),
-  ),
-  'relatedContent' => array(
-    0 => array(
-      'type' => 'research-article',
-      'status' => 'poa',
-      'id' => '14107',
-      'version' => 1,
-      'doi' => '10.7554/eLife.14107',
-      'authorLine' => 'Yongjian Huang et al',
-      'title' => 'Molecular basis for multimerization in the activation of the epidermal growth factor',
-      'published' => '2016-03-28T00:00:00+00:00',
-      'statusDate' => '2016-03-28T00:00:00+00:00',
-      'volume' => 5,
-      'elocationId' => 'e14107',
-    ),
-  ),
-  'podcastEpisodes' => array(
-    0 => array(
-      'number' => 29,
-      'title' => 'April/May 2016',
-      'published' => '2016-05-27T13:19:42+00:00',
-      'image' => array(
-        'thumbnail' => array(
-          'alt' => '',
-          'sizes' => array(
-            '16:9' => array(
-              250 => 'https://placehold.it/250x141',
-              500 => 'https://placehold.it/500x281',
-            ),
-            '1:1' => array(
-              70 => 'https://placehold.it/70x70',
-              140 => 'https://placehold.it/140x140',
-            ),
-          ),
-        ),
-      ),
-      'sources' => array(
-        0 => array(
-          'mediaType' => 'audio/mpeg',
-          'uri' => 'https://nakeddiscovery.com/scripts/mp3s/audio/eLife_Podcast_16.05.mp3',
-        ),
-      ),
-    ),
-  ),
-),
+                [
+                    'id' => '1',
+                    'title' => 'Tropical disease',
+                    'subTitle' => 'A selection of papers',
+                    'impactStatement' => 'eLife has published papers on many...',
+                    'updated' => '2015-09-16T11:19:26+00:00',
+                    'image' => [
+                        'banner' => [
+                            'alt' => '',
+                            'sizes' => [
+                                '2:1' => [
+                                    900 => 'https://placehold.it/900x450',
+                                    1800 => 'https://placehold.it/1800x900',
+                                ],
+                            ],
+                        ],
+                        'thumbnail' => [
+                            'alt' => '',
+                            'sizes' => [
+                                '16:9' => [
+                                    250 => 'https://placehold.it/250x141',
+                                    500 => 'https://placehold.it/500x281',
+                                ],
+                                '1:1' => [
+                                    70 => 'https://placehold.it/70x70',
+                                    140 => 'https://placehold.it/140x140',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'subjects' => [
+                        0 => [
+                            'id' => 'epidemiology-global-health',
+                            'name' => 'Epidemiology and Global Health',
+                        ],
+                        1 => [
+                            'id' => 'microbiology-infectious-disease',
+                            'name' => 'Microbiology and Infectious Disease',
+                        ],
+                    ],
+                    'selectedCurator' => [
+                        'id' => 'pjha',
+                        'type' => 'senior-editor',
+                        'name' => [
+                            'preferred' => 'Prabhat Jha',
+                            'index' => 'Jha, Prabhat',
+                        ],
+                        'etAl' => true,
+                    ],
+                    'curators' => [
+                        0 => [
+                            'id' => 'bcooper',
+                            'type' => 'reviewing-editor',
+                            'name' => [
+                                'preferred' => 'Ben Cooper',
+                                'index' => 'Cooper, Ben',
+                            ],
+                        ],
+                        1 => [
+                            'id' => 'pjha',
+                            'type' => 'senior-editor',
+                            'name' => [
+                                'preferred' => 'Prabhat Jha',
+                                'index' => 'Jha, Prabhat',
+                            ],
+                        ],
+                    ],
+                    'content' => [
+                        0 => [
+                            'type' => 'research-article',
+                            'status' => 'vor',
+                            'id' => '09560',
+                            'version' => 1,
+                            'doi' => '10.7554/eLife.09560',
+                            'authorLine' => 'Lee R Berger et al',
+                            'title' => '<i>Homo naledi</i>, a new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa',
+                            'published' => '2015-09-10T00:00:00+00:00',
+                            'statusDate' => '2015-09-10T00:00:00+00:00',
+                            'volume' => 4,
+                            'elocationId' => 'e09560',
+                            'pdf' => 'https://elifesciences.org/content/4/e09560.pdf',
+                            'subjects' => [
+                                0 => [
+                                    'id' => 'genomics-evolutionary-biology',
+                                    'name' => 'Genomics and Evolutionary Biology',
+                                ],
+                            ],
+                            'impactStatement' => 'A new hominin species has been unearthed in the Dinaledi Chamber of the Rising Star cave system in the largest assemblage of a single species of hominins yet discovered in Africa.',
+                            'image' => [
+                                'thumbnail' => [
+                                    'alt' => '',
+                                    'sizes' => [
+                                        '16:9' => [
+                                            250 => 'https://placehold.it/250x141',
+                                            500 => 'https://placehold.it/500x281',
+                                        ],
+                                        '1:1' => [
+                                            70 => 'https://placehold.it/70x70',
+                                            140 => 'https://placehold.it/140x140',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        1 => [
+                            'type' => 'blog-article',
+                            'id' => '1',
+                            'title' => 'Media coverage: Slime can see',
+                            'impactStatement' => 'In their research paper – Cyanobacteria use micro-optics to sense light direction – Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world’s oldest and smallest camera eye, allowing them to ‘see’.',
+                            'published' => '2016-07-08T08:33:25+00:00',
+                            'subjects' => [
+                                0 => [
+                                    'id' => 'biophysics-structural-biology',
+                                    'name' => 'Biophysics and Structural Biology',
+                                ],
+                            ],
+                        ],
+                        2 => [
+                            'type' => 'interview',
+                            'id' => '1',
+                            'interviewee' => [
+                                'name' => [
+                                    'preferred' => 'Ramanath Hegde',
+                                    'index' => 'Hegde, Ramanath',
+                                ],
+                            ],
+                            'title' => 'Controlling traffic',
+                            'impactStatement' => 'Ramanath Hegde is a Postdoctoral Fellow at the Institute of Protein Biochemistry in Naples, Italy, where he investigates ways of preventing cells from destroying mutant proteins.',
+                            'published' => '2016-01-29T16:22:28+00:00',
+                        ],
+                    ],
+                    'relatedContent' => [
+                        0 => [
+                            'type' => 'research-article',
+                            'status' => 'poa',
+                            'id' => '14107',
+                            'version' => 1,
+                            'doi' => '10.7554/eLife.14107',
+                            'authorLine' => 'Yongjian Huang et al',
+                            'title' => 'Molecular basis for multimerization in the activation of the epidermal growth factor',
+                            'published' => '2016-03-28T00:00:00+00:00',
+                            'statusDate' => '2016-03-28T00:00:00+00:00',
+                            'volume' => 5,
+                            'elocationId' => 'e14107',
+                        ],
+                    ],
+                    'podcastEpisodes' => [
+                        0 => [
+                            'number' => 29,
+                            'title' => 'April/May 2016',
+                            'published' => '2016-05-27T13:19:42+00:00',
+                            'image' => [
+                                'thumbnail' => [
+                                    'alt' => '',
+                                    'sizes' => [
+                                        '16:9' => [
+                                            250 => 'https://placehold.it/250x141',
+                                            500 => 'https://placehold.it/500x281',
+                                        ],
+                                        '1:1' => [
+                                            70 => 'https://placehold.it/70x70',
+                                            140 => 'https://placehold.it/140x140',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                            'sources' => [
+                                0 => [
+                                    'mediaType' => 'audio/mpeg',
+                                    'uri' => 'https://nakeddiscovery.com/scripts/mp3s/audio/eLife_Podcast_16.05.mp3',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
             ],
         ];
     }

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -5,23 +5,23 @@ namespace test\eLife\ApiSdk\Serializer;
 use DateTimeImmutable;
 use eLife\ApiClient\ApiClient\CollectionsClient;
 use eLife\ApiSdk\ApiSdk;
-#use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Collection\ArraySequence;
 #use eLife\ApiSdk\Collection\PromiseSequence;
 #use eLife\ApiSdk\Model\ArticlePoA;
 #use eLife\ApiSdk\Model\ArticleSection;
 #use eLife\ApiSdk\Model\Block\Paragraph;
 #use eLife\ApiSdk\Model\Copyright;
 use eLife\ApiSdk\Model\Image;
-#use eLife\ApiSdk\Model\ImageSize;
+use eLife\ApiSdk\Model\ImageSize;
 #use eLife\ApiSdk\Model\Person;
 #use eLife\ApiSdk\Model\PersonAuthor;
 use eLife\ApiSdk\Model\Collection;
-#use eLife\ApiSdk\Model\Subject;
+use eLife\ApiSdk\Model\Subject;
 use eLife\ApiSdk\Serializer\CollectionNormalizer;
 #use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use test\eLife\ApiSdk\ApiTestCase;
-#use function GuzzleHttp\Promise\promise_for;
+use function GuzzleHttp\Promise\promise_for;
 use function GuzzleHttp\Promise\rejection_for;
 
 final class CollectionNormalizerTest extends ApiTestCase
@@ -68,4 +68,75 @@ final class CollectionNormalizerTest extends ApiTestCase
         ];
     }
 
+    /**
+     * @test
+     * @dataProvider normalizeProvider
+     */
+    public function it_normalizes_collections(Collection $collection, array $context, array $expected)
+    {
+        $this->assertEquals($expected, $this->normalizer->normalize($collection, null, $context));
+    }
+
+    public function normalizeProvider() : array
+    {
+        $date = new DateTimeImmutable();
+        $banner = new Image('',
+            [new ImageSize('2:1', [900 => 'https://placehold.it/900x450', 1800 => 'https://placehold.it/1800x900'])]);
+        $thumbnail = new Image('', [
+            new ImageSize('16:9', [
+                250 => 'https://placehold.it/250x141',
+                500 => 'https://placehold.it/500x281',
+            ]),
+            new ImageSize('1:1', [
+                '70' => 'https://placehold.it/70x70',
+                '140' => 'https://placehold.it/140x140',
+            ]),
+        ]);
+        $subject = new Subject('subject1', 'Subject 1 name', promise_for('Subject 1 impact statement'), promise_for($banner), promise_for($thumbnail)); 
+
+        return [
+            'complete' => [
+                new Collection(
+                    'tropical-disease',
+                    'Tropical disease',
+                    'Tropical disease impact statement',
+                    $date,
+                    promise_for($banner),
+                    $thumbnail,
+                    new ArraySequence([$subject])
+                ),
+                ['complete' => true],
+                [
+                    'id' => 'tropical-disease',
+                    'title' => 'Tropical disease',
+                    'impact_statement' => 'Tropical disease impact statement',
+                    'updated' => $date->format(DATE_ATOM),
+                    'image' => [
+                        'thumbnail' => [
+                            'alt' => '',
+                            'sizes' => [
+                                '16:9' => [
+                                    250 => 'https://placehold.it/250x141',
+                                    500 => 'https://placehold.it/500x281',
+                                ],
+                                '1:1' => [
+                                    70 => 'https://placehold.it/70x70',
+                                    140 => 'https://placehold.it/140x140',
+                                ],
+                            ],
+                        ],
+                        'banner' => [
+                            'alt' => '',
+                            'sizes' => [
+                                '2:1' => [
+                                    900 => 'https://placehold.it/900x450',
+                                    1800 => 'https://placehold.it/1800x900',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
 }

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -91,6 +91,7 @@ final class CollectionNormalizerTest extends ApiTestCase
         if ($extra) {
             call_user_func($extra, $this);
         }
+        $this->mockPersonCall('pjha');
 
         $actual = $this->normalizer->denormalize($json, Collection::class, null, $context);
 
@@ -346,7 +347,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ->withThumbnail($thumbnail)
                     ->withSelectedCurator(
                         $selectedCurator = Builder::for(Person::class)
-                            ->sample('pjha')
+                            ->sample('pjha', ['snippet' => false])
                     )
                     ->withCurators(new ArraySequence([
                         $selectedCurator,
@@ -403,7 +404,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                             ],
                         ],
                     ],
-                    'content' => [
+                    'content' => $minimumContent = [
                         0 => [
                             'type' => 'research-article',
                             'status' => 'poa',
@@ -476,7 +477,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ],
                 ],
                 function (ApiTestCase $test) {
-                    //$test->mockCollectionCall(1, true);
+                    $test->mockCollectionCall('1', true);
                 },
             ],
             'minimum snippet' => [
@@ -484,11 +485,14 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ->withId('1')
                     ->withTitle('Tropical disease')
                     ->withPublishedDate(new DateTimeImmutable('2015-09-16T11:19:26+00:00'))
+                    ->withPromiseOfBanner($banner)
                     ->withThumbnail($thumbnail)
                     ->withSelectedCurator(
                         $selectedCurator = Builder::for(Person::class)
-                            ->sample('pjha')
+                            ->sample('pjha', ['snippet' => false])
                     )
+                    ->withCurators(new ArraySequence())
+                    ->withContent(new ArraySequence())
                     ->__invoke(),
                 ['snippet' => true],
                 [
@@ -519,6 +523,9 @@ final class CollectionNormalizerTest extends ApiTestCase
                         ],
                     ],
                 ],
+                function (ApiTestCase $test) {
+                    $test->mockCollectionCall('1', true);
+                },
             ],
         ];
     }

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -21,6 +21,7 @@ use eLife\ApiSdk\Serializer\CollectionNormalizer;
 #use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use test\eLife\ApiSdk\ApiTestCase;
+use test\eLife\ApiSdk\Builder;
 use function GuzzleHttp\Promise\promise_for;
 use function GuzzleHttp\Promise\rejection_for;
 
@@ -59,7 +60,7 @@ final class CollectionNormalizerTest extends ApiTestCase
 
     public function canNormalizeProvider() : array
     {
-        $collection = new Collection('tropical-disease', 'Tropical disease', promise_for('Tropical disease subtitle'), null, new DateTimeImmutable(), rejection_for('No banner'), new Image('', []));
+        $collection = Builder::for(Collection::CLASS)->__invoke();
 
         return [
             'collection' => [$collection, null, true],
@@ -98,33 +99,31 @@ final class CollectionNormalizerTest extends ApiTestCase
 
     public function normalizeProvider() : array
     {
+        $this->builder = Builder::for(Collection::CLASS);
         $date = new DateTimeImmutable();
-        $banner = new Image('',
-            [new ImageSize('2:1', [900 => 'https://placehold.it/900x450', 1800 => 'https://placehold.it/1800x900'])]);
-        $thumbnail = new Image('', [
-            new ImageSize('16:9', [
-                250 => 'https://placehold.it/250x141',
-                500 => 'https://placehold.it/500x281',
-            ]),
-            new ImageSize('1:1', [
-                '70' => 'https://placehold.it/70x70',
-                '140' => 'https://placehold.it/140x140',
-            ]),
-        ]);
-        $subject = new Subject('subject1', 'Subject 1 name', promise_for('Subject 1 impact statement'), promise_for($banner), promise_for($thumbnail)); 
+        $banner = Builder::for(Image::CLASS)
+            ->sample('banner');
+        $thumbnail = Builder::for(Image::CLASS)
+            ->sample('thumbnail');
+        $subject = Builder::for(Subject::class)
+            ->withId('subject1')
+            ->withName('Subject 1 name')
+            ->withPromiseOfImpactStatement('Subject 1 impact statement')
+            ->withPromiseOfBanner($banner)
+            ->withPromiseOfThumbnail($thumbnail); 
 
         return [
             'complete' => [
-                new Collection(
-                    'tropical-disease',
-                    'Tropical disease',
-                    promise_for('Tropical disease subtitle'),
-                    'Tropical disease impact statement',
-                    $date,
-                    promise_for($banner),
-                    $thumbnail,
-                    new ArraySequence([$subject])
-                ),
+                $this->builder
+                    ->withId('tropical-disease')
+                    ->withTitle('Tropical disease')
+                    ->withPromiseOfSubTitle('Tropical disease subtitle')
+                    ->withImpactStatement('Tropical disease impact statement')
+                    ->withPublishedDate($date)
+                    ->withPromiseOfBanner($banner)
+                    ->withThumbnail($thumbnail)
+                    ->withSubjects(new ArraySequence([$subject]))
+                    ->__invoke(),
                 ['complete' => true],
                 [
                     'id' => 'tropical-disease',

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -59,7 +59,7 @@ final class CollectionNormalizerTest extends ApiTestCase
 
     public function canNormalizeProvider() : array
     {
-        $collection = new Collection('tropical-disease', 'Tropical disease', null, new DateTimeImmutable(), rejection_for('No banner'), new Image('', []));
+        $collection = new Collection('tropical-disease', 'Tropical disease', promise_for('Tropical disease subtitle'), null, new DateTimeImmutable(), rejection_for('No banner'), new Image('', []));
 
         return [
             'collection' => [$collection, null, true],
@@ -118,6 +118,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                 new Collection(
                     'tropical-disease',
                     'Tropical disease',
+                    promise_for('Tropical disease subtitle'),
                     'Tropical disease impact statement',
                     $date,
                     promise_for($banner),
@@ -128,6 +129,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                 [
                     'id' => 'tropical-disease',
                     'title' => 'Tropical disease',
+                    'subTitle' => 'Tropical disease subtitle',
                     'impactStatement' => 'Tropical disease impact statement',
                     'updated' => $date->format(DATE_ATOM),
                     'image' => [

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -91,8 +91,8 @@ final class CollectionNormalizerTest extends ApiTestCase
         if ($extra) {
             call_user_func($extra, $this);
         }
-        $this->mockPersonCall('pjha', $complete=false, $isSnippet=true);
-        $this->mockPersonCall('bcooper', $complete=false, $isSnippet=true);
+        $this->mockPersonCall('pjha', $complete = false, $isSnippet = true);
+        $this->mockPersonCall('bcooper', $complete = false, $isSnippet = true);
 
         $actual = $this->normalizer->denormalize($json, Collection::class, null, $context);
 
@@ -334,7 +334,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                         ],
                     ],
                 ],
-                function($test) {
+                function ($test) {
                     $test->mockCollectionCall('1', true);
                     $test->mockSubjectCall('biophysics-structural-biology', true);
                     $test->mockSubjectCall('epidemiology-global-health', true);
@@ -347,7 +347,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                     $test->mockPodcastEpisodeCall(29, true);
                     $test->mockSubjectCall('1', true);
                     $test->mockArticleCall('1', true);
-                }
+                },
             ],
             'minimum' => [
                 Builder::for(Collection::class)
@@ -530,7 +530,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ->withCurators(new ArraySequence([
                         $bcooper = Builder::for(Person::class)
                             ->sample('bcooper', ['snippet' => false]),
-                        $selectedCurator, 
+                        $selectedCurator,
                     ]))
                     ->withContent(new ArraySequence([
                         $blogArticle = Builder::for(BlogArticle::class)

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -6,11 +6,7 @@ use DateTimeImmutable;
 use eLife\ApiClient\ApiClient\CollectionsClient;
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Collection\ArraySequence;
-//use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\ArticlePoA;
-//use eLife\ApiSdk\Model\ArticleSection;
-//use eLife\ApiSdk\Model\Block\Paragraph;
-//use eLife\ApiSdk\Model\Copyright;
 use eLife\ApiSdk\Model\ArticleVoR;
 use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Collection;
@@ -20,7 +16,6 @@ use eLife\ApiSdk\Model\Person;
 use eLife\ApiSdk\Model\PodcastEpisode;
 use eLife\ApiSdk\Model\Subject;
 use eLife\ApiSdk\Serializer\CollectionNormalizer;
-//use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use test\eLife\ApiSdk\ApiTestCase;
 use test\eLife\ApiSdk\Builder;
@@ -101,25 +96,6 @@ final class CollectionNormalizerTest extends ApiTestCase
 
     public function normalizeProvider() : array
     {
-        $this->builder = Builder::for(Collection::class);
-        $date = new DateTimeImmutable();
-        $banner = Builder::for(Image::class)
-            ->sample('banner');
-        $thumbnail = Builder::for(Image::class)
-            ->sample('thumbnail');
-        $subject = Builder::for(Subject::class)
-            ->withId('subject1')
-            ->withName('Subject 1 name')
-            ->withPromiseOfImpactStatement('Subject 1 impact statement')
-            ->withPromiseOfBanner($banner)
-            ->withPromiseOfThumbnail($thumbnail);
-        $subjects = new ArraySequence([
-            Builder::for(Subject::class)
-                ->sample('epidemiology-global-health'),
-            Builder::for(Subject::class)
-                ->sample('microbiology-infectious-disease'),
-        ]);
-
         return [
             'complete' => [
                 Builder::for(Collection::class)
@@ -128,9 +104,12 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ->withPromiseOfSubTitle('A selection of papers')
                     ->withImpactStatement('eLife has published papers on many...')
                     ->withPublishedDate(new DateTimeImmutable('2015-09-16T11:19:26+00:00'))
-                    ->withPromiseOfBanner($banner)
-                    ->withThumbnail($thumbnail)
-                    ->withSubjects($subjects)
+                    ->withSubjects(new ArraySequence([
+                        Builder::for(Subject::class)
+                            ->sample('epidemiology-global-health'),
+                        Builder::for(Subject::class)
+                            ->sample('microbiology-infectious-disease'),
+                    ]))
                     ->withSelectedCurator(
                         $selectedCurator = Builder::for(Person::class)
                             ->sample('pjha')
@@ -354,8 +333,6 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ->withId('1')
                     ->withTitle('Tropical disease')
                     ->withPublishedDate(new DateTimeImmutable('2015-09-16T11:19:26+00:00'))
-                    ->withPromiseOfBanner($banner)
-                    ->withThumbnail($thumbnail)
                     ->withSelectedCurator(
                         $selectedCurator = Builder::for(Person::class)
                             ->sample('pjha', ['snippet' => false])
@@ -443,9 +420,12 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ->withTitle('Tropical disease')
                     ->withImpactStatement('eLife has published papers on many...')
                     ->withPublishedDate(new DateTimeImmutable('2015-09-16T11:19:26+00:00'))
-                    ->withThumbnail($thumbnail)
-                    ->withSubjects(
-                        $subjects)
+                    ->withSubjects(new ArraySequence([
+                        Builder::for(Subject::class)
+                            ->sample('epidemiology-global-health'),
+                        Builder::for(Subject::class)
+                            ->sample('microbiology-infectious-disease'),
+                    ]))
                     ->withSelectedCurator(
                         $selectedCurator = Builder::for(Person::class)
                             ->sample('pjha')
@@ -521,8 +501,6 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ->withId('1')
                     ->withTitle('Tropical disease')
                     ->withPublishedDate(new DateTimeImmutable('2015-09-16T11:19:26+00:00'))
-                    ->withPromiseOfBanner($banner)
-                    ->withThumbnail($thumbnail)
                     ->withSelectedCurator(
                         $selectedCurator = Builder::for(Person::class)
                             ->sample('pjha', ['snippet' => false])

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -265,7 +265,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                         ],
                         1 => [
                             'type' => 'blog-article',
-                            'id' => '1',
+                            'id' => '359325',
                             'title' => 'Media coverage: Slime can see',
                             'impactStatement' => 'In their research paper – Cyanobacteria use micro-optics to sense light direction – Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world’s oldest and smallest camera eye, allowing them to ‘see’.',
                             'published' => '2016-07-08T08:33:25+00:00',
@@ -334,6 +334,14 @@ final class CollectionNormalizerTest extends ApiTestCase
                         ],
                     ],
                 ],
+                function($test) {
+                    $test->mockCollectionCall('1', true);
+                    $test->mockSubjectCall('biophysics-structural-biology', true);
+                    $test->mockSubjectCall('epidemiology-global-health', true);
+                    $test->mockSubjectCall('microbiology-infectious-disease', true);
+                    $test->mockSubjectCall('genomics-evolutionary-biology', true);
+                    $test->mockBlogArticleCall('359325');
+                }
             ],
             'minimum' => [
                 Builder::for(Collection::class)

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -444,6 +444,10 @@ final class CollectionNormalizerTest extends ApiTestCase
                         Builder::for(ArticlePoa::class)
                             ->sample('growth-factor'),
                     ]))
+                    ->withPodcastEpisodes(new ArraySequence([
+                        Builder::for(PodcastEpisode::class)
+                            ->sample('29')
+                    ]))
                     ->__invoke(),
                 ['complete' => true, 'snippet' => true],
                 [
@@ -493,6 +497,9 @@ final class CollectionNormalizerTest extends ApiTestCase
                     $test->mockSubjectCall('microbiology-infectious-disease', true);
                     $test->mockBlogArticleCall('359325');
                     $test->mockArticleCall('14107', true);
+                    $test->mockPodcastEpisodeCall('29', true);
+                    $test->mockSubjectCall('1', true);
+                    $test->mockArticleCall('1', true);
                 },
             ],
             'minimum snippet' => [

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -7,7 +7,7 @@ use eLife\ApiClient\ApiClient\CollectionsClient;
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Collection\ArraySequence;
 //use eLife\ApiSdk\Collection\PromiseSequence;
-//use eLife\ApiSdk\Model\ArticlePoA;
+use eLife\ApiSdk\Model\ArticlePoA;
 //use eLife\ApiSdk\Model\ArticleSection;
 //use eLife\ApiSdk\Model\Block\Paragraph;
 //use eLife\ApiSdk\Model\Copyright;
@@ -163,6 +163,10 @@ final class CollectionNormalizerTest extends ApiTestCase
                             ->sample('slime'),
                         Builder::for(Interview::class)
                             ->sample('controlling-traffic'),
+                    ]))
+                    ->withRelatedContent(new ArraySequence([
+                        Builder::for(ArticlePoa::class)
+                            ->sample('growth-factor'),
                     ]))
                     ->__invoke(),
                     /*

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -17,7 +17,7 @@ use eLife\ApiSdk\Model\Collection;
 use eLife\ApiSdk\Model\Interview;
 use eLife\ApiSdk\Model\Person;
 use eLife\ApiSdk\Model\PersonDetails;
-//use eLife\ApiSdk\Model\PersonAuthor;
+use eLife\ApiSdk\Model\PodcastEpisode;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\Subject;
 use eLife\ApiSdk\Serializer\CollectionNormalizer;
@@ -168,36 +168,11 @@ final class CollectionNormalizerTest extends ApiTestCase
                         Builder::for(ArticlePoa::class)
                             ->sample('growth-factor'),
                     ]))
+                    ->withPodcastEpisodes(new ArraySequence([
+                        Builder::for(PodcastEpisode::class)
+                            ->sample('29')
+                    ]))
                     ->__invoke(),
-                    /*
-    1 => array(
-      'type' => 'blog-article',
-      'id' => '1',
-      'title' => 'Media coverage: Slime can see',
-      'impactStatement' => 'In their research paper – Cyanobacteria use micro-optics to sense light direction – Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world’s oldest and smallest camera eye, allowing them to ‘see’.',
-      'published' => '2016-07-08T08:33:25+00:00',
-      'subjects' => array(
-        0 => array(
-          'id' => 'biophysics-structural-biology',
-          'name' => 'Biophysics and Structural Biology',
-        ),
-      ),
-    ),
-    2 => array(
-      'type' => 'interview',
-      'id' => '1',
-      'interviewee' => array(
-        'name' => array(
-          'preferred' => 'Ramanath Hegde',
-          'index' => 'Hegde, Ramanath',
-        ),
-      ),
-      'title' => 'Controlling traffic',
-      'impactStatement' => 'Ramanath Hegde is a Postdoctoral Fellow at the Institute of Protein Biochemistry in Naples, Italy, where he investigates ways of preventing cells from destroying mutant proteins.',
-      'published' => '2016-01-29T16:22:28+00:00',
-    ),
-  ),
-                     */
                 ['complete' => true],
 array(
   'id' => '1',

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -91,7 +91,8 @@ final class CollectionNormalizerTest extends ApiTestCase
         if ($extra) {
             call_user_func($extra, $this);
         }
-        $this->mockPersonCall('pjha');
+        $this->mockPersonCall('pjha', $complete=false, $isSnippet=true);
+        $this->mockPersonCall('bcooper', $complete=false, $isSnippet=true);
 
         $actual = $this->normalizer->denormalize($json, Collection::class, null, $context);
 
@@ -491,8 +492,18 @@ final class CollectionNormalizerTest extends ApiTestCase
                         $selectedCurator = Builder::for(Person::class)
                             ->sample('pjha', ['snippet' => false])
                     )
-                    ->withCurators(new ArraySequence())
-                    ->withContent(new ArraySequence())
+                    ->withCurators(new ArraySequence([
+                        $bcooper = Builder::for(Person::class)
+                            ->sample('bcooper', ['snippet' => false]),
+                        $selectedCurator, 
+                    ]))
+                    ->withContent(new ArraySequence([
+                        $blogArticle = Builder::for(BlogArticle::class)
+                            ->sample('slime'),
+                        //null,
+                        //$articlePoA = Builder::for(ArticlePoA::class)
+                        //    ->sample('growth-factor')
+                    ]))
                     ->__invoke(),
                 ['snippet' => true],
                 [
@@ -525,6 +536,8 @@ final class CollectionNormalizerTest extends ApiTestCase
                 ],
                 function (ApiTestCase $test) {
                     $test->mockCollectionCall('1', true);
+                    $test->mockSubjectCall('biophysics-structural-biology', true);
+                    $test->mockBlogArticleCall('359325');
                 },
             ],
         ];

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -14,11 +14,10 @@ use eLife\ApiSdk\Model\ArticlePoA;
 use eLife\ApiSdk\Model\ArticleVoR;
 use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Collection;
+use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\Interview;
 use eLife\ApiSdk\Model\Person;
-use eLife\ApiSdk\Model\PersonDetails;
 use eLife\ApiSdk\Model\PodcastEpisode;
-use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\Subject;
 use eLife\ApiSdk\Serializer\CollectionNormalizer;
 //use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -142,7 +141,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ->withCurators(new ArraySequence([
                         Builder::for(Person::class)
                             ->sample('bcooper'),
-                        $selectedCurator
+                        $selectedCurator,
                     ]))
                     ->withContent(new ArraySequence([
                         Builder::for(ArticleVoR::class)
@@ -158,7 +157,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ]))
                     ->withPodcastEpisodes(new ArraySequence([
                         Builder::for(PodcastEpisode::class)
-                            ->sample('29')
+                            ->sample('29'),
                     ]))
                     ->__invoke(),
                 ['complete' => true],
@@ -350,7 +349,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                             ->sample('pjha')
                     )
                     ->withCurators(new ArraySequence([
-                        $selectedCurator
+                        $selectedCurator,
                     ]))
                     ->withContent(new ArraySequence([
                         Builder::for(ArticlePoA::class)
@@ -362,65 +361,50 @@ final class CollectionNormalizerTest extends ApiTestCase
                     'id' => '1',
                     'title' => 'Tropical disease',
                     'updated' => '2015-09-16T11:19:26+00:00',
-                    'image' => 
-                    [
-                        'banner' => 
-                        [
+                    'image' => [
+                        'banner' => [
                             'alt' => '',
-                            'sizes' => 
-                            [
-                                '2:1' => 
-                                [
+                            'sizes' => [
+                                '2:1' => [
                                     900 => 'https://placehold.it/900x450',
                                     1800 => 'https://placehold.it/1800x900',
                                 ],
                             ],
                         ],
-                        'thumbnail' => 
-                        [
+                        'thumbnail' => [
                             'alt' => '',
-                            'sizes' => 
-                            [
-                                '16:9' => 
-                                [
+                            'sizes' => [
+                                '16:9' => [
                                     250 => 'https://placehold.it/250x141',
                                     500 => 'https://placehold.it/500x281',
                                 ],
-                                '1:1' => 
-                                [
+                                '1:1' => [
                                     70 => 'https://placehold.it/70x70',
                                     140 => 'https://placehold.it/140x140',
                                 ],
                             ],
                         ],
                     ],
-                    'selectedCurator' => 
-                    [
+                    'selectedCurator' => [
                         'id' => 'pjha',
                         'type' => 'senior-editor',
-                        'name' => 
-                        [
+                        'name' => [
                             'preferred' => 'Prabhat Jha',
                             'index' => 'Jha, Prabhat',
                         ],
                     ],
-                    'curators' => 
-                    [
-                        0 => 
-                        [
+                    'curators' => [
+                        0 => [
                             'id' => 'pjha',
                             'type' => 'senior-editor',
-                            'name' => 
-                            [
+                            'name' => [
                                 'preferred' => 'Prabhat Jha',
                                 'index' => 'Jha, Prabhat',
                             ],
                         ],
                     ],
-                    'content' => 
-                    [
-                        0 => 
-                        [
+                    'content' => [
+                        0 => [
                             'type' => 'research-article',
                             'status' => 'poa',
                             'id' => '14107',
@@ -434,7 +418,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                             'elocationId' => 'e14107',
                         ],
                     ],
-                ]
+                ],
             ],
             'complete snippet' => [
                 Builder::for(Collection::class)
@@ -511,37 +495,30 @@ final class CollectionNormalizerTest extends ApiTestCase
                     'id' => '1',
                     'title' => 'Tropical disease',
                     'updated' => '2015-09-16T11:19:26+00:00',
-                    'image' => 
-                    [
-                        'thumbnail' => 
-                        [
+                    'image' => [
+                        'thumbnail' => [
                             'alt' => '',
-                            'sizes' => 
-                            [
-                                '16:9' => 
-                                [
+                            'sizes' => [
+                                '16:9' => [
                                     250 => 'https://placehold.it/250x141',
                                     500 => 'https://placehold.it/500x281',
                                 ],
-                                '1:1' => 
-                                [
+                                '1:1' => [
                                     70 => 'https://placehold.it/70x70',
                                     140 => 'https://placehold.it/140x140',
                                 ],
                             ],
                         ],
                     ],
-                    'selectedCurator' => 
-                    [
+                    'selectedCurator' => [
                         'id' => 'pjha',
                         'type' => 'senior-editor',
-                        'name' => 
-                        [
+                        'name' => [
                             'preferred' => 'Prabhat Jha',
                             'index' => 'Jha, Prabhat',
                         ],
                     ],
-                ]
+                ],
             ],
         ];
     }

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -2,7 +2,7 @@
 
 namespace test\eLife\ApiSdk\Serializer;
 
-#use DateTimeImmutable;
+use DateTimeImmutable;
 use eLife\ApiClient\ApiClient\CollectionsClient;
 use eLife\ApiSdk\ApiSdk;
 #use eLife\ApiSdk\Collection\ArraySequence;
@@ -11,18 +11,18 @@ use eLife\ApiSdk\ApiSdk;
 #use eLife\ApiSdk\Model\ArticleSection;
 #use eLife\ApiSdk\Model\Block\Paragraph;
 #use eLife\ApiSdk\Model\Copyright;
-#use eLife\ApiSdk\Model\Image;
+use eLife\ApiSdk\Model\Image;
 #use eLife\ApiSdk\Model\ImageSize;
 #use eLife\ApiSdk\Model\Person;
 #use eLife\ApiSdk\Model\PersonAuthor;
-#use eLife\ApiSdk\Model\CollectionEpisode;
+use eLife\ApiSdk\Model\Collection;
 #use eLife\ApiSdk\Model\Subject;
 use eLife\ApiSdk\Serializer\CollectionNormalizer;
 #use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use test\eLife\ApiSdk\ApiTestCase;
 #use function GuzzleHttp\Promise\promise_for;
-#use function GuzzleHttp\Promise\rejection_for;
+use function GuzzleHttp\Promise\rejection_for;
 
 final class CollectionNormalizerTest extends ApiTestCase
 {
@@ -47,4 +47,25 @@ final class CollectionNormalizerTest extends ApiTestCase
     {
         $this->assertInstanceOf(NormalizerInterface::class, $this->normalizer);
     }
+
+    /**
+     * @test
+     * @dataProvider canNormalizeProvider
+     */
+    public function it_can_normalize_collections($data, $format, bool $expected)
+    {
+        $this->assertSame($expected, $this->normalizer->supportsNormalization($data, $format));
+    }
+
+    public function canNormalizeProvider() : array
+    {
+        $collection = new Collection('tropical-disease', 'Tropical disease', null, new DateTimeImmutable(), rejection_for('No banner'), new Image('', []));
+
+        return [
+            'collection' => [$collection, null, true],
+            'collection with format' => [$collection, 'foo', true],
+            'non-collection' => [$this, null, false],
+        ];
+    }
+
 }

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -314,7 +314,6 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ],
                 ],
                 function ($test) {
-                    $test->mockCollectionCall('1', true);
                     $test->mockSubjectCall('biophysics-structural-biology', true);
                     $test->mockSubjectCall('epidemiology-global-health', true);
                     $test->mockSubjectCall('microbiology-infectious-disease', true);
@@ -409,7 +408,6 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ],
                 ],
                 function (ApiTestCase $test) {
-                    $test->mockCollectionCall('1', true);
                     $test->mockSubjectCall('biophysics-structural-biology', true);
                     $test->mockArticleCall('14107', true);
                 },
@@ -516,10 +514,6 @@ final class CollectionNormalizerTest extends ApiTestCase
                         $blogArticle = Builder::for(BlogArticle::class)
                             ->sample('slime'),
                     ]))
-                    ->withRelatedContent(new ArraySequence([
-                        Builder::for(ArticlePoa::class)
-                            ->sample('growth-factor'),
-                    ]))
                     ->__invoke(),
                 ['snippet' => true],
                 [
@@ -551,7 +545,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ],
                 ],
                 function (ApiTestCase $test) {
-                    $test->mockCollectionCall('1', true);
+                    $test->mockCollectionCall('1', false);
                     $test->mockSubjectCall('biophysics-structural-biology', true);
                     $test->mockBlogArticleCall('359325');
                     $test->mockArticleCall('14107', true);

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -115,13 +115,9 @@ final class CollectionNormalizerTest extends ApiTestCase
             ->withPromiseOfThumbnail($thumbnail);
         $subjects = new ArraySequence([
             Builder::for(Subject::class)
-                ->withId('epidemiology-global-health')
-                ->withName('Epidemiology and Global Health')
-                ->__invoke(),
+                ->sample('epidemiology-global-health'),
             Builder::for(Subject::class)
-                ->withId('microbiology-infectious-disease')
-                ->withName('Microbiology and Infectious Disease')
-                ->__invoke(),
+                ->sample('microbiology-infectious-disease'),
         ]);
 
         return [
@@ -434,12 +430,23 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ->withImpactStatement('eLife has published papers on many...')
                     ->withPublishedDate(new DateTimeImmutable('2015-09-16T11:19:26+00:00'))
                     ->withThumbnail($thumbnail)
-                    ->withSubjects($subjects)
+                    ->withSubjects(
+                        $subjects)
                     ->withSelectedCurator(
                         $selectedCurator = Builder::for(Person::class)
                             ->sample('pjha')
                     )
                     ->withSelectedCuratorEtAl(true)
+                    ->withCurators(new ArraySequence([
+                        Builder::for(Person::class)
+                            ->sample('bcooper', ['snippet' => false]),
+                        Builder::for(Person::class)
+                            ->sample('pjha', ['snippet' => false]),
+                    ]))
+                    ->withContent(new ArraySequence([
+                        $blogArticle = Builder::for(BlogArticle::class)
+                            ->sample('slime'),
+                    ]))
                     ->__invoke(),
                 ['complete' => true, 'snippet' => true],
                 [
@@ -484,6 +491,10 @@ final class CollectionNormalizerTest extends ApiTestCase
                 ],
                 function (ApiTestCase $test) {
                     $test->mockCollectionCall('1', true);
+                    $test->mockSubjectCall('biophysics-structural-biology', true);
+                    $test->mockSubjectCall('epidemiology-global-health', true);
+                    $test->mockSubjectCall('microbiology-infectious-disease', true);
+                    $test->mockBlogArticleCall('359325');
                 },
             ],
             'minimum snippet' => [

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -11,8 +11,12 @@ use eLife\ApiSdk\Collection\ArraySequence;
 //use eLife\ApiSdk\Model\ArticleSection;
 //use eLife\ApiSdk\Model\Block\Paragraph;
 //use eLife\ApiSdk\Model\Copyright;
+use eLife\ApiSdk\Model\ArticleVoR;
+use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Collection;
-//use eLife\ApiSdk\Model\Person;
+use eLife\ApiSdk\Model\Interview;
+use eLife\ApiSdk\Model\Person;
+use eLife\ApiSdk\Model\PersonDetails;
 //use eLife\ApiSdk\Model\PersonAuthor;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\Subject;
@@ -118,6 +122,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                 ->withName('Microbiology and Infectious Disease')
                 ->__invoke(),
         ]);
+
         return [
             'complete' => [
                 $this->builder
@@ -129,163 +134,56 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ->withPromiseOfBanner($banner)
                     ->withThumbnail($thumbnail)
                     ->withSubjects($subjects)
+                    ->withSelectedCurator(
+                        $selectedCurator = Builder::for(Person::class)
+                            ->withId('pjha')
+                            ->withType('senior-editor')
+                            ->withDetails(new PersonDetails(
+                                'Prabhat Jha',
+                                'Jha, Prabhat'
+                            ))
+                            ->__invoke()
+                    )
+                    ->withSelectedCuratorEtAl(true)
+                    ->withCurators(new ArraySequence([
+                        Builder::for(Person::class)
+                            ->withId('bcooper')
+                            ->withType('reviewing-editor')
+                            ->withDetails(new PersonDetails(
+                                'Ben Cooper',
+                                'Cooper, Ben'
+                            ))
+                            ->__invoke(),
+                        $selectedCurator
+                    ]))
+                    ->withContent(new ArraySequence([
+                        Builder::for(ArticleVoR::class)
+                            ->sample('homo-naledi'),
+                        Builder::for(BlogArticle::class)
+                            ->sample('slime'),
+                        Builder::for(Interview::class)
+                            ->sample('controlling-traffic'),
+                    ]))
                     ->__invoke(),
-                ['complete' => true],
-array (
-  'id' => '1',
-  'title' => 'Tropical disease',
-  'subTitle' => 'A selection of papers',
-  'impactStatement' => 'eLife has published papers on many...',
-  'updated' => '2015-09-16T11:19:26+00:00',
-  'image' => 
-  array (
-    'banner' => 
-    array (
-      'alt' => '',
-      'sizes' => 
-      array (
-        '2:1' => 
-        array (
-          900 => 'https://placehold.it/900x450',
-          1800 => 'https://placehold.it/1800x900',
-        ),
-      ),
-    ),
-    'thumbnail' => 
-    array (
-      'alt' => '',
-      'sizes' => 
-      array (
-        '16:9' => 
-        array (
-          250 => 'https://placehold.it/250x141',
-          500 => 'https://placehold.it/500x281',
-        ),
-        '1:1' => 
-        array (
-          70 => 'https://placehold.it/70x70',
-          140 => 'https://placehold.it/140x140',
-        ),
-      ),
-    ),
-  ),
-  'subjects' => 
-  array (
-    0 => 
-    array (
-      'id' => 'epidemiology-global-health',
-      'name' => 'Epidemiology and Global Health',
-    ),
-    1 => 
-    array (
-      'id' => 'microbiology-infectious-disease',
-      'name' => 'Microbiology and Infectious Disease',
-    ),
-  ),
-  'selectedCurator' => 
-  array (
-    'id' => 'pjha',
-    'type' => 'senior-editor',
-    'name' => 
-    array (
-      'preferred' => 'Prabhat Jha',
-      'index' => 'Jha, Prabhat',
-    ),
-    'etAl' => true,
-  ),
-  'curators' => 
-  array (
-    0 => 
-    array (
-      'id' => 'bcooper',
-      'type' => 'reviewing-editor',
-      'name' => 
-      array (
-        'preferred' => 'Ben Cooper',
-        'index' => 'Cooper, Ben',
-      ),
-    ),
-    1 => 
-    array (
-      'id' => 'pjha',
-      'type' => 'senior-editor',
-      'name' => 
-      array (
-        'preferred' => 'Prabhat Jha',
-        'index' => 'Jha, Prabhat',
-      ),
-    ),
-  ),
-  'content' => 
-  array (
-    0 => 
-    array (
-      'type' => 'research-article',
-      'status' => 'vor',
-      'id' => '09560',
-      'version' => 1,
-      'doi' => '10.7554/eLife.09560',
-      'authorLine' => 'Lee R Berger et al',
-      'title' => '<i>Homo naledi</i>, a new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa',
-      'published' => '2015-09-10T00:00:00Z',
-      'statusDate' => '2015-09-10T00:00:00Z',
-      'volume' => 4,
-      'elocationId' => 'e09560',
-      'pdf' => 'https://elifesciences.org/content/4/e09560.pdf',
-      'subjects' => 
-      array (
-        0 => 
-        array (
-          'id' => 'genomics-evolutionary-biology',
-          'name' => 'Genomics and Evolutionary Biology',
-        ),
-      ),
-      'impactStatement' => 'A new hominin species has been unearthed in the Dinaledi Chamber of the Rising Star cave system in the largest assemblage of a single species of hominins yet discovered in Africa.',
-      'image' => 
-      array (
-        'thumbnail' => 
-        array (
-          'alt' => '',
-          'sizes' => 
-          array (
-            '16:9' => 
-            array (
-              250 => 'https://placehold.it/250x141',
-              500 => 'https://placehold.it/500x281',
-            ),
-            '1:1' => 
-            array (
-              70 => 'https://placehold.it/70x70',
-              140 => 'https://placehold.it/140x140',
-            ),
-          ),
-        ),
-      ),
-    ),
-    1 => 
-    array (
+                    /*
+    1 => array(
       'type' => 'blog-article',
       'id' => '1',
       'title' => 'Media coverage: Slime can see',
       'impactStatement' => 'In their research paper – Cyanobacteria use micro-optics to sense light direction – Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world’s oldest and smallest camera eye, allowing them to ‘see’.',
       'published' => '2016-07-08T08:33:25+00:00',
-      'subjects' => 
-      array (
-        0 => 
-        array (
+      'subjects' => array(
+        0 => array(
           'id' => 'biophysics-structural-biology',
           'name' => 'Biophysics and Structural Biology',
         ),
       ),
     ),
-    2 => 
-    array (
+    2 => array(
       'type' => 'interview',
       'id' => '1',
-      'interviewee' => 
-      array (
-        'name' => 
-        array (
+      'interviewee' => array(
+        'name' => array(
           'preferred' => 'Ramanath Hegde',
           'index' => 'Hegde, Ramanath',
         ),
@@ -295,10 +193,141 @@ array (
       'published' => '2016-01-29T16:22:28+00:00',
     ),
   ),
-  'relatedContent' => 
-  array (
-    0 => 
-    array (
+                     */
+                ['complete' => true],
+array(
+  'id' => '1',
+  'title' => 'Tropical disease',
+  'subTitle' => 'A selection of papers',
+  'impactStatement' => 'eLife has published papers on many...',
+  'updated' => '2015-09-16T11:19:26+00:00',
+  'image' => array(
+    'banner' => array(
+      'alt' => '',
+      'sizes' => array(
+        '2:1' => array(
+          900 => 'https://placehold.it/900x450',
+          1800 => 'https://placehold.it/1800x900',
+        ),
+      ),
+    ),
+    'thumbnail' => array(
+      'alt' => '',
+      'sizes' => array(
+        '16:9' => array(
+          250 => 'https://placehold.it/250x141',
+          500 => 'https://placehold.it/500x281',
+        ),
+        '1:1' => array(
+          70 => 'https://placehold.it/70x70',
+          140 => 'https://placehold.it/140x140',
+        ),
+      ),
+    ),
+  ),
+  'subjects' => array(
+    0 => array(
+      'id' => 'epidemiology-global-health',
+      'name' => 'Epidemiology and Global Health',
+    ),
+    1 => array(
+      'id' => 'microbiology-infectious-disease',
+      'name' => 'Microbiology and Infectious Disease',
+    ),
+  ),
+  'selectedCurator' => array(
+    'id' => 'pjha',
+    'type' => 'senior-editor',
+    'name' => array(
+      'preferred' => 'Prabhat Jha',
+      'index' => 'Jha, Prabhat',
+    ),
+    'etAl' => true,
+  ),
+  'curators' => array(
+    0 => array(
+      'id' => 'bcooper',
+      'type' => 'reviewing-editor',
+      'name' => array(
+        'preferred' => 'Ben Cooper',
+        'index' => 'Cooper, Ben',
+      ),
+    ),
+    1 => array(
+      'id' => 'pjha',
+      'type' => 'senior-editor',
+      'name' => array(
+        'preferred' => 'Prabhat Jha',
+        'index' => 'Jha, Prabhat',
+      ),
+    ),
+  ),
+  'content' => array(
+    0 => array(
+      'type' => 'research-article',
+      'status' => 'vor',
+      'id' => '09560',
+      'version' => 1,
+      'doi' => '10.7554/eLife.09560',
+      'authorLine' => 'Lee R Berger et al',
+      'title' => '<i>Homo naledi</i>, a new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa',
+      'published' => '2015-09-10T00:00:00+00:00',
+      'statusDate' => '2015-09-10T00:00:00+00:00',
+      'volume' => 4,
+      'elocationId' => 'e09560',
+      'pdf' => 'https://elifesciences.org/content/4/e09560.pdf',
+      'subjects' => array(
+        0 => array(
+          'id' => 'genomics-evolutionary-biology',
+          'name' => 'Genomics and Evolutionary Biology',
+        ),
+      ),
+      'impactStatement' => 'A new hominin species has been unearthed in the Dinaledi Chamber of the Rising Star cave system in the largest assemblage of a single species of hominins yet discovered in Africa.',
+      'image' => array(
+        'thumbnail' => array(
+          'alt' => '',
+          'sizes' => array(
+            '16:9' => array(
+              250 => 'https://placehold.it/250x141',
+              500 => 'https://placehold.it/500x281',
+            ),
+            '1:1' => array(
+              70 => 'https://placehold.it/70x70',
+              140 => 'https://placehold.it/140x140',
+            ),
+          ),
+        ),
+      ),
+    ),
+    1 => array(
+      'type' => 'blog-article',
+      'id' => '1',
+      'title' => 'Media coverage: Slime can see',
+      'impactStatement' => 'In their research paper – Cyanobacteria use micro-optics to sense light direction – Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world’s oldest and smallest camera eye, allowing them to ‘see’.',
+      'published' => '2016-07-08T08:33:25+00:00',
+      'subjects' => array(
+        0 => array(
+          'id' => 'biophysics-structural-biology',
+          'name' => 'Biophysics and Structural Biology',
+        ),
+      ),
+    ),
+    2 => array(
+      'type' => 'interview',
+      'id' => '1',
+      'interviewee' => array(
+        'name' => array(
+          'preferred' => 'Ramanath Hegde',
+          'index' => 'Hegde, Ramanath',
+        ),
+      ),
+      'title' => 'Controlling traffic',
+      'impactStatement' => 'Ramanath Hegde is a Postdoctoral Fellow at the Institute of Protein Biochemistry in Naples, Italy, where he investigates ways of preventing cells from destroying mutant proteins.',
+      'published' => '2016-01-29T16:22:28+00:00',
+    ),
+  ),
+  'relatedContent' => array(
+    0 => array(
       'type' => 'research-article',
       'status' => 'poa',
       'id' => '14107',
@@ -306,50 +335,41 @@ array (
       'doi' => '10.7554/eLife.14107',
       'authorLine' => 'Yongjian Huang et al',
       'title' => 'Molecular basis for multimerization in the activation of the epidermal growth factor',
-      'published' => '2016-03-28T00:00:00Z',
-      'statusDate' => '2016-03-28T00:00:00Z',
+      'published' => '2016-03-28T00:00:00+00:00',
+      'statusDate' => '2016-03-28T00:00:00+00:00',
       'volume' => 5,
       'elocationId' => 'e14107',
     ),
   ),
-  'podcastEpisodes' => 
-  array (
-    0 => 
-    array (
+  'podcastEpisodes' => array(
+    0 => array(
       'number' => 29,
       'title' => 'April/May 2016',
       'published' => '2016-05-27T13:19:42+00:00',
-      'image' => 
-      array (
-        'thumbnail' => 
-        array (
+      'image' => array(
+        'thumbnail' => array(
           'alt' => '',
-          'sizes' => 
-          array (
-            '16:9' => 
-            array (
+          'sizes' => array(
+            '16:9' => array(
               250 => 'https://placehold.it/250x141',
               500 => 'https://placehold.it/500x281',
             ),
-            '1:1' => 
-            array (
+            '1:1' => array(
               70 => 'https://placehold.it/70x70',
               140 => 'https://placehold.it/140x140',
             ),
           ),
         ),
       ),
-      'sources' => 
-      array (
-        0 => 
-        array (
+      'sources' => array(
+        0 => array(
           'mediaType' => 'audio/mpeg',
           'uri' => 'https://nakeddiscovery.com/scripts/mp3s/audio/eLife_Podcast_16.05.mp3',
         ),
       ),
     ),
   ),
-)
+),
             ],
         ];
     }

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -341,6 +341,12 @@ final class CollectionNormalizerTest extends ApiTestCase
                     $test->mockSubjectCall('microbiology-infectious-disease', true);
                     $test->mockSubjectCall('genomics-evolutionary-biology', true);
                     $test->mockBlogArticleCall('359325');
+                    $test->mockArticleCall('09560', true, $vor = true);
+                    $test->mockInterviewCall('1', true);
+                    $test->mockArticleCall('14107', true);
+                    $test->mockPodcastEpisodeCall(29, true);
+                    $test->mockSubjectCall('1', true);
+                    $test->mockArticleCall('1', true);
                 }
             ],
             'minimum' => [
@@ -455,6 +461,10 @@ final class CollectionNormalizerTest extends ApiTestCase
                         $blogArticle = Builder::for(BlogArticle::class)
                             ->sample('slime'),
                     ]))
+                    ->withRelatedContent(new ArraySequence([
+                        Builder::for(ArticlePoa::class)
+                            ->sample('growth-factor'),
+                    ]))
                     ->__invoke(),
                 ['complete' => true, 'snippet' => true],
                 [
@@ -503,6 +513,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                     $test->mockSubjectCall('epidemiology-global-health', true);
                     $test->mockSubjectCall('microbiology-infectious-disease', true);
                     $test->mockBlogArticleCall('359325');
+                    $test->mockArticleCall('14107', true);
                 },
             ],
             'minimum snippet' => [
@@ -524,9 +535,10 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ->withContent(new ArraySequence([
                         $blogArticle = Builder::for(BlogArticle::class)
                             ->sample('slime'),
-                        //null,
-                        //$articlePoA = Builder::for(ArticlePoA::class)
-                        //    ->sample('growth-factor')
+                    ]))
+                    ->withRelatedContent(new ArraySequence([
+                        Builder::for(ArticlePoa::class)
+                            ->sample('growth-factor'),
                     ]))
                     ->__invoke(),
                 ['snippet' => true],
@@ -562,6 +574,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                     $test->mockCollectionCall('1', true);
                     $test->mockSubjectCall('biophysics-structural-biology', true);
                     $test->mockBlogArticleCall('359325');
+                    $test->mockArticleCall('14107', true);
                 },
             ],
         ];

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -436,6 +436,54 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ],
                 ]
             ],
+            'minimum snippet' => [
+                Builder::for(Collection::class)
+                    ->withId('1')
+                    ->withTitle('Tropical disease')
+                    ->withPublishedDate(new DateTimeImmutable('2015-09-16T11:19:26+00:00'))
+                    ->withThumbnail($thumbnail)
+                    ->withSelectedCurator(
+                        $selectedCurator = Builder::for(Person::class)
+                            ->sample('pjha')
+                    )
+                    ->__invoke(),
+                ['snippet' => true],
+                [
+                    'id' => '1',
+                    'title' => 'Tropical disease',
+                    'updated' => '2015-09-16T11:19:26+00:00',
+                    'image' => 
+                    [
+                        'thumbnail' => 
+                        [
+                            'alt' => '',
+                            'sizes' => 
+                            [
+                                '16:9' => 
+                                [
+                                    250 => 'https://placehold.it/250x141',
+                                    500 => 'https://placehold.it/500x281',
+                                ],
+                                '1:1' => 
+                                [
+                                    70 => 'https://placehold.it/70x70',
+                                    140 => 'https://placehold.it/140x140',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'selectedCurator' => 
+                    [
+                        'id' => 'pjha',
+                        'type' => 'senior-editor',
+                        'name' => 
+                        [
+                            'preferred' => 'Prabhat Jha',
+                            'index' => 'Jha, Prabhat',
+                        ],
+                    ],
+                ]
+            ],
         ];
     }
 }

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -436,6 +436,65 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ],
                 ]
             ],
+            'complete snippet' => [
+                Builder::for(Collection::class)
+                    ->withId('1')
+                    ->withTitle('Tropical disease')
+                    ->withImpactStatement('eLife has published papers on many...')
+                    ->withPublishedDate(new DateTimeImmutable('2015-09-16T11:19:26+00:00'))
+                    ->withThumbnail($thumbnail)
+                    ->withSubjects($subjects)
+                    ->withSelectedCurator(
+                        $selectedCurator = Builder::for(Person::class)
+                            ->sample('pjha')
+                    )
+                    ->withSelectedCuratorEtAl(true)
+                    ->__invoke(),
+                ['complete' => true, 'snippet' => true],
+                [
+                    'id' => '1',
+                    'title' => 'Tropical disease',
+                    'impactStatement' => 'eLife has published papers on many...',
+                    'updated' => '2015-09-16T11:19:26+00:00',
+                    'image' => [
+                        'thumbnail' => [
+                            'alt' => '',
+                            'sizes' => [
+                                '16:9' => [
+                                    250 => 'https://placehold.it/250x141',
+                                    500 => 'https://placehold.it/500x281',
+                                ],
+                                '1:1' => [
+                                    70 => 'https://placehold.it/70x70',
+                                    140 => 'https://placehold.it/140x140',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'subjects' => [
+                        0 => [
+                            'id' => 'epidemiology-global-health',
+                            'name' => 'Epidemiology and Global Health',
+                        ],
+                        1 => [
+                            'id' => 'microbiology-infectious-disease',
+                            'name' => 'Microbiology and Infectious Disease',
+                        ],
+                    ],
+                    'selectedCurator' => [
+                        'id' => 'pjha',
+                        'type' => 'senior-editor',
+                        'name' => [
+                            'preferred' => 'Prabhat Jha',
+                            'index' => 'Jha, Prabhat',
+                        ],
+                        'etAl' => true,
+                    ],
+                ],
+                function (ApiTestCase $test) {
+                    //$test->mockCollectionCall(1, true);
+                },
+            ],
             'minimum snippet' => [
                 Builder::for(Collection::class)
                     ->withId('1')

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -446,7 +446,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ]))
                     ->withPodcastEpisodes(new ArraySequence([
                         Builder::for(PodcastEpisode::class)
-                            ->sample('29')
+                            ->sample('29'),
                     ]))
                     ->__invoke(),
                 ['complete' => true, 'snippet' => true],

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -77,6 +77,25 @@ final class CollectionNormalizerTest extends ApiTestCase
         $this->assertEquals($expected, $this->normalizer->normalize($collection, null, $context));
     }
 
+    /**
+     * @test
+     * @dataProvider normalizeProvider
+     */
+    public function it_denormalizes_collections(
+        Collection $expected,
+        array $context,
+        array $json,
+        callable $extra = null
+    ) {
+        if ($extra) {
+            call_user_func($extra, $this);
+        }
+
+        $actual = $this->normalizer->denormalize($json, Collection::class, null, $context);
+
+        $this->assertObjectsAreEqual($expected, $actual);
+    }
+
     public function normalizeProvider() : array
     {
         $date = new DateTimeImmutable();
@@ -109,7 +128,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                 [
                     'id' => 'tropical-disease',
                     'title' => 'Tropical disease',
-                    'impact_statement' => 'Tropical disease impact statement',
+                    'impactStatement' => 'Tropical disease impact statement',
                     'updated' => $date->format(DATE_ATOM),
                     'image' => [
                         'thumbnail' => [

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -125,7 +125,7 @@ final class CollectionNormalizerTest extends ApiTestCase
 
         return [
             'complete' => [
-                $this->builder
+                Builder::for(Collection::class)
                     ->withId('1')
                     ->withTitle('Tropical disease')
                     ->withPromiseOfSubTitle('A selection of papers')
@@ -136,24 +136,12 @@ final class CollectionNormalizerTest extends ApiTestCase
                     ->withSubjects($subjects)
                     ->withSelectedCurator(
                         $selectedCurator = Builder::for(Person::class)
-                            ->withId('pjha')
-                            ->withType('senior-editor')
-                            ->withDetails(new PersonDetails(
-                                'Prabhat Jha',
-                                'Jha, Prabhat'
-                            ))
-                            ->__invoke()
+                            ->sample('pjha')
                     )
                     ->withSelectedCuratorEtAl(true)
                     ->withCurators(new ArraySequence([
                         Builder::for(Person::class)
-                            ->withId('bcooper')
-                            ->withType('reviewing-editor')
-                            ->withDetails(new PersonDetails(
-                                'Ben Cooper',
-                                'Cooper, Ben'
-                            ))
-                            ->__invoke(),
+                            ->sample('bcooper'),
                         $selectedCurator
                     ]))
                     ->withContent(new ArraySequence([
@@ -349,6 +337,104 @@ final class CollectionNormalizerTest extends ApiTestCase
                         ],
                     ],
                 ],
+            ],
+            'minimum' => [
+                Builder::for(Collection::class)
+                    ->withId('1')
+                    ->withTitle('Tropical disease')
+                    ->withPublishedDate(new DateTimeImmutable('2015-09-16T11:19:26+00:00'))
+                    ->withPromiseOfBanner($banner)
+                    ->withThumbnail($thumbnail)
+                    ->withSelectedCurator(
+                        $selectedCurator = Builder::for(Person::class)
+                            ->sample('pjha')
+                    )
+                    ->withCurators(new ArraySequence([
+                        $selectedCurator
+                    ]))
+                    ->withContent(new ArraySequence([
+                        Builder::for(ArticlePoA::class)
+                            ->sample('growth-factor'),
+                    ]))
+                    ->__invoke(),
+                [],
+                [
+                    'id' => '1',
+                    'title' => 'Tropical disease',
+                    'updated' => '2015-09-16T11:19:26+00:00',
+                    'image' => 
+                    [
+                        'banner' => 
+                        [
+                            'alt' => '',
+                            'sizes' => 
+                            [
+                                '2:1' => 
+                                [
+                                    900 => 'https://placehold.it/900x450',
+                                    1800 => 'https://placehold.it/1800x900',
+                                ],
+                            ],
+                        ],
+                        'thumbnail' => 
+                        [
+                            'alt' => '',
+                            'sizes' => 
+                            [
+                                '16:9' => 
+                                [
+                                    250 => 'https://placehold.it/250x141',
+                                    500 => 'https://placehold.it/500x281',
+                                ],
+                                '1:1' => 
+                                [
+                                    70 => 'https://placehold.it/70x70',
+                                    140 => 'https://placehold.it/140x140',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'selectedCurator' => 
+                    [
+                        'id' => 'pjha',
+                        'type' => 'senior-editor',
+                        'name' => 
+                        [
+                            'preferred' => 'Prabhat Jha',
+                            'index' => 'Jha, Prabhat',
+                        ],
+                    ],
+                    'curators' => 
+                    [
+                        0 => 
+                        [
+                            'id' => 'pjha',
+                            'type' => 'senior-editor',
+                            'name' => 
+                            [
+                                'preferred' => 'Prabhat Jha',
+                                'index' => 'Jha, Prabhat',
+                            ],
+                        ],
+                    ],
+                    'content' => 
+                    [
+                        0 => 
+                        [
+                            'type' => 'research-article',
+                            'status' => 'poa',
+                            'id' => '14107',
+                            'version' => 1,
+                            'doi' => '10.7554/eLife.14107',
+                            'authorLine' => 'Yongjian Huang et al',
+                            'title' => 'Molecular basis for multimerization in the activation of the epidermal growth factor',
+                            'published' => '2016-03-28T00:00:00+00:00',
+                            'statusDate' => '2016-03-28T00:00:00+00:00',
+                            'volume' => 5,
+                            'elocationId' => 'e14107',
+                        ],
+                    ],
+                ]
             ],
         ];
     }

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -421,6 +421,11 @@ final class CollectionNormalizerTest extends ApiTestCase
                         ],
                     ],
                 ],
+                function (ApiTestCase $test) {
+                    $test->mockCollectionCall('1', true);
+                    $test->mockSubjectCall('biophysics-structural-biology', true);
+                    $test->mockArticleCall('14107', true);
+                },
             ],
             'complete snippet' => [
                 Builder::for(Collection::class)

--- a/test/Serializer/InterviewNormalizerTest.php
+++ b/test/Serializer/InterviewNormalizerTest.php
@@ -183,7 +183,7 @@ final class InterviewNormalizerTest extends ApiTestCase
                 $interview = new Interview('interview1',
                     new Interviewee(new PersonDetails('preferred name', 'index name', '0000-0002-1825-0097'),
                         new ArraySequence([new IntervieweeCvLine('date', 'text')])), 'Interview 1 title', $date,
-                    'Interview 1 impact statement', new ArraySequence([new Paragraph('Interview 1 text')])
+                    'Interview 1 impact statement', new ArraySequence([new Paragraph('Interview interview1 text')])
                 ),
                 ['snippet' => true],
                 [
@@ -200,13 +200,13 @@ final class InterviewNormalizerTest extends ApiTestCase
                     'impactStatement' => 'Interview 1 impact statement',
                 ],
                 function (ApiTestCase $test) {
-                    $test->mockInterviewCall(1, true);
+                    $test->mockInterviewCall('interview1', true);
                 },
             ],
             'minimum snippet' => [
                 $interview = new Interview('interview1',
                     new Interviewee(new PersonDetails('preferred name', 'index name'), new ArraySequence([])),
-                    'Interview 1 title', $date, null, new ArraySequence([new Paragraph('Interview 1 text')])
+                    'Interview 1 title', $date, null, new ArraySequence([new Paragraph('Interview interview1 text')])
                 ),
                 ['snippet' => true],
                 [
@@ -221,7 +221,7 @@ final class InterviewNormalizerTest extends ApiTestCase
                     'published' => $date->format(DATE_ATOM),
                 ],
                 function (ApiTestCase $test) {
-                    $test->mockInterviewCall(1);
+                    $test->mockInterviewCall('interview1');
                 },
             ],
         ];

--- a/test/Serializer/PersonNormalizerTest.php
+++ b/test/Serializer/PersonNormalizerTest.php
@@ -117,7 +117,7 @@ final class PersonNormalizerTest extends ApiTestCase
 
         $actual = $this->normalizer->denormalize($json, Person::class, null, $context);
 
-        $this->mockSubjectCall(1);
+        $this->mockSubjectCall('subject1');
 
         $this->assertObjectsAreEqual($expected, $actual);
     }
@@ -136,7 +136,7 @@ final class PersonNormalizerTest extends ApiTestCase
                 '140' => 'https://placehold.it/140x140',
             ]),
         ]);
-        $subject = new Subject('subject1', 'Subject 1 name', promise_for('Subject 1 impact statement'),
+        $subject = new Subject('subject1', 'Subject 1 name', promise_for('Subject subject1 impact statement'),
             promise_for($banner), promise_for($thumbnail));
 
         return [
@@ -201,8 +201,8 @@ final class PersonNormalizerTest extends ApiTestCase
                 new Person('person1', new PersonDetails('Person 1 preferred', 'Person 1 index', '0000-0002-1825-0097'),
                     'senior-editor', $thumbnail,
                     promise_for(new PersonResearch(new ArraySequence([$subject]), ['Focus'], ['Organism'])),
-                    new ArraySequence([new Paragraph('Person 1 profile text')]),
-                    promise_for('Person 1 competing interests')),
+                    new ArraySequence([new Paragraph('person1 profile text')]),
+                    promise_for('person1 competing interests')),
                 ['snippet' => true],
                 [
                     'name' => [

--- a/test/Serializer/PodcastEpisodeNormalizerTest.php
+++ b/test/Serializer/PodcastEpisodeNormalizerTest.php
@@ -124,8 +124,8 @@ final class PodcastEpisodeNormalizerTest extends ApiTestCase
 
         $actual = $this->normalizer->denormalize($json, PodcastEpisode::class, null, $context);
 
-        $this->mockSubjectCall(1);
-        $this->mockArticleCall(1, !empty($context['complete']));
+        $this->mockSubjectCall('1');
+        $this->mockArticleCall('1', !empty($context['complete']));
 
         $this->assertObjectsAreEqual($expected, $actual);
     }
@@ -145,7 +145,7 @@ final class PodcastEpisodeNormalizerTest extends ApiTestCase
                 '140' => 'https://placehold.it/140x140',
             ]),
         ]);
-        $subject = new Subject('subject1', 'Subject 1 name', promise_for('Subject 1 impact statement'),
+        $subject = new Subject('1', 'Subject 1 name', promise_for('Subject 1 impact statement'),
             promise_for($banner), promise_for($thumbnail));
 
         return [
@@ -156,7 +156,7 @@ final class PodcastEpisodeNormalizerTest extends ApiTestCase
                     new ArraySequence([]), new ArraySequence([
                         new PodcastEpisodeChapter(1, 'Chapter 1 title', 0, 'Chapter impact statement',
                             new ArraySequence([
-                                new ArticlePoA('article1', 1, 'research-article', '10.7554/eLife.1', 'Author et al',
+                                new ArticlePoA('1', 1, 'research-article', '10.7554/eLife.1', 'Author et al',
                                     'Article 1 title prefix', 'Article 1 title',
                                     new DateTimeImmutable('2000-01-01T00:00:00+00:00'),
                                     new DateTimeImmutable('1999-12-31T00:00:00+00:00'), 1, 'e1',
@@ -210,7 +210,7 @@ final class PodcastEpisodeNormalizerTest extends ApiTestCase
                             'time' => 0,
                             'content' => [
                                 [
-                                    'id' => 'article1',
+                                    'id' => '1',
                                     'version' => 1,
                                     'type' => 'research-article',
                                     'doi' => '10.7554/eLife.1',
@@ -223,7 +223,7 @@ final class PodcastEpisodeNormalizerTest extends ApiTestCase
                                     'titlePrefix' => 'Article 1 title prefix',
                                     'pdf' => 'http://www.example.com/',
                                     'subjects' => [
-                                        ['id' => 'subject1', 'name' => 'Subject 1 name'],
+                                        ['id' => '1', 'name' => 'Subject 1 name'],
                                     ],
                                     'researchOrganisms' => ['Article 1 research organism'],
                                     'status' => 'poa',
@@ -240,7 +240,7 @@ final class PodcastEpisodeNormalizerTest extends ApiTestCase
                     [new PodcastEpisodeSource('audio/mpeg', 'https://www.example.com/episode.mp3')],
                     new ArraySequence([]), new ArraySequence([
                         new PodcastEpisodeChapter(1, 'Chapter title', 0, null, new ArraySequence([
-                            new ArticlePoA('article1', 1, 'research-article', '10.7554/eLife.1', 'Author et al', null,
+                            new ArticlePoA('1', 1, 'research-article', '10.7554/eLife.1', 'Author et al', null,
                                 'Article 1 title', new DateTimeImmutable('2000-01-01T00:00:00+00:00'),
                                 new DateTimeImmutable('1999-12-31T00:00:00+00:00'), 1, 'e1', null,
                                 new ArraySequence([]), [], promise_for(null), promise_for(null),
@@ -290,7 +290,7 @@ final class PodcastEpisodeNormalizerTest extends ApiTestCase
                             'time' => 0,
                             'content' => [
                                 [
-                                    'id' => 'article1',
+                                    'id' => '1',
                                     'version' => 1,
                                     'type' => 'research-article',
                                     'doi' => '10.7554/eLife.1',
@@ -313,7 +313,7 @@ final class PodcastEpisodeNormalizerTest extends ApiTestCase
                     [new PodcastEpisodeSource('audio/mpeg', 'https://www.example.com/episode.mp3')],
                     new ArraySequence([]), new ArraySequence([
                         new PodcastEpisodeChapter(1, 'Chapter title', 0, 'Chapter impact statement', new ArraySequence([
-                            new ArticlePoA('article1', 1, 'research-article', '10.7554/eLife.1', 'Author et al',
+                            new ArticlePoA('1', 1, 'research-article', '10.7554/eLife.1', 'Author et al',
                                 'Article 1 title prefix', 'Article 1 title',
                                 new DateTimeImmutable('2000-01-01T00:00:00+00:00'),
                                 new DateTimeImmutable('1999-12-31T00:00:00+00:00'), 1, 'e1', 'http://www.example.com/',
@@ -360,7 +360,7 @@ final class PodcastEpisodeNormalizerTest extends ApiTestCase
                     [new PodcastEpisodeSource('audio/mpeg', 'https://www.example.com/episode.mp3')],
                     new ArraySequence([]), new ArraySequence([
                         new PodcastEpisodeChapter(1, 'Chapter title', 0, null, new ArraySequence([
-                            new ArticlePoA('article1', 1, 'research-article', '10.7554/eLife.1', 'Author et al', null,
+                            new ArticlePoA('1', 1, 'research-article', '10.7554/eLife.1', 'Author et al', null,
                                 'Article 1 title', new DateTimeImmutable('2000-01-01T00:00:00+00:00'),
                                 new DateTimeImmutable('1999-12-31T00:00:00+00:00'), 1, 'e1', null,
                                 new ArraySequence([]), [], promise_for(null), promise_for(null),

--- a/test/Serializer/PodcastEpisodeNormalizerTest.php
+++ b/test/Serializer/PodcastEpisodeNormalizerTest.php
@@ -10,6 +10,7 @@ use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\ArticlePoA;
 use eLife\ApiSdk\Model\ArticleSection;
 use eLife\ApiSdk\Model\Block\Paragraph;
+use eLife\ApiSdk\Model\Collection;
 use eLife\ApiSdk\Model\Copyright;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\ImageSize;
@@ -23,6 +24,7 @@ use eLife\ApiSdk\Serializer\PodcastEpisodeNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use test\eLife\ApiSdk\ApiTestCase;
+use test\eLife\ApiSdk\Builder;
 use function GuzzleHttp\Promise\promise_for;
 use function GuzzleHttp\Promise\rejection_for;
 
@@ -126,6 +128,12 @@ final class PodcastEpisodeNormalizerTest extends ApiTestCase
 
         $this->mockSubjectCall('1');
         $this->mockArticleCall('1', !empty($context['complete']));
+        // only for complete?
+        $this->mockCollectionCall('tropical-disease', false);
+        $this->mockPersonCall('pjha', false);
+        $this->mockPersonCall('bcooper', false);
+        $this->mockBlogArticleCall('359325', false);
+        $this->mockSubjectCall('biophysics-structural-biology');
 
         $this->assertObjectsAreEqual($expected, $actual);
     }
@@ -166,6 +174,8 @@ final class PodcastEpisodeNormalizerTest extends ApiTestCase
                                     promise_for(1),
                                     promise_for(new Copyright('CC-BY-4.0', 'Statement', 'Author et al')),
                                     new ArraySequence([new PersonAuthor(new PersonDetails('Author', 'Author'))])),
+                                Builder::for(Collection::class)
+                                    ->sample('tropical-disease'),
                             ])),
                     ])),
                 ['complete' => true],
@@ -227,6 +237,35 @@ final class PodcastEpisodeNormalizerTest extends ApiTestCase
                                     ],
                                     'researchOrganisms' => ['Article 1 research organism'],
                                     'status' => 'poa',
+                                ],
+                                [
+                                    'id' => 'tropical-disease',
+                                    'type' => 'collection',
+                                    'title' => 'Tropical disease',
+                                    'updated' => '2000-01-01T00:00:00+00:00',
+                                    'image' => [
+                                        'thumbnail' => [
+                                            'alt' => '',
+                                            'sizes' => [
+                                                '16:9' => [
+                                                    250 => 'https://placehold.it/250x141',
+                                                    500 => 'https://placehold.it/500x281',
+                                                ],
+                                                '1:1' => [
+                                                    70 => 'https://placehold.it/70x70',
+                                                    140 => 'https://placehold.it/140x140',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                    'selectedCurator' => [
+                                        'id' => 'pjha',
+                                        'name' => [
+                                            'preferred' => 'Prabhat Jha',
+                                            'index' => 'Jha, Prabhat',
+                                        ],
+                                        'type' => 'senior-editor',
+                                    ],
                                 ],
                             ],
                             'impactStatement' => 'Chapter impact statement',

--- a/test/Serializer/PodcastEpisodeNormalizerTest.php
+++ b/test/Serializer/PodcastEpisodeNormalizerTest.php
@@ -128,12 +128,6 @@ final class PodcastEpisodeNormalizerTest extends ApiTestCase
 
         $this->mockSubjectCall('1');
         $this->mockArticleCall('1', !empty($context['complete']));
-        // only for complete?
-        $this->mockCollectionCall('tropical-disease', false);
-        $this->mockPersonCall('pjha', false);
-        $this->mockPersonCall('bcooper', false);
-        $this->mockBlogArticleCall('359325', false);
-        $this->mockSubjectCall('biophysics-structural-biology');
 
         $this->assertObjectsAreEqual($expected, $actual);
     }
@@ -273,6 +267,13 @@ final class PodcastEpisodeNormalizerTest extends ApiTestCase
                     ],
                     'impactStatement' => 'Podcast episode 1 impact statement',
                 ],
+                function ($test) {
+                    $test->mockCollectionCall('tropical-disease', false);
+                    $test->mockPersonCall('pjha', false);
+                    $test->mockPersonCall('bcooper', false);
+                    $test->mockBlogArticleCall('359325', false);
+                    $test->mockSubjectCall('biophysics-structural-biology');
+                },
             ],
             'minimum' => [
                 new PodcastEpisode(1, 'Podcast episode 1 title', null, $date, promise_for($banner), $thumbnail,

--- a/test/Serializer/SubjectNormalizerTest.php
+++ b/test/Serializer/SubjectNormalizerTest.php
@@ -76,7 +76,7 @@ final class SubjectNormalizerTest extends ApiTestCase
     public function it_normalize_subjects(Subject $subject, array $context, array $expected)
     {
         if (!empty($context['snippet'])) {
-            $this->mockSubjectCall(1);
+            $this->mockSubjectCall('subject1');
         }
 
         $this->assertSame($expected, $this->normalizer->normalize($subject, null, $context));
@@ -116,7 +116,7 @@ final class SubjectNormalizerTest extends ApiTestCase
         $actual = $this->normalizer->denormalize($json, Subject::class, null, $context);
 
         if (!empty($context['snippet'])) {
-            $this->mockSubjectCall(1);
+            $this->mockSubjectCall('subject1');
         }
 
         $this->assertObjectsAreEqual($expected, $actual);
@@ -139,7 +139,7 @@ final class SubjectNormalizerTest extends ApiTestCase
 
         return [
             'complete' => [
-                new Subject('subject1', 'Subject 1 name', promise_for('Subject 1 impact statement'),
+                new Subject('subject1', 'Subject 1 name', promise_for('Subject subject1 impact statement'),
                     promise_for($banner), promise_for($thumbnail)),
                 [],
                 [
@@ -169,7 +169,7 @@ final class SubjectNormalizerTest extends ApiTestCase
                             ],
                         ],
                     ],
-                    'impactStatement' => 'Subject 1 impact statement',
+                    'impactStatement' => 'Subject subject1 impact statement',
                 ],
             ],
             'minimum' => [
@@ -206,7 +206,7 @@ final class SubjectNormalizerTest extends ApiTestCase
                 ],
             ],
             'snippet' => [
-                new Subject('subject1', 'Subject 1 name', promise_for('Subject 1 impact statement'),
+                new Subject('subject1', 'Subject 1 name', promise_for('Subject subject1 impact statement'),
                     promise_for($banner), promise_for($thumbnail)),
                 ['snippet' => true],
                 [

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -27,7 +27,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
                 continue;
             }
 
-            $methodDetail = $detail.' '.get_class($actual)."::".$method;
+            $methodDetail = $detail.' '.get_class($actual).'::'.$method;
             try {
                 $this->assertItemsAreEqual($expected->{$method}(), $actual->{$method}(), $methodDetail);
             } catch (RejectionException $e) {
@@ -47,7 +47,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
             $this->assertInternalType('array', $expected, "We are getting an array out of $detail but we were not expecting it");
             $this->assertEquals(count($expected), count($actual), "Count of $detail doesn't match expected");
             foreach ($actual as $key => $actualItem) {
-                $this->assertItemsAreEqual($expected[$key], $actualItem, $detail .' '.$key);
+                $this->assertItemsAreEqual($expected[$key], $actualItem, $detail.' '.$key);
             }
         } else {
             $this->assertEquals($expected, $actual, $detail);

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -23,20 +23,24 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
                 continue;
             }
 
-            $this->assertItemsAreEqual($expected->{$method}(), $actual->{$method}());
+            $detail = get_class($actual)."::".$method;
+            $this->assertItemsAreEqual($expected->{$method}(), $actual->{$method}(), $detail);
         }
     }
 
-    private function assertItemsAreEqual($expected, $actual)
+    private function assertItemsAreEqual($expected, $actual, $detail = null)
     {
         $actual = $this->normalise($actual);
         $expected = $this->normalise($expected);
 
         if (is_object($actual)) {
+            echo "Recur: " . get_class($actual) . PHP_EOL;
             $this->assertObjectsAreEqual($expected, $actual);
         } elseif (is_array($actual)) {
+            $this->assertInternalType('array', $expected, "We are getting an array out of $detail but we were not expecting it");
+            $this->assertEquals(count($expected), count($actual), "Count of $detail doesn't match expected");
             foreach ($actual as $key => $actualItem) {
-                $this->assertItemsAreEqual($expected[$key], $actualItem);
+                $this->assertItemsAreEqual($expected[$key], $actualItem, $detail .' '.$key);
             }
         } else {
             $this->assertEquals($expected, $actual);

--- a/vendor-extra/Csa/GuzzleBundle/GuzzleHttp/Middleware/MockMiddleware.php
+++ b/vendor-extra/Csa/GuzzleBundle/GuzzleHttp/Middleware/MockMiddleware.php
@@ -45,8 +45,11 @@ class MockMiddleware extends CacheMiddleware
 
             try {
                 if (null === $response = $this->adapter->fetch($request)) {
-                    var_Dump($request);
-                    throw new \RuntimeException('Record not found.');
+                    throw new \RuntimeException(sprintf(
+                        'Record not found for request: %s %s',
+                        $request->getMethod(),
+                        $request->getUri()
+                    ));
                 }
 
                 $response = $this->addDebugHeader($response, 'REPLAY');

--- a/vendor-extra/Csa/GuzzleBundle/GuzzleHttp/Middleware/MockMiddleware.php
+++ b/vendor-extra/Csa/GuzzleBundle/GuzzleHttp/Middleware/MockMiddleware.php
@@ -45,6 +45,7 @@ class MockMiddleware extends CacheMiddleware
 
             try {
                 if (null === $response = $this->adapter->fetch($request)) {
+                    var_Dump($request);
                     throw new \RuntimeException('Record not found.');
                 }
 

--- a/vendor-extra/Csa/GuzzleBundle/GuzzleHttp/Middleware/MockMiddleware.php
+++ b/vendor-extra/Csa/GuzzleBundle/GuzzleHttp/Middleware/MockMiddleware.php
@@ -13,7 +13,6 @@ namespace Csa\Bundle\GuzzleBundle\GuzzleHttp\Middleware;
 
 use Csa\Bundle\GuzzleBundle\Cache\StorageAdapterInterface;
 use GuzzleHttp\Promise\FulfilledPromise;
-use GuzzleHttp\Promise\RejectedPromise;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -43,19 +42,15 @@ class MockMiddleware extends CacheMiddleware
                 return $this->handleSave($handler, $request, $options);
             }
 
-            try {
-                if (null === $response = $this->adapter->fetch($request)) {
-                    throw new \RuntimeException(sprintf(
-                        'Record not found for request: %s %s',
-                        $request->getMethod(),
-                        $request->getUri()
-                    ));
-                }
-
-                $response = $this->addDebugHeader($response, 'REPLAY');
-            } catch (\RuntimeException $e) {
-                return new RejectedPromise($e);
+            if (null === $response = $this->adapter->fetch($request)) {
+                throw new \RuntimeException(sprintf(
+                    'Record not found for request: %s %s',
+                    $request->getMethod(),
+                    $request->getUri()
+                ));
             }
+
+            $response = $this->addDebugHeader($response, 'REPLAY');
 
             return new FulfilledPromise($response);
         };


### PR DESCRIPTION
A `Collections` object is created and configured with a `CollectionNormalizer` to create `Collection` objects from API responses.

Given the size of the test data, the `Builder` class extracts duplicated code used to create object instances. It does so through two mechanisms:
- creation with default values (`create(...::CLASS)->with...()->__invoke()`, which allows to specify only the values which are interesting for the current test
- sample objects which are representative of a category (`sample(...)`), usually to quickly fill as collaborators of the objects which are actually under test.

Whenever possible, API responses are generated starting from the id (or `number` for more natural primary keys).

On the implementation side, I extracted two classes `IdentityMap` and `NormalizationHelper` to reduce the amount of duplication between different `Normalizers`. They are used only in the `Collection` section but can in theory be used for other types when we rework them for other reasons.
