### PR TITLE
Allow normalization to/from any model

### DIFF
--- a/src/Model/AnnualReport.php
+++ b/src/Model/AnnualReport.php
@@ -2,7 +2,7 @@
 
 namespace eLife\ApiSdk\Model;
 
-final class AnnualReport
+final class AnnualReport implements Model
 {
     private $year;
     private $uri;

--- a/src/Model/ArticleVersion.php
+++ b/src/Model/ArticleVersion.php
@@ -6,7 +6,7 @@ use DateTimeImmutable;
 use eLife\ApiSdk\Collection\Sequence;
 use GuzzleHttp\Promise\PromiseInterface;
 
-abstract class ArticleVersion
+abstract class ArticleVersion implements Model
 {
     private $id;
     private $version;

--- a/src/Model/BlogArticle.php
+++ b/src/Model/BlogArticle.php
@@ -5,7 +5,7 @@ namespace eLife\ApiSdk\Model;
 use DateTimeImmutable;
 use eLife\ApiSdk\Collection\Sequence;
 
-final class BlogArticle
+final class BlogArticle implements Model
 {
     private $id;
     private $title;

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -6,7 +6,7 @@ use DateTimeImmutable;
 use eLife\ApiSdk\Collection\Sequence;
 use GuzzleHttp\Promise\PromiseInterface;
 
-final class Collection
+final class Collection implements Model
 {
     private $id;
     private $title;
@@ -99,6 +99,9 @@ final class Collection
         return $this->thumbnail;
     }
 
+    /**
+     * @return Sequence|Subject[]
+     */
     public function getSubjects() : Sequence
     {
         return $this->subjects;
@@ -114,21 +117,33 @@ final class Collection
         return $this->selectedCuratorEtAl;
     }
 
+    /**
+     * @return Sequence|Person[]
+     */
     public function getCurators() : Sequence
     {
         return $this->curators;
     }
 
+    /**
+     * @return Sequence|Model[]
+     */
     public function getContent() : Sequence
     {
         return $this->content;
     }
 
+    /**
+     * @return Sequence|Model[]
+     */
     public function getRelatedContent() : Sequence
     {
         return $this->relatedContent;
     }
 
+    /**
+     * @return Sequence|PodcastEpisode[]
+     */
     public function getPodcastEpisodes() : Sequence
     {
         return $this->podcastEpisodes;

--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -7,7 +7,7 @@ use DateTimeZone;
 use eLife\ApiSdk\Collection\Sequence;
 use GuzzleHttp\Promise\PromiseInterface;
 
-final class Event
+final class Event implements Model
 {
     private $id;
     private $title;

--- a/src/Model/Interview.php
+++ b/src/Model/Interview.php
@@ -5,7 +5,7 @@ namespace eLife\ApiSdk\Model;
 use DateTimeImmutable;
 use eLife\ApiSdk\Collection\Sequence;
 
-final class Interview
+final class Interview implements Model
 {
     private $id;
     private $interviewee;

--- a/src/Model/LabsExperiment.php
+++ b/src/Model/LabsExperiment.php
@@ -6,7 +6,7 @@ use DateTimeImmutable;
 use eLife\ApiSdk\Collection\Sequence;
 use GuzzleHttp\Promise\PromiseInterface;
 
-final class LabsExperiment
+final class LabsExperiment implements Model
 {
     private $number;
     private $title;

--- a/src/Model/MediumArticle.php
+++ b/src/Model/MediumArticle.php
@@ -5,7 +5,7 @@ namespace eLife\ApiSdk\Model;
 use DateTimeImmutable;
 use DateTimeZone;
 
-final class MediumArticle
+final class MediumArticle implements Model
 {
     private $uri;
     private $title;

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace eLife\ApiSdk\Model;
+
+interface Model
+{
+}

--- a/src/Model/Person.php
+++ b/src/Model/Person.php
@@ -5,7 +5,7 @@ namespace eLife\ApiSdk\Model;
 use eLife\ApiSdk\Collection\Sequence;
 use GuzzleHttp\Promise\PromiseInterface;
 
-final class Person
+final class Person implements Model
 {
     private $id;
     private $details;

--- a/src/Model/PodcastEpisode.php
+++ b/src/Model/PodcastEpisode.php
@@ -6,7 +6,7 @@ use DateTimeImmutable;
 use eLife\ApiSdk\Collection\Sequence;
 use GuzzleHttp\Promise\PromiseInterface;
 
-final class PodcastEpisode
+final class PodcastEpisode implements Model
 {
     private $number;
     private $title;

--- a/src/Model/PodcastEpisodeChapter.php
+++ b/src/Model/PodcastEpisodeChapter.php
@@ -52,6 +52,9 @@ final class PodcastEpisodeChapter
         return $this->impactStatement;
     }
 
+    /**
+     * @return Sequence|Model[]
+     */
     public function getContent(): Sequence
     {
         return $this->content;

--- a/src/Model/Subject.php
+++ b/src/Model/Subject.php
@@ -4,7 +4,7 @@ namespace eLife\ApiSdk\Model;
 
 use GuzzleHttp\Promise\PromiseInterface;
 
-final class Subject
+final class Subject implements Model
 {
     private $id;
     private $name;

--- a/src/Serializer/ArticlePoANormalizer.php
+++ b/src/Serializer/ArticlePoANormalizer.php
@@ -5,6 +5,7 @@ namespace eLife\ApiSdk\Serializer;
 use DateTimeImmutable;
 use eLife\ApiSdk\Model\ArticlePoA;
 use eLife\ApiSdk\Model\ArticleVersion;
+use eLife\ApiSdk\Model\Model;
 use GuzzleHttp\Promise\PromiseInterface;
 
 final class ArticlePoANormalizer extends ArticleVersionNormalizer
@@ -43,7 +44,9 @@ final class ArticlePoANormalizer extends ArticleVersionNormalizer
         return
             ArticlePoA::class === $type
             ||
-            (ArticleVersion::class === $type && 'poa' === $data['status']);
+            (ArticleVersion::class === $type && 'poa' === $data['status'])
+            ||
+            Model::class === $type && $this->isArticleType($data['type'] ?? 'unknown') && 'poa' === ($data['status'] ?? 'unknown');
     }
 
     /**

--- a/src/Serializer/ArticleVersionNormalizer.php
+++ b/src/Serializer/ArticleVersionNormalizer.php
@@ -251,6 +251,24 @@ abstract class ArticleVersionNormalizer implements NormalizerInterface, Denormal
         return $this->normalizeArticle($object, $data, $format, $context);
     }
 
+    final protected function isArticleType(string $type)
+    {
+        return in_array($type, [
+            'correction',
+            'editorial',
+            'feature',
+            'insight',
+            'research-advance',
+            'research-article',
+            'research-exchange',
+            'retraction',
+            'registered-report',
+            'replication-study',
+            'short-report',
+            'tools-resources',
+        ]);
+    }
+
     abstract protected function denormalizeArticle(
         $data,
         PromiseInterface $article = null,

--- a/src/Serializer/ArticleVoRNormalizer.php
+++ b/src/Serializer/ArticleVoRNormalizer.php
@@ -11,6 +11,7 @@ use eLife\ApiSdk\Model\ArticleVersion;
 use eLife\ApiSdk\Model\ArticleVoR;
 use eLife\ApiSdk\Model\Block;
 use eLife\ApiSdk\Model\Image;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\Reference;
 use GuzzleHttp\Promise\PromiseInterface;
 use function GuzzleHttp\Promise\promise_for;
@@ -193,7 +194,9 @@ final class ArticleVoRNormalizer extends ArticleVersionNormalizer
         return
             ArticleVoR::class === $type
             ||
-            (ArticleVersion::class === $type && 'vor' === $data['status']);
+            (ArticleVersion::class === $type && 'vor' === $data['status'])
+            ||
+            Model::class === $type && $this->isArticleType($data['type'] ?? 'unknown') && 'vor' === ($data['status'] ?? 'unknown');
     }
 
     /**

--- a/src/Serializer/BlogArticleNormalizer.php
+++ b/src/Serializer/BlogArticleNormalizer.php
@@ -10,6 +10,7 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Block;
 use eLife\ApiSdk\Model\BlogArticle;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\Subject;
 use eLife\ApiSdk\Promise\CallbackPromise;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -103,7 +104,10 @@ final class BlogArticleNormalizer implements NormalizerInterface, DenormalizerIn
 
     public function supportsDenormalization($data, $type, $format = null) : bool
     {
-        return BlogArticle::class === $type;
+        return
+            BlogArticle::class === $type
+            ||
+            Model::class === $type && 'blog-article' === ($data['type'] ?? 'unknown');
     }
 
     /**
@@ -116,6 +120,10 @@ final class BlogArticleNormalizer implements NormalizerInterface, DenormalizerIn
             'title' => $object->getTitle(),
             'published' => $object->getPublishedDate()->format(DATE_ATOM),
         ];
+
+        if (!empty($context['type'])) {
+            $data['type'] = 'blog-article';
+        }
 
         if ($object->getImpactStatement()) {
             $data['impactStatement'] = $object->getImpactStatement();

--- a/src/Serializer/EventNormalizer.php
+++ b/src/Serializer/EventNormalizer.php
@@ -11,6 +11,7 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Block;
 use eLife\ApiSdk\Model\Event;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\Place;
 use eLife\ApiSdk\Promise\CallbackPromise;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -115,7 +116,10 @@ final class EventNormalizer implements NormalizerInterface, DenormalizerInterfac
 
     public function supportsDenormalization($data, $type, $format = null) : bool
     {
-        return Event::class === $type;
+        return
+            Event::class === $type
+            ||
+            Model::class === $type && 'event' === ($data['type'] ?? 'unknown');
     }
 
     /**
@@ -129,6 +133,10 @@ final class EventNormalizer implements NormalizerInterface, DenormalizerInterfac
             'starts' => $object->getStarts()->format(DATE_ATOM),
             'ends' => $object->getStarts()->format(DATE_ATOM),
         ];
+
+        if (!empty($context['type'])) {
+            $data['type'] = 'event';
+        }
 
         if ($object->getImpactStatement()) {
             $data['impactStatement'] = $object->getImpactStatement();

--- a/src/Serializer/InterviewNormalizer.php
+++ b/src/Serializer/InterviewNormalizer.php
@@ -12,6 +12,7 @@ use eLife\ApiSdk\Model\Block;
 use eLife\ApiSdk\Model\Interview;
 use eLife\ApiSdk\Model\Interviewee;
 use eLife\ApiSdk\Model\IntervieweeCvLine;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\PersonDetails;
 use eLife\ApiSdk\Promise\CallbackPromise;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -111,7 +112,10 @@ final class InterviewNormalizer implements NormalizerInterface, DenormalizerInte
 
     public function supportsDenormalization($data, $type, $format = null) : bool
     {
-        return Interview::class === $type;
+        return
+            Interview::class === $type
+            ||
+            Model::class === $type && 'interview' === ($data['type'] ?? 'unknown');
     }
 
     /**
@@ -125,6 +129,10 @@ final class InterviewNormalizer implements NormalizerInterface, DenormalizerInte
             'title' => $object->getTitle(),
             'published' => $object->getPublishedDate()->format(DATE_ATOM),
         ];
+
+        if (!empty($context['type'])) {
+            $data['type'] = 'interview';
+        }
 
         if ($object->getImpactStatement()) {
             $data['impactStatement'] = $object->getImpactStatement();

--- a/src/Serializer/LabsExperimentNormalizer.php
+++ b/src/Serializer/LabsExperimentNormalizer.php
@@ -11,6 +11,7 @@ use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Block;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\LabsExperiment;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Promise\CallbackPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
@@ -112,7 +113,10 @@ final class LabsExperimentNormalizer implements NormalizerInterface, Denormalize
 
     public function supportsDenormalization($data, $type, $format = null) : bool
     {
-        return LabsExperiment::class === $type;
+        return
+            LabsExperiment::class === $type
+            ||
+            Model::class === $type && 'labs-experiment' === ($data['type'] ?? 'unknown');
     }
 
     /**
@@ -128,6 +132,10 @@ final class LabsExperimentNormalizer implements NormalizerInterface, Denormalize
                 'thumbnail' => $this->normalizer->normalize($object->getThumbnail(), $format, $context),
             ],
         ];
+
+        if (!empty($context['type'])) {
+            $data['type'] = 'labs-experiment';
+        }
 
         if ($object->getImpactStatement()) {
             $data['impactStatement'] = $object->getImpactStatement();

--- a/src/Serializer/NormalizationHelper.php
+++ b/src/Serializer/NormalizationHelper.php
@@ -78,17 +78,17 @@ final class NormalizationHelper
         }, $array));
     }
 
-    public function normalizeSequenceToSnippets(Sequence $sequence, array $context) : array
+    public function normalizeSequenceToSnippets(Sequence $sequence, array $context = []) : array
     {
         return $sequence->map(function ($each) use ($context) {
-            $context['snippet'] = true;
-
-            return $this->normalizer->normalize($each, $this->format, $context);
+            return $this->normalizeToSnippet($each, $context);
         })->toArray();
     }
 
-    public function normalizeToSnippet($object) : array
+    public function normalizeToSnippet($object, array $context = []) : array
     {
-        return $this->normalizer->normalize($object, $this->format, ['snippet' => true]);
+        $context['snippet'] = true;
+
+        return $this->normalizer->normalize($object, $this->format, $context);
     }
 }

--- a/src/Serializer/PodcastEpisodeNormalizer.php
+++ b/src/Serializer/PodcastEpisodeNormalizer.php
@@ -66,13 +66,8 @@ final class PodcastEpisodeNormalizer implements NormalizerInterface, Denormalize
                     $chapter['impactStatement'] ?? null,
                     new ArraySequence(array_map(function (array $item) use ($format, $context) {
                         $context['snippet'] = true;
-                        if ($item['type'] == 'collection') {
-                            return $this->denormalizer->denormalize($item, Collection::class, $format, $context);
-                        } else {
-                            $class = ArticleVersionNormalizer::articleClass($item['type'], $item['status']);
 
-                            return $this->denormalizer->denormalize($item, $class, $format, $context);
-                        }
+                        return $this->denormalizer->denormalize($item, Model::class, $format, $context);
                     }, $chapter['content'])));
             });
 

--- a/src/Serializer/PodcastEpisodeNormalizer.php
+++ b/src/Serializer/PodcastEpisodeNormalizer.php
@@ -8,7 +8,6 @@ use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
-use eLife\ApiSdk\Model\Collection;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\PodcastEpisode;

--- a/test/Model/ArticleTest.php
+++ b/test/Model/ArticleTest.php
@@ -12,6 +12,7 @@ use eLife\ApiSdk\Model\Block\Paragraph;
 use eLife\ApiSdk\Model\Copyright;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\ImageSize;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\PersonAuthor;
 use eLife\ApiSdk\Model\PersonDetails;
 use eLife\ApiSdk\Model\Subject;
@@ -22,6 +23,19 @@ use function GuzzleHttp\Promise\rejection_for;
 
 abstract class ArticleTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @test
+     */
+    final public function it_is_a_model()
+    {
+        $article = $this->createArticleVersion('id', 1, 'type', 'doi', 'author line', null, 'title',
+            new DateTimeImmutable(), new DateTimeImmutable(), 1, 'elocationId', null, new ArraySequence([]), [],
+            rejection_for('No abstract'), rejection_for('No issue'), rejection_for('No copyright'),
+            new PromiseSequence(rejection_for('No authors')));
+
+        $this->assertInstanceOf(Model::class, $article);
+    }
+
     /**
      * @test
      */

--- a/test/Model/BlogArticleTest.php
+++ b/test/Model/BlogArticleTest.php
@@ -8,12 +8,26 @@ use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Block;
 use eLife\ApiSdk\Model\BlogArticle;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\Subject;
 use PHPUnit_Framework_TestCase;
 use function GuzzleHttp\Promise\rejection_for;
 
 final class BlogArticleTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @test
+     */
+    public function it_is_a_model()
+    {
+        $blogArticle = new BlogArticle('id', 'title', new DateTimeImmutable(), null,
+            new PromiseSequence(rejection_for('Full blog article should not be unwrapped')),
+            new PromiseSequence(rejection_for('Subjects should not be unwrapped'))
+        );
+
+        $this->assertInstanceOf(Model::class, $blogArticle);
+    }
+
     /**
      * @test
      */

--- a/test/Model/CollectionTest.php
+++ b/test/Model/CollectionTest.php
@@ -8,6 +8,7 @@ use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Collection;
 use eLife\ApiSdk\Model\Image;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\Person;
 use eLife\ApiSdk\Model\PodcastEpisode;
 use eLife\ApiSdk\Model\Subject;
@@ -21,6 +22,16 @@ final class CollectionTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->builder = Builder::for(Collection::class);
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_a_model()
+    {
+        $collection = $this->builder->__invoke();
+
+        $this->assertInstanceOf(Model::class, $collection);
     }
 
     /**

--- a/test/Model/EventTest.php
+++ b/test/Model/EventTest.php
@@ -8,6 +8,7 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Block;
 use eLife\ApiSdk\Model\Event;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\Place;
 use PHPUnit_Framework_TestCase;
 use function GuzzleHttp\Promise\promise_for;
@@ -15,6 +16,18 @@ use function GuzzleHttp\Promise\rejection_for;
 
 final class EventTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @test
+     */
+    public function it_is_a_model()
+    {
+        $event = new Event('id', 'title', null, new DateTimeImmutable(), new DateTimeImmutable(), null,
+            new PromiseSequence(rejection_for('Event content should not be unwrapped')),
+            rejection_for('Event venue should not be unwrapped'));
+
+        $this->assertInstanceOf(Model::class, $event);
+    }
+
     /**
      * @test
      */

--- a/test/Model/LabsExperimentTest.php
+++ b/test/Model/LabsExperimentTest.php
@@ -8,12 +8,26 @@ use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Block;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\LabsExperiment;
+use eLife\ApiSdk\Model\Model;
 use PHPUnit_Framework_TestCase;
 use function GuzzleHttp\Promise\promise_for;
 use function GuzzleHttp\Promise\rejection_for;
 
 final class LabsExperimentTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @test
+     */
+    public function it_is_a_model()
+    {
+        $labsExperiment = new LabsExperiment(1, 'title', new DateTimeImmutable(), null, rejection_for('No banner'),
+            new Image('', [900 => 'https://placehold.it/900x450']),
+            new PromiseSequence(rejection_for('Full Labs experiment should not be unwrapped'))
+        );
+
+        $this->assertInstanceOf(Model::class, $labsExperiment);
+    }
+
     /**
      * @test
      */

--- a/test/Model/MediumArticleTest.php
+++ b/test/Model/MediumArticleTest.php
@@ -5,10 +5,21 @@ namespace test\eLife\ApiSdk\Model;
 use DateTimeImmutable;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\MediumArticle;
+use eLife\ApiSdk\Model\Model;
 use PHPUnit_Framework_TestCase;
 
 final class MediumArticleTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @test
+     */
+    public function it_is_a_model()
+    {
+        $mediumArticle = new MediumArticle('http://www.example.com/', 'title', null, new DateTimeImmutable(), null);
+
+        $this->assertInstanceOf(Model::class, $mediumArticle);
+    }
+
     /**
      * @test
      */

--- a/test/Model/PersonTest.php
+++ b/test/Model/PersonTest.php
@@ -6,6 +6,7 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Block\Paragraph;
 use eLife\ApiSdk\Model\Image;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\Person;
 use eLife\ApiSdk\Model\PersonDetails;
 use eLife\ApiSdk\Model\PersonResearch;
@@ -15,6 +16,19 @@ use function GuzzleHttp\Promise\rejection_for;
 
 final class PersonTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @test
+     */
+    public function it_is_a_model()
+    {
+        $person = new Person('id', new PersonDetails('preferred name', 'index name'), 'senior-editor', null,
+            rejection_for('Research should not be unwrapped'),
+            new PromiseSequence(rejection_for('Profile should not be unwrapped')),
+            rejection_for('Competing interests should not be unwrapped'));
+
+        $this->assertInstanceOf(Model::class, $person);
+    }
+
     /**
      * @test
      */

--- a/test/Model/PodcastEpisodeTest.php
+++ b/test/Model/PodcastEpisodeTest.php
@@ -7,6 +7,7 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Image;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\PodcastEpisode;
 use eLife\ApiSdk\Model\PodcastEpisodeChapter;
 use eLife\ApiSdk\Model\PodcastEpisodeSource;
@@ -17,6 +18,20 @@ use function GuzzleHttp\Promise\rejection_for;
 
 final class PodcastEpisodeTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @test
+     */
+    public function it_is_a_model()
+    {
+        $podcastEpisode = new PodcastEpisode(1, 'title', null, new DateTimeImmutable(), rejection_for('No banner'),
+            new Image('', [900 => 'https://placehold.it/900x450']),
+            [new PodcastEpisodeSource('audio/mpeg', 'https://www.example.com/episode.mp3')],
+            new PromiseSequence(rejection_for('Subjects should not be unwrapped')),
+            new PromiseSequence(rejection_for('Chapters should not be unwrapped')));
+
+        $this->assertInstanceOf(Model::class, $podcastEpisode);
+    }
+
     /**
      * @test
      */

--- a/test/Model/SubjectTest.php
+++ b/test/Model/SubjectTest.php
@@ -3,6 +3,7 @@
 namespace test\eLife\ApiSdk\Model;
 
 use eLife\ApiSdk\Model\Image;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\Subject;
 use PHPUnit_Framework_TestCase;
 use function GuzzleHttp\Promise\promise_for;
@@ -10,6 +11,17 @@ use function GuzzleHttp\Promise\rejection_for;
 
 final class SubjectTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @test
+     */
+    public function it_is_a_model()
+    {
+        $subject = new Subject('id', 'name', rejection_for('Impact statement should not be unwrapped'),
+            rejection_for('No banner'), rejection_for('Image should not be unwrapped'));
+
+        $this->assertInstanceOf(Model::class, $subject);
+    }
+
     /**
      * @test
      */

--- a/test/Serializer/ArticlePoANormalizerTest.php
+++ b/test/Serializer/ArticlePoANormalizerTest.php
@@ -12,6 +12,7 @@ use eLife\ApiSdk\Model\Block\Paragraph;
 use eLife\ApiSdk\Model\Copyright;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\ImageSize;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\PersonAuthor;
 use eLife\ApiSdk\Model\PersonDetails;
 use eLife\ApiSdk\Model\Subject;
@@ -98,6 +99,7 @@ final class ArticlePoANormalizerTest extends ApiTestCase
     {
         return [
             'article poa' => [[], ArticlePoA::class, [], true],
+            'article poa by type' => [['type' => 'research-article', 'status' => 'poa'], Model::class, [], true],
             'non-article poa' => [[], get_class($this), [], false],
         ];
     }

--- a/test/Serializer/ArticleVoRNormalizerTest.php
+++ b/test/Serializer/ArticleVoRNormalizerTest.php
@@ -13,6 +13,7 @@ use eLife\ApiSdk\Model\Block\Section;
 use eLife\ApiSdk\Model\Copyright;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\ImageSize;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\PersonAuthor;
 use eLife\ApiSdk\Model\PersonDetails;
 use eLife\ApiSdk\Model\Place;
@@ -105,6 +106,7 @@ final class ArticleVoRNormalizerTest extends ApiTestCase
     {
         return [
             'article vor' => [[], ArticleVoR::class, [], true],
+            'article vor by type' => [['type' => 'research-article', 'status' => 'vor'], Model::class, [], true],
             'non-article vor' => [[], get_class($this), [], false],
         ];
     }

--- a/test/Serializer/BlogArticleNormalizerTest.php
+++ b/test/Serializer/BlogArticleNormalizerTest.php
@@ -11,6 +11,7 @@ use eLife\ApiSdk\Model\Block\Paragraph;
 use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\ImageSize;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\Subject;
 use eLife\ApiSdk\Serializer\BlogArticleNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -96,6 +97,7 @@ final class BlogArticleNormalizerTest extends ApiTestCase
     {
         return [
             'blog article' => [[], BlogArticle::class, [], true],
+            'blog article by type' => [['type' => 'blog-article'], Model::class, [], true],
             'non-blog article' => [[], get_class($this), [], false],
         ];
     }
@@ -179,7 +181,7 @@ final class BlogArticleNormalizerTest extends ApiTestCase
             'complete snippet' => [
                 new BlogArticle('blogArticle1', 'Blog article 1 title', $date, 'Blog article 1 impact statement',
                     new ArraySequence([new Paragraph('Blog article blogArticle1 text')]), new ArraySequence([$subject])),
-                ['snippet' => true],
+                ['snippet' => true, 'type' => true],
                 [
                     'id' => 'blogArticle1',
                     'title' => 'Blog article 1 title',
@@ -188,6 +190,7 @@ final class BlogArticleNormalizerTest extends ApiTestCase
                     'subjects' => [
                         ['id' => 'subject1', 'name' => 'Subject 1 name'],
                     ],
+                    'type' => 'blog-article',
                 ],
                 function (ApiTestCase $test) {
                     $test->mockBlogArticleCall(1, true);

--- a/test/Serializer/CollectionNormalizerTest.php
+++ b/test/Serializer/CollectionNormalizerTest.php
@@ -12,10 +12,12 @@ use eLife\ApiSdk\Model\BlogArticle;
 use eLife\ApiSdk\Model\Collection;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\Interview;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\Person;
 use eLife\ApiSdk\Model\PodcastEpisode;
 use eLife\ApiSdk\Model\Subject;
 use eLife\ApiSdk\Serializer\CollectionNormalizer;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use test\eLife\ApiSdk\ApiTestCase;
 use test\eLife\ApiSdk\Builder;
@@ -71,6 +73,32 @@ final class CollectionNormalizerTest extends ApiTestCase
     public function it_normalizes_collections(Collection $collection, array $context, array $expected)
     {
         $this->assertEquals($expected, $this->normalizer->normalize($collection, null, $context));
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_a_denormalizer()
+    {
+        $this->assertInstanceOf(DenormalizerInterface::class, $this->normalizer);
+    }
+
+    /**
+     * @test
+     * @dataProvider canDenormalizeProvider
+     */
+    public function it_can_denormalize_collections($data, $format, array $context, bool $expected)
+    {
+        $this->assertSame($expected, $this->normalizer->supportsDenormalization($data, $format, $context));
+    }
+
+    public function canDenormalizeProvider() : array
+    {
+        return [
+            'collection' => [[], Collection::class, [], true],
+            'collection by type' => [['type' => 'collection'], Model::class, [], true],
+            'non-collection' => [[], get_class($this), [], false],
+        ];
     }
 
     /**
@@ -449,7 +477,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                             ->sample('29'),
                     ]))
                     ->__invoke(),
-                ['complete' => true, 'snippet' => true],
+                ['complete' => true, 'snippet' => true, 'type' => true],
                 [
                     'id' => '1',
                     'title' => 'Tropical disease',
@@ -489,6 +517,7 @@ final class CollectionNormalizerTest extends ApiTestCase
                         ],
                         'etAl' => true,
                     ],
+                    'type' => 'collection',
                 ],
                 function (ApiTestCase $test) {
                     $test->mockCollectionCall('1', true);

--- a/test/Serializer/EventNormalizerTest.php
+++ b/test/Serializer/EventNormalizerTest.php
@@ -10,6 +10,7 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Model\Block\Paragraph;
 use eLife\ApiSdk\Model\Event;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\Place;
 use eLife\ApiSdk\Serializer\EventNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -94,6 +95,7 @@ final class EventNormalizerTest extends ApiTestCase
     {
         return [
             'event' => [[], Event::class, [], true],
+            'event by type' => [['type' => 'event'], Model::class, [], true],
             'non-event' => [[], get_class($this), [], false],
         ];
     }
@@ -165,7 +167,7 @@ final class EventNormalizerTest extends ApiTestCase
             'complete snippet' => [
                 new Event('event1', 'Event 1 title', 'Event 1 impact statement', $starts, $ends, $timezone,
                     new ArraySequence([new Paragraph('Event 1 text')]), promise_for($venue)),
-                ['snippet' => true],
+                ['snippet' => true, 'type' => true],
                 [
                     'id' => 'event1',
                     'title' => 'Event 1 title',
@@ -173,6 +175,7 @@ final class EventNormalizerTest extends ApiTestCase
                     'ends' => $ends->format(DATE_ATOM),
                     'impactStatement' => 'Event 1 impact statement',
                     'timezone' => $timezone->getName(),
+                    'type' => 'event',
                 ],
                 function (ApiTestCase $test) {
                     $test->mockEventCall(1, true);

--- a/test/Serializer/InterviewNormalizerTest.php
+++ b/test/Serializer/InterviewNormalizerTest.php
@@ -11,6 +11,7 @@ use eLife\ApiSdk\Model\Block\Paragraph;
 use eLife\ApiSdk\Model\Interview;
 use eLife\ApiSdk\Model\Interviewee;
 use eLife\ApiSdk\Model\IntervieweeCvLine;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\PersonDetails;
 use eLife\ApiSdk\Serializer\InterviewNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -97,6 +98,7 @@ final class InterviewNormalizerTest extends ApiTestCase
     {
         return [
             'interview' => [[], Interview::class, [], true],
+            'interview by type' => [['type' => 'interview'], Model::class, [], true],
             'non-interview' => [[], get_class($this), [], false],
         ];
     }
@@ -185,7 +187,7 @@ final class InterviewNormalizerTest extends ApiTestCase
                         new ArraySequence([new IntervieweeCvLine('date', 'text')])), 'Interview 1 title', $date,
                     'Interview 1 impact statement', new ArraySequence([new Paragraph('Interview interview1 text')])
                 ),
-                ['snippet' => true],
+                ['snippet' => true, 'type' => true],
                 [
                     'id' => 'interview1',
                     'interviewee' => [
@@ -198,6 +200,7 @@ final class InterviewNormalizerTest extends ApiTestCase
                     'title' => 'Interview 1 title',
                     'published' => $date->format(DATE_ATOM),
                     'impactStatement' => 'Interview 1 impact statement',
+                    'type' => 'interview',
                 ],
                 function (ApiTestCase $test) {
                     $test->mockInterviewCall('interview1', true);

--- a/test/Serializer/LabsExperimentNormalizerTest.php
+++ b/test/Serializer/LabsExperimentNormalizerTest.php
@@ -11,6 +11,7 @@ use eLife\ApiSdk\Model\Block\Paragraph;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\ImageSize;
 use eLife\ApiSdk\Model\LabsExperiment;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Serializer\LabsExperimentNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -95,6 +96,7 @@ final class LabsExperimentNormalizerTest extends ApiTestCase
     {
         return [
             'Labs experiment' => [[], LabsExperiment::class, [], true],
+            'Labs experiment by type' => [['type' => 'labs-experiment'], Model::class, [], true],
             'non-Labs experiment' => [[], get_class($this), [], false],
         ];
     }
@@ -219,7 +221,7 @@ final class LabsExperimentNormalizerTest extends ApiTestCase
             'complete snippet' => [
                 new LabsExperiment(1, 'Labs experiment 1 title', $date, 'Labs experiment 1 impact statement',
                     promise_for($banner), $thumbnail, new ArraySequence([new Paragraph('Labs experiment 1 text')])),
-                ['snippet' => true],
+                ['snippet' => true, 'type' => true],
                 [
                     'number' => 1,
                     'title' => 'Labs experiment 1 title',
@@ -240,6 +242,7 @@ final class LabsExperimentNormalizerTest extends ApiTestCase
                         ],
                     ],
                     'impactStatement' => 'Labs experiment 1 impact statement',
+                    'type' => 'labs-experiment',
                 ],
                 function (ApiTestCase $test) {
                     $test->mockLabsExperimentCall(1, true);

--- a/test/Serializer/PodcastEpisodeNormalizerTest.php
+++ b/test/Serializer/PodcastEpisodeNormalizerTest.php
@@ -14,6 +14,7 @@ use eLife\ApiSdk\Model\Collection;
 use eLife\ApiSdk\Model\Copyright;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\ImageSize;
+use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\PersonAuthor;
 use eLife\ApiSdk\Model\PersonDetails;
 use eLife\ApiSdk\Model\PodcastEpisode;
@@ -106,6 +107,7 @@ final class PodcastEpisodeNormalizerTest extends ApiTestCase
     {
         return [
             'podcast episode' => [[], PodcastEpisode::class, [], true],
+            'podcast episode by type' => [['type' => 'podcast-episode'], Model::class, [], true],
             'non-podcast episode' => [[], get_class($this), [], false],
         ];
     }
@@ -363,7 +365,7 @@ final class PodcastEpisodeNormalizerTest extends ApiTestCase
                                 new ArraySequence([new PersonAuthor(new PersonDetails('Author', 'Author'))])),
                         ])),
                     ])),
-                ['snippet' => true, 'complete' => true],
+                ['snippet' => true, 'complete' => true, 'type' => true],
                 [
                     'number' => 1,
                     'title' => 'Podcast episode 1 title',
@@ -390,6 +392,7 @@ final class PodcastEpisodeNormalizerTest extends ApiTestCase
                             'uri' => 'https://www.example.com/episode.mp3',
                         ],
                     ],
+                    'type' => 'podcast-episode',
                 ],
                 function (ApiTestCase $test) {
                     $test->mockPodcastEpisodeCall(1, true);


### PR DESCRIPTION
Introduces a `Model` marker interface to avoid having to repeat introducing/using the `type` property that appears when a list of content contains multiple types.

Ping @giorgiosironi.
