### PR TITLE
Updated default status date for articles

### DIFF
--- a/src/Model/ArticleVersion.php
+++ b/src/Model/ArticleVersion.php
@@ -39,7 +39,7 @@ abstract class ArticleVersion
         string $titlePrefix = null,
         string $title,
         DateTimeImmutable $published,
-        DateTimeImmutable $statusDate,
+        DateTimeImmutable $statusDate = null,
         int $volume,
         string $elocationId,
         string $pdf = null,

--- a/src/Serializer/ArticlePoANormalizer.php
+++ b/src/Serializer/ArticlePoANormalizer.php
@@ -25,7 +25,7 @@ final class ArticlePoANormalizer extends ArticleVersionNormalizer
             $data['titlePrefix'] ?? null,
             $data['title'],
             DateTimeImmutable::createFromFormat(DATE_ATOM, $data['published']),
-            DateTimeImmutable::createFromFormat(DATE_ATOM, $data['statusDate']),
+            $data['statusDate'] ? DateTimeImmutable::createFromFormat(DATE_ATOM, $data['statusDate']) : null,
             $data['volume'],
             $data['elocationId'],
             $data['pdf'] ?? null,

--- a/src/Serializer/ArticleVoRNormalizer.php
+++ b/src/Serializer/ArticleVoRNormalizer.php
@@ -165,7 +165,7 @@ final class ArticleVoRNormalizer extends ArticleVersionNormalizer
             $data['titlePrefix'] ?? null,
             $data['title'],
             DateTimeImmutable::createFromFormat(DATE_ATOM, $data['published']),
-            DateTimeImmutable::createFromFormat(DATE_ATOM, $data['statusDate']),
+            $data['statusDate'] ? DateTimeImmutable::createFromFormat(DATE_ATOM, $data['statusDate']) : null,
             $data['volume'],
             $data['elocationId'],
             $data['pdf'] ?? null,


### PR DESCRIPTION
@thewilkybarkid @giorgiosironi 

Just looking through the RAML and the dummy data, I'm not sure if something has changed recently, but this was causing a bug when pulling data from the api dummy. 

I guess the question along with this PR is: Is the status date for all article type required?