### PR TITLE
Let Sequence extend ArrayAccess

### DIFF
--- a/src/Client/AnnualReports.php
+++ b/src/Client/AnnualReports.php
@@ -11,6 +11,7 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\AnnualReport;
+use eLife\ApiSdk\SlicedArrayAccess;
 use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
@@ -20,7 +21,12 @@ use function GuzzleHttp\Promise\promise_for;
 final class AnnualReports implements Iterator, Sequence
 {
     use ArrayFromIterator;
-    use SlicedIterator;
+    use SlicedArrayAccess;
+    use SlicedIterator {
+        SlicedIterator::getPage insteadof SlicedArrayAccess;
+        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
+        SlicedIterator::resetPages insteadof SlicedArrayAccess;
+    }
 
     private $count;
     private $reports;

--- a/src/Client/AnnualReports.php
+++ b/src/Client/AnnualReports.php
@@ -6,13 +6,10 @@ use ArrayObject;
 use eLife\ApiClient\ApiClient\AnnualReportsClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
-use eLife\ApiSdk\ArrayFromIterator;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\AnnualReport;
-use eLife\ApiSdk\SlicedArrayAccess;
-use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -20,15 +17,8 @@ use function GuzzleHttp\Promise\promise_for;
 
 final class AnnualReports implements Iterator, Sequence
 {
-    use ArrayFromIterator;
-    use SlicedArrayAccess;
-    use SlicedIterator {
-        SlicedIterator::getPage insteadof SlicedArrayAccess;
-        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
-        SlicedIterator::resetPages insteadof SlicedArrayAccess;
-    }
+    use Client;
 
-    private $count;
     private $reports;
     private $descendingOrder = true;
     private $annualReportsClient;
@@ -39,11 +29,6 @@ final class AnnualReports implements Iterator, Sequence
         $this->reports = new ArrayObject();
         $this->annualReportsClient = $annualReportsClient;
         $this->denormalizer = $denormalizer;
-    }
-
-    public function __clone()
-    {
-        $this->resetIterator();
     }
 
     public function get(int $year) : PromiseInterface
@@ -108,14 +93,5 @@ final class AnnualReports implements Iterator, Sequence
         $clone->descendingOrder = !$this->descendingOrder;
 
         return $clone;
-    }
-
-    public function count() : int
-    {
-        if (null === $this->count) {
-            $this->slice(0, 1)->count();
-        }
-
-        return $this->count;
     }
 }

--- a/src/Client/Articles.php
+++ b/src/Client/Articles.php
@@ -11,6 +11,7 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\ArticleVersion;
+use eLife\ApiSdk\SlicedArrayAccess;
 use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
@@ -20,7 +21,12 @@ use function GuzzleHttp\Promise\promise_for;
 final class Articles implements Iterator, Sequence
 {
     use ArrayFromIterator;
-    use SlicedIterator;
+    use SlicedArrayAccess;
+    use SlicedIterator {
+        SlicedIterator::getPage insteadof SlicedArrayAccess;
+        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
+        SlicedIterator::resetPages insteadof SlicedArrayAccess;
+    }
 
     private $count;
     private $articles;

--- a/src/Client/Articles.php
+++ b/src/Client/Articles.php
@@ -6,13 +6,10 @@ use ArrayObject;
 use eLife\ApiClient\ApiClient\ArticlesClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
-use eLife\ApiSdk\ArrayFromIterator;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\ArticleVersion;
-use eLife\ApiSdk\SlicedArrayAccess;
-use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -20,13 +17,7 @@ use function GuzzleHttp\Promise\promise_for;
 
 final class Articles implements Iterator, Sequence
 {
-    use ArrayFromIterator;
-    use SlicedArrayAccess;
-    use SlicedIterator {
-        SlicedIterator::getPage insteadof SlicedArrayAccess;
-        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
-        SlicedIterator::resetPages insteadof SlicedArrayAccess;
-    }
+    use Client;
 
     private $count;
     private $articles;
@@ -42,11 +33,6 @@ final class Articles implements Iterator, Sequence
         $this->articleVersions = new ArrayObject();
         $this->articlesClient = $articlesClient;
         $this->denormalizer = $denormalizer;
-    }
-
-    public function __clone()
-    {
-        $this->resetIterator();
     }
 
     public function forSubject(string ...$subjectId) : Articles
@@ -152,14 +138,5 @@ final class Articles implements Iterator, Sequence
         $clone->descendingOrder = !$this->descendingOrder;
 
         return $clone;
-    }
-
-    public function count() : int
-    {
-        if (null === $this->count) {
-            $this->slice(0, 1)->count();
-        }
-
-        return $this->count;
     }
 }

--- a/src/Client/BlogArticles.php
+++ b/src/Client/BlogArticles.php
@@ -11,6 +11,7 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\BlogArticle;
+use eLife\ApiSdk\SlicedArrayAccess;
 use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
@@ -20,7 +21,12 @@ use function GuzzleHttp\Promise\promise_for;
 final class BlogArticles implements Iterator, Sequence
 {
     use ArrayFromIterator;
-    use SlicedIterator;
+    use SlicedArrayAccess;
+    use SlicedIterator {
+        SlicedIterator::getPage insteadof SlicedArrayAccess;
+        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
+        SlicedIterator::resetPages insteadof SlicedArrayAccess;
+    }
 
     private $count;
     private $articles;

--- a/src/Client/BlogArticles.php
+++ b/src/Client/BlogArticles.php
@@ -6,13 +6,10 @@ use ArrayObject;
 use eLife\ApiClient\ApiClient\BlogClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
-use eLife\ApiSdk\ArrayFromIterator;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\BlogArticle;
-use eLife\ApiSdk\SlicedArrayAccess;
-use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -20,13 +17,7 @@ use function GuzzleHttp\Promise\promise_for;
 
 final class BlogArticles implements Iterator, Sequence
 {
-    use ArrayFromIterator;
-    use SlicedArrayAccess;
-    use SlicedIterator {
-        SlicedIterator::getPage insteadof SlicedArrayAccess;
-        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
-        SlicedIterator::resetPages insteadof SlicedArrayAccess;
-    }
+    use Client;
 
     private $count;
     private $articles;
@@ -40,11 +31,6 @@ final class BlogArticles implements Iterator, Sequence
         $this->articles = new ArrayObject();
         $this->blogClient = $blogClient;
         $this->denormalizer = $denormalizer;
-    }
-
-    public function __clone()
-    {
-        $this->resetIterator();
     }
 
     public function get(string $id) : PromiseInterface
@@ -124,14 +110,5 @@ final class BlogArticles implements Iterator, Sequence
         $clone->descendingOrder = !$this->descendingOrder;
 
         return $clone;
-    }
-
-    public function count() : int
-    {
-        if (null === $this->count) {
-            $this->slice(0, 1)->count();
-        }
-
-        return $this->count;
     }
 }

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace eLife\ApiSdk\Client;
+
+use eLife\ApiSdk\ArrayFromIterator;
+use eLife\ApiSdk\SlicedArrayAccess;
+use eLife\ApiSdk\SlicedIterator;
+
+trait Client
+{
+    use ArrayFromIterator;
+    use SlicedArrayAccess;
+    use SlicedIterator {
+        SlicedIterator::getPage insteadof SlicedArrayAccess;
+        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
+        SlicedIterator::resetPages insteadof SlicedArrayAccess;
+    }
+
+    private $count;
+
+    final public function __clone()
+    {
+        $this->resetIterator();
+    }
+
+    final public function count() : int
+    {
+        if (null === $this->count) {
+            $this->slice(0, 1)->count();
+        }
+
+        return $this->count;
+    }
+}

--- a/src/Client/Collections.php
+++ b/src/Client/Collections.php
@@ -6,13 +6,10 @@ use ArrayObject;
 use eLife\ApiClient\ApiClient\CollectionsClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
-use eLife\ApiSdk\ArrayFromIterator;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Collection;
-use eLife\ApiSdk\SlicedArrayAccess;
-use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -20,13 +17,7 @@ use function GuzzleHttp\Promise\promise_for;
 
 final class Collections implements Iterator, Sequence
 {
-    use ArrayFromIterator;
-    use SlicedArrayAccess;
-    use SlicedIterator {
-        SlicedIterator::getPage insteadof SlicedArrayAccess;
-        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
-        SlicedIterator::resetPages insteadof SlicedArrayAccess;
-    }
+    use Client;
 
     private $count;
     private $collections = [];
@@ -40,11 +31,6 @@ final class Collections implements Iterator, Sequence
         $this->collections = new ArrayObject();
         $this->collectionsClient = $collectionsClient;
         $this->denormalizer = $denormalizer;
-    }
-
-    public function __clone()
-    {
-        $this->resetIterator();
     }
 
     public function get(string $id) : PromiseInterface
@@ -124,14 +110,5 @@ final class Collections implements Iterator, Sequence
         $clone->descendingOrder = !$this->descendingOrder;
 
         return $clone;
-    }
-
-    public function count() : int
-    {
-        if (null === $this->count) {
-            $this->slice(0, 1)->count();
-        }
-
-        return $this->count;
     }
 }

--- a/src/Client/Collections.php
+++ b/src/Client/Collections.php
@@ -11,6 +11,7 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Collection;
+use eLife\ApiSdk\SlicedArrayAccess;
 use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
@@ -20,7 +21,12 @@ use function GuzzleHttp\Promise\promise_for;
 final class Collections implements Iterator, Sequence
 {
     use ArrayFromIterator;
-    use SlicedIterator;
+    use SlicedArrayAccess;
+    use SlicedIterator {
+        SlicedIterator::getPage insteadof SlicedArrayAccess;
+        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
+        SlicedIterator::resetPages insteadof SlicedArrayAccess;
+    }
 
     private $count;
     private $collections = [];

--- a/src/Client/Events.php
+++ b/src/Client/Events.php
@@ -6,13 +6,10 @@ use ArrayObject;
 use eLife\ApiClient\ApiClient\EventsClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
-use eLife\ApiSdk\ArrayFromIterator;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Event;
-use eLife\ApiSdk\SlicedArrayAccess;
-use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -20,13 +17,7 @@ use function GuzzleHttp\Promise\promise_for;
 
 final class Events implements Iterator, Sequence
 {
-    use ArrayFromIterator;
-    use SlicedArrayAccess;
-    use SlicedIterator {
-        SlicedIterator::getPage insteadof SlicedArrayAccess;
-        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
-        SlicedIterator::resetPages insteadof SlicedArrayAccess;
-    }
+    use Client;
 
     private $count;
     private $events;
@@ -40,11 +31,6 @@ final class Events implements Iterator, Sequence
         $this->events = new ArrayObject();
         $this->eventsClient = $eventsClient;
         $this->denormalizer = $denormalizer;
-    }
-
-    public function __clone()
-    {
-        $this->resetIterator();
     }
 
     public function get(string $id) : PromiseInterface
@@ -124,14 +110,5 @@ final class Events implements Iterator, Sequence
         $clone->descendingOrder = !$this->descendingOrder;
 
         return $clone;
-    }
-
-    public function count() : int
-    {
-        if (null === $this->count) {
-            $this->slice(0, 1)->count();
-        }
-
-        return $this->count;
     }
 }

--- a/src/Client/Events.php
+++ b/src/Client/Events.php
@@ -11,6 +11,7 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Event;
+use eLife\ApiSdk\SlicedArrayAccess;
 use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
@@ -20,7 +21,12 @@ use function GuzzleHttp\Promise\promise_for;
 final class Events implements Iterator, Sequence
 {
     use ArrayFromIterator;
-    use SlicedIterator;
+    use SlicedArrayAccess;
+    use SlicedIterator {
+        SlicedIterator::getPage insteadof SlicedArrayAccess;
+        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
+        SlicedIterator::resetPages insteadof SlicedArrayAccess;
+    }
 
     private $count;
     private $events;

--- a/src/Client/Interviews.php
+++ b/src/Client/Interviews.php
@@ -11,6 +11,7 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Interview;
+use eLife\ApiSdk\SlicedArrayAccess;
 use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
@@ -20,7 +21,12 @@ use function GuzzleHttp\Promise\promise_for;
 final class Interviews implements Iterator, Sequence
 {
     use ArrayFromIterator;
-    use SlicedIterator;
+    use SlicedArrayAccess;
+    use SlicedIterator {
+        SlicedIterator::getPage insteadof SlicedArrayAccess;
+        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
+        SlicedIterator::resetPages insteadof SlicedArrayAccess;
+    }
 
     private $count;
     private $interviews;

--- a/src/Client/Interviews.php
+++ b/src/Client/Interviews.php
@@ -6,13 +6,10 @@ use ArrayObject;
 use eLife\ApiClient\ApiClient\InterviewsClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
-use eLife\ApiSdk\ArrayFromIterator;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Interview;
-use eLife\ApiSdk\SlicedArrayAccess;
-use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -20,13 +17,7 @@ use function GuzzleHttp\Promise\promise_for;
 
 final class Interviews implements Iterator, Sequence
 {
-    use ArrayFromIterator;
-    use SlicedArrayAccess;
-    use SlicedIterator {
-        SlicedIterator::getPage insteadof SlicedArrayAccess;
-        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
-        SlicedIterator::resetPages insteadof SlicedArrayAccess;
-    }
+    use Client;
 
     private $count;
     private $interviews;
@@ -39,11 +30,6 @@ final class Interviews implements Iterator, Sequence
         $this->interviews = new ArrayObject();
         $this->interviewsClient = $interviewsClient;
         $this->denormalizer = $denormalizer;
-    }
-
-    public function __clone()
-    {
-        $this->resetIterator();
     }
 
     public function get(string $id) : PromiseInterface
@@ -109,14 +95,5 @@ final class Interviews implements Iterator, Sequence
         $clone->descendingOrder = !$this->descendingOrder;
 
         return $clone;
-    }
-
-    public function count() : int
-    {
-        if (null === $this->count) {
-            $this->slice(0, 1)->count();
-        }
-
-        return $this->count;
     }
 }

--- a/src/Client/LabsExperiments.php
+++ b/src/Client/LabsExperiments.php
@@ -6,13 +6,10 @@ use ArrayObject;
 use eLife\ApiClient\ApiClient\LabsClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
-use eLife\ApiSdk\ArrayFromIterator;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\LabsExperiment;
-use eLife\ApiSdk\SlicedArrayAccess;
-use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -20,13 +17,7 @@ use function GuzzleHttp\Promise\promise_for;
 
 final class LabsExperiments implements Iterator, Sequence
 {
-    use ArrayFromIterator;
-    use SlicedArrayAccess;
-    use SlicedIterator {
-        SlicedIterator::getPage insteadof SlicedArrayAccess;
-        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
-        SlicedIterator::resetPages insteadof SlicedArrayAccess;
-    }
+    use Client;
 
     private $count;
     private $experiments;
@@ -39,11 +30,6 @@ final class LabsExperiments implements Iterator, Sequence
         $this->experiments = new ArrayObject();
         $this->labsClient = $labsClient;
         $this->denormalizer = $denormalizer;
-    }
-
-    public function __clone()
-    {
-        $this->resetIterator();
     }
 
     public function get(int $number) : PromiseInterface
@@ -109,14 +95,5 @@ final class LabsExperiments implements Iterator, Sequence
         $clone->descendingOrder = !$this->descendingOrder;
 
         return $clone;
-    }
-
-    public function count() : int
-    {
-        if (null === $this->count) {
-            $this->slice(0, 1)->count();
-        }
-
-        return $this->count;
     }
 }

--- a/src/Client/LabsExperiments.php
+++ b/src/Client/LabsExperiments.php
@@ -11,6 +11,7 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\LabsExperiment;
+use eLife\ApiSdk\SlicedArrayAccess;
 use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
@@ -20,7 +21,12 @@ use function GuzzleHttp\Promise\promise_for;
 final class LabsExperiments implements Iterator, Sequence
 {
     use ArrayFromIterator;
-    use SlicedIterator;
+    use SlicedArrayAccess;
+    use SlicedIterator {
+        SlicedIterator::getPage insteadof SlicedArrayAccess;
+        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
+        SlicedIterator::resetPages insteadof SlicedArrayAccess;
+    }
 
     private $count;
     private $experiments;

--- a/src/Client/MediumArticles.php
+++ b/src/Client/MediumArticles.php
@@ -6,26 +6,17 @@ use ArrayObject;
 use eLife\ApiClient\ApiClient\MediumClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
-use eLife\ApiSdk\ArrayFromIterator;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\MediumArticle;
-use eLife\ApiSdk\SlicedArrayAccess;
-use eLife\ApiSdk\SlicedIterator;
 use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use function GuzzleHttp\Promise\promise_for;
 
 final class MediumArticles implements Iterator, Sequence
 {
-    use ArrayFromIterator;
-    use SlicedArrayAccess;
-    use SlicedIterator {
-        SlicedIterator::getPage insteadof SlicedArrayAccess;
-        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
-        SlicedIterator::resetPages insteadof SlicedArrayAccess;
-    }
+    use Client;
 
     private $count;
     private $articles;
@@ -38,11 +29,6 @@ final class MediumArticles implements Iterator, Sequence
         $this->articles = new ArrayObject();
         $this->mediumArticlesClient = $mediumArticlesClient;
         $this->denormalizer = $denormalizer;
-    }
-
-    public function __clone()
-    {
-        $this->resetIterator();
     }
 
     public function slice(int $offset, int $length = null) : Sequence
@@ -92,14 +78,5 @@ final class MediumArticles implements Iterator, Sequence
         $clone->descendingOrder = !$this->descendingOrder;
 
         return $clone;
-    }
-
-    public function count() : int
-    {
-        if (null === $this->count) {
-            $this->slice(0, 1)->count();
-        }
-
-        return $this->count;
     }
 }

--- a/src/Client/MediumArticles.php
+++ b/src/Client/MediumArticles.php
@@ -11,6 +11,7 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\MediumArticle;
+use eLife\ApiSdk\SlicedArrayAccess;
 use eLife\ApiSdk\SlicedIterator;
 use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -19,7 +20,12 @@ use function GuzzleHttp\Promise\promise_for;
 final class MediumArticles implements Iterator, Sequence
 {
     use ArrayFromIterator;
-    use SlicedIterator;
+    use SlicedArrayAccess;
+    use SlicedIterator {
+        SlicedIterator::getPage insteadof SlicedArrayAccess;
+        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
+        SlicedIterator::resetPages insteadof SlicedArrayAccess;
+    }
 
     private $count;
     private $articles;

--- a/src/Client/People.php
+++ b/src/Client/People.php
@@ -11,6 +11,7 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Person;
+use eLife\ApiSdk\SlicedArrayAccess;
 use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
@@ -20,7 +21,12 @@ use function GuzzleHttp\Promise\promise_for;
 final class People implements Iterator, Sequence
 {
     use ArrayFromIterator;
-    use SlicedIterator;
+    use SlicedArrayAccess;
+    use SlicedIterator {
+        SlicedIterator::getPage insteadof SlicedArrayAccess;
+        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
+        SlicedIterator::resetPages insteadof SlicedArrayAccess;
+    }
 
     private $count;
     private $people;

--- a/src/Client/People.php
+++ b/src/Client/People.php
@@ -6,13 +6,10 @@ use ArrayObject;
 use eLife\ApiClient\ApiClient\PeopleClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
-use eLife\ApiSdk\ArrayFromIterator;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Person;
-use eLife\ApiSdk\SlicedArrayAccess;
-use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -20,13 +17,7 @@ use function GuzzleHttp\Promise\promise_for;
 
 final class People implements Iterator, Sequence
 {
-    use ArrayFromIterator;
-    use SlicedArrayAccess;
-    use SlicedIterator {
-        SlicedIterator::getPage insteadof SlicedArrayAccess;
-        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
-        SlicedIterator::resetPages insteadof SlicedArrayAccess;
-    }
+    use Client;
 
     private $count;
     private $people;
@@ -41,11 +32,6 @@ final class People implements Iterator, Sequence
         $this->people = new ArrayObject();
         $this->peopleClient = $peopleClient;
         $this->denormalizer = $denormalizer;
-    }
-
-    public function __clone()
-    {
-        $this->resetIterator();
     }
 
     public function get(string $id) : PromiseInterface
@@ -139,14 +125,5 @@ final class People implements Iterator, Sequence
         $clone->descendingOrder = !$this->descendingOrder;
 
         return $clone;
-    }
-
-    public function count() : int
-    {
-        if (null === $this->count) {
-            $this->slice(0, 1)->count();
-        }
-
-        return $this->count;
     }
 }

--- a/src/Client/PodcastEpisodes.php
+++ b/src/Client/PodcastEpisodes.php
@@ -6,13 +6,10 @@ use ArrayObject;
 use eLife\ApiClient\ApiClient\PodcastClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
-use eLife\ApiSdk\ArrayFromIterator;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\PodcastEpisode;
-use eLife\ApiSdk\SlicedArrayAccess;
-use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -20,13 +17,7 @@ use function GuzzleHttp\Promise\promise_for;
 
 final class PodcastEpisodes implements Iterator, Sequence
 {
-    use ArrayFromIterator;
-    use SlicedArrayAccess;
-    use SlicedIterator {
-        SlicedIterator::getPage insteadof SlicedArrayAccess;
-        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
-        SlicedIterator::resetPages insteadof SlicedArrayAccess;
-    }
+    use Client;
 
     private $count;
     private $episodes;
@@ -40,11 +31,6 @@ final class PodcastEpisodes implements Iterator, Sequence
         $this->episodes = new ArrayObject();
         $this->podcastClient = $podcastClient;
         $this->denormalizer = $denormalizer;
-    }
-
-    public function __clone()
-    {
-        $this->resetIterator();
     }
 
     public function get(int $number) : PromiseInterface
@@ -124,14 +110,5 @@ final class PodcastEpisodes implements Iterator, Sequence
         $clone->descendingOrder = !$this->descendingOrder;
 
         return $clone;
-    }
-
-    public function count() : int
-    {
-        if (null === $this->count) {
-            $this->slice(0, 1)->count();
-        }
-
-        return $this->count;
     }
 }

--- a/src/Client/PodcastEpisodes.php
+++ b/src/Client/PodcastEpisodes.php
@@ -11,6 +11,7 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\PodcastEpisode;
+use eLife\ApiSdk\SlicedArrayAccess;
 use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
@@ -20,7 +21,12 @@ use function GuzzleHttp\Promise\promise_for;
 final class PodcastEpisodes implements Iterator, Sequence
 {
     use ArrayFromIterator;
-    use SlicedIterator;
+    use SlicedArrayAccess;
+    use SlicedIterator {
+        SlicedIterator::getPage insteadof SlicedArrayAccess;
+        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
+        SlicedIterator::resetPages insteadof SlicedArrayAccess;
+    }
 
     private $count;
     private $episodes;

--- a/src/Client/Search.php
+++ b/src/Client/Search.php
@@ -12,6 +12,7 @@ use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\SearchSubjects;
 use eLife\ApiSdk\Model\SearchTypes;
+use eLife\ApiSdk\SlicedArrayAccess;
 use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
@@ -21,7 +22,12 @@ use function GuzzleHttp\Promise\promise_for;
 final class Search implements Iterator, Sequence
 {
     use ArrayFromIterator;
-    use SlicedIterator;
+    use SlicedArrayAccess;
+    use SlicedIterator {
+        SlicedIterator::getPage insteadof SlicedArrayAccess;
+        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
+        SlicedIterator::resetPages insteadof SlicedArrayAccess;
+    }
 
     // collaborators
     private $searchClient;

--- a/src/Client/Search.php
+++ b/src/Client/Search.php
@@ -5,15 +5,12 @@ namespace eLife\ApiSdk\Client;
 use eLife\ApiClient\ApiClient\SearchClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
-use eLife\ApiSdk\ArrayFromIterator;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Model;
 use eLife\ApiSdk\Model\SearchSubjects;
 use eLife\ApiSdk\Model\SearchTypes;
-use eLife\ApiSdk\SlicedArrayAccess;
-use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -21,13 +18,7 @@ use function GuzzleHttp\Promise\promise_for;
 
 final class Search implements Iterator, Sequence
 {
-    use ArrayFromIterator;
-    use SlicedArrayAccess;
-    use SlicedIterator {
-        SlicedIterator::getPage insteadof SlicedArrayAccess;
-        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
-        SlicedIterator::resetPages insteadof SlicedArrayAccess;
-    }
+    use Client;
 
     // collaborators
     private $searchClient;
@@ -192,15 +183,6 @@ final class Search implements Iterator, Sequence
         $clone->descendingOrder = !$this->descendingOrder;
 
         return $clone;
-    }
-
-    public function count() : int
-    {
-        if (null === $this->count) {
-            $this->slice(0, 1)->count();
-        }
-
-        return $this->count;
     }
 
     public function types() : SearchTypes

--- a/src/Client/Subjects.php
+++ b/src/Client/Subjects.php
@@ -6,13 +6,10 @@ use ArrayObject;
 use eLife\ApiClient\ApiClient\SubjectsClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
-use eLife\ApiSdk\ArrayFromIterator;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Subject;
-use eLife\ApiSdk\SlicedArrayAccess;
-use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -20,13 +17,7 @@ use function GuzzleHttp\Promise\promise_for;
 
 final class Subjects implements Iterator, Sequence
 {
-    use ArrayFromIterator;
-    use SlicedArrayAccess;
-    use SlicedIterator {
-        SlicedIterator::getPage insteadof SlicedArrayAccess;
-        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
-        SlicedIterator::resetPages insteadof SlicedArrayAccess;
-    }
+    use Client;
 
     private $count;
     private $subjects;
@@ -39,11 +30,6 @@ final class Subjects implements Iterator, Sequence
         $this->subjects = new ArrayObject();
         $this->subjectsClient = $subjectsClient;
         $this->denormalizer = $denormalizer;
-    }
-
-    public function __clone()
-    {
-        $this->resetIterator();
     }
 
     public function get(string $id) : PromiseInterface
@@ -108,14 +94,5 @@ final class Subjects implements Iterator, Sequence
         $clone->descendingOrder = !$this->descendingOrder;
 
         return $clone;
-    }
-
-    public function count() : int
-    {
-        if (null === $this->count) {
-            $this->slice(0, 1)->count();
-        }
-
-        return $this->count;
     }
 }

--- a/src/Client/Subjects.php
+++ b/src/Client/Subjects.php
@@ -11,6 +11,7 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Subject;
+use eLife\ApiSdk\SlicedArrayAccess;
 use eLife\ApiSdk\SlicedIterator;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
@@ -20,7 +21,12 @@ use function GuzzleHttp\Promise\promise_for;
 final class Subjects implements Iterator, Sequence
 {
     use ArrayFromIterator;
-    use SlicedIterator;
+    use SlicedArrayAccess;
+    use SlicedIterator {
+        SlicedIterator::getPage insteadof SlicedArrayAccess;
+        SlicedIterator::isEmpty insteadof SlicedArrayAccess;
+        SlicedIterator::resetPages insteadof SlicedArrayAccess;
+    }
 
     private $count;
     private $subjects;

--- a/src/Collection/ArraySequence.php
+++ b/src/Collection/ArraySequence.php
@@ -5,6 +5,7 @@ namespace eLife\ApiSdk\Collection;
 use ArrayIterator;
 use eLife\ApiSdk\CanBeCounted;
 use eLife\ApiSdk\Collection;
+use eLife\ApiSdk\ImmutableArrayAccess;
 use GuzzleHttp\Promise\PromiseInterface;
 use IteratorAggregate;
 use Traversable;
@@ -13,6 +14,7 @@ use function GuzzleHttp\Promise\promise_for;
 final class ArraySequence implements IteratorAggregate, Sequence
 {
     use CanBeCounted;
+    use ImmutableArrayAccess;
 
     private $array;
 
@@ -68,5 +70,19 @@ final class ArraySequence implements IteratorAggregate, Sequence
     public function reverse() : Sequence
     {
         return new self(array_reverse($this->array));
+    }
+
+    public function offsetExists($offset) : bool
+    {
+        return isset($this->array[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        if (!isset($this->array[$offset])) {
+            return null;
+        }
+
+        return $this->array[$offset];
     }
 }

--- a/src/Collection/PromiseSequence.php
+++ b/src/Collection/PromiseSequence.php
@@ -4,6 +4,7 @@ namespace eLife\ApiSdk\Collection;
 
 use eLife\ApiSdk\CanBeCounted;
 use eLife\ApiSdk\Collection;
+use eLife\ApiSdk\ImmutableArrayAccess;
 use GuzzleHttp\Promise\PromiseInterface;
 use IteratorAggregate;
 use LogicException;
@@ -12,6 +13,7 @@ use Traversable;
 final class PromiseSequence implements IteratorAggregate, Sequence, PromiseInterface
 {
     use CanBeCounted;
+    use ImmutableArrayAccess;
 
     private $promise;
 
@@ -130,5 +132,15 @@ final class PromiseSequence implements IteratorAggregate, Sequence, PromiseInter
     public function wait($unwrap = true)
     {
         return $this->promise->wait($unwrap);
+    }
+
+    public function offsetExists($offset) : bool
+    {
+        return $this->wait()->offsetExists($offset);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->wait()->offsetGet($offset);
     }
 }

--- a/src/Collection/Sequence.php
+++ b/src/Collection/Sequence.php
@@ -2,10 +2,11 @@
 
 namespace eLife\ApiSdk\Collection;
 
+use ArrayAccess;
 use eLife\ApiSdk\Collection;
 use GuzzleHttp\Promise\PromiseInterface;
 
-interface Sequence extends Collection
+interface Sequence extends Collection, ArrayAccess
 {
     public function map(callable $callback) : Sequence;
 

--- a/src/ImmutableArrayAccess.php
+++ b/src/ImmutableArrayAccess.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace eLife\ApiSdk;
+
+use BadMethodCallException;
+
+trait ImmutableArrayAccess
+{
+    final public function offsetSet($offset, $value)
+    {
+        throw new BadMethodCallException('Object is immutable');
+    }
+
+    final public function offsetUnset($offset)
+    {
+        throw new BadMethodCallException('Object is immutable');
+    }
+}

--- a/src/SlicedArrayAccess.php
+++ b/src/SlicedArrayAccess.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace eLife\ApiSdk;
+
+use eLife\ApiClient\Exception\BadResponse;
+
+trait SlicedArrayAccess
+{
+    use CanBeSliced;
+    use ImmutableArrayAccess;
+
+    public function offsetExists($offset) : bool
+    {
+        return null !== $this->offsetGet($offset);
+    }
+
+    public function offsetGet($offset)
+    {
+        try {
+            $slice = $this->slice($offset, 1)->toArray();
+        } catch (BadResponse $e) {
+            if (404 === $e->getResponse()->getStatusCode()) {
+                return null;
+            }
+
+            throw $e;
+        }
+
+        if (empty($slice)) {
+            return null;
+        }
+
+        return $slice[0];
+    }
+}

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -68,6 +68,24 @@ abstract class ApiTestCase extends TestCase
         return $this->httpClient;
     }
 
+    final protected function mockNotFound(string $uri, array $headers)
+    {
+        $this->storage->save(
+            new Request(
+                'GET',
+                'http://api.elifesciences.org/'.$uri,
+                $headers
+            ),
+            new Response(
+                404,
+                ['Content-Type' => 'application/problem+json'],
+                json_encode([
+                    'title' => 'Not found',
+                ])
+            )
+        );
+    }
+
     final protected function mockAnnualReportListCall(int $page, int $perPage, int $total, $descendingOrder = true)
     {
         $annualReports = array_map(function (int $year) {

--- a/test/Client/AnnualReportsTest.php
+++ b/test/Client/AnnualReportsTest.php
@@ -2,7 +2,9 @@
 
 namespace test\eLife\ApiSdk\Client;
 
+use BadMethodCallException;
 use eLife\ApiClient\ApiClient\AnnualReportsClient;
+use eLife\ApiClient\MediaType;
 use eLife\ApiSdk\Client\AnnualReports;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\AnnualReport;
@@ -77,6 +79,35 @@ final class AnnualReportsTest extends ApiTestCase
             $this->assertInstanceOf(AnnualReport::class, $annualReport);
             $this->assertSame(2011 + $i + 1, $annualReport->getYear());
         }
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_accessed_like_an_array()
+    {
+        $this->mockAnnualReportListCall(1, 1, 1);
+
+        $this->assertTrue(isset($this->annualReports[0]));
+        $this->assertSame(2012, $this->annualReports[0]->getYear());
+
+        $this->mockNotFound(
+            'annual-reports?page=6&per-page=1&order=desc',
+            ['Accept' => new MediaType(AnnualReportsClient::TYPE_ANNUAL_REPORT_LIST, 1)]
+        );
+
+        $this->assertFalse(isset($this->annualReports[5]));
+        $this->assertSame(null, $this->annualReports[5]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_an_immutable_array()
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        $this->annualReports[0] = 'foo';
     }
 
     /**

--- a/test/Client/ArticlesTest.php
+++ b/test/Client/ArticlesTest.php
@@ -2,6 +2,9 @@
 
 namespace test\eLife\ApiSdk\Client;
 
+use BadMethodCallException;
+use eLife\ApiClient\ApiClient\ArticlesClient;
+use eLife\ApiClient\MediaType;
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Client\Articles;
 use eLife\ApiSdk\Collection\Sequence;
@@ -79,6 +82,35 @@ final class ArticlesTest extends ApiTestCase
     /**
      * @test
      */
+    public function it_can_be_accessed_like_an_array()
+    {
+        $this->mockArticleListCall(1, 1, 1);
+
+        $this->assertTrue(isset($this->articles[0]));
+        $this->assertSame('article1', $this->articles[0]->getId());
+
+        $this->mockNotFound(
+            'articles?page=6&per-page=1&order=desc',
+            ['Accept' => new MediaType(ArticlesClient::TYPE_ARTICLE_LIST, 1)]
+        );
+
+        $this->assertFalse(isset($this->articles[5]));
+        $this->assertSame(null, $this->articles[5]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_an_immutable_array()
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        $this->articles[0] = 'foo';
+    }
+
+    /**
+     * @test
+     */
     public function it_gets_an_article()
     {
         $this->mockArticleCall('article7', true, true);
@@ -88,15 +120,15 @@ final class ArticlesTest extends ApiTestCase
         $this->assertInstanceOf(ArticleVersion::class, $article);
         $this->assertSame('article7', $article->getId());
 
-        $this->assertInstanceOf(Section::class, $article->getContent()->toArray()[0]);
-        $this->assertSame('Article article7 section title', $article->getContent()->toArray()[0]->getTitle());
-        $this->assertInstanceOf(Paragraph::class, $article->getContent()->toArray()[0]->getContent()[0]);
-        $this->assertSame('Article article7 text', $article->getContent()->toArray()[0]->getContent()[0]->getText());
+        $this->assertInstanceOf(Section::class, $article->getContent()[0]);
+        $this->assertSame('Article article7 section title', $article->getContent()[0]->getTitle());
+        $this->assertInstanceOf(Paragraph::class, $article->getContent()[0]->getContent()[0]);
+        $this->assertSame('Article article7 text', $article->getContent()[0]->getContent()[0]->getText());
 
         $this->mockSubjectCall(1);
 
-        $this->assertInstanceOf(Subject::class, $article->getSubjects()->toArray()[0]);
-        $this->assertSame('Subject 1 name', $article->getSubjects()->toArray()[0]->getName());
+        $this->assertInstanceOf(Subject::class, $article->getSubjects()[0]);
+        $this->assertSame('Subject 1 name', $article->getSubjects()[0]->getName());
     }
 
     /**
@@ -116,8 +148,8 @@ final class ArticlesTest extends ApiTestCase
 
         $this->mockArticleCall('article1', false, true);
 
-        $this->assertInstanceOf(Section::class, $article->getContent()->toArray()[0]);
-        $this->assertSame('Article article1 section title', $article->getContent()->toArray()[0]->getTitle());
+        $this->assertInstanceOf(Section::class, $article->getContent()[0]);
+        $this->assertSame('Article article1 section title', $article->getContent()[0]->getTitle());
     }
 
     /**

--- a/test/Client/BlogArticlesTest.php
+++ b/test/Client/BlogArticlesTest.php
@@ -2,6 +2,9 @@
 
 namespace test\eLife\ApiSdk\Client;
 
+use BadMethodCallException;
+use eLife\ApiClient\ApiClient\BlogClient;
+use eLife\ApiClient\MediaType;
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Client\BlogArticles;
 use eLife\ApiSdk\Collection\Sequence;
@@ -78,6 +81,35 @@ final class BlogArticlesTest extends ApiTestCase
     /**
      * @test
      */
+    public function it_can_be_accessed_like_an_array()
+    {
+        $this->mockBlogArticleListCall(1, 1, 1);
+
+        $this->assertTrue(isset($this->blogArticles[0]));
+        $this->assertSame('blogArticle1', $this->blogArticles[0]->getId());
+
+        $this->mockNotFound(
+            'blog-articles?page=6&per-page=1&order=desc',
+            ['Accept' => new MediaType(BlogClient::TYPE_BLOG_ARTICLE_LIST, 1)]
+        );
+
+        $this->assertFalse(isset($this->blogArticles[5]));
+        $this->assertSame(null, $this->blogArticles[5]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_an_immutable_array()
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        $this->blogArticles[0] = 'foo';
+    }
+
+    /**
+     * @test
+     */
     public function it_gets_a_blog_article()
     {
         $this->mockBlogArticleCall(7, true);
@@ -87,16 +119,16 @@ final class BlogArticlesTest extends ApiTestCase
         $this->assertInstanceOf(BlogArticle::class, $blogArticle);
         $this->assertSame('blogArticle7', $blogArticle->getId());
 
-        $this->assertInstanceOf(Paragraph::class, $blogArticle->getContent()->toArray()[0]);
-        $this->assertSame('Blog article blogArticle7 text', $blogArticle->getContent()->toArray()[0]->getText());
+        $this->assertInstanceOf(Paragraph::class, $blogArticle->getContent()[0]);
+        $this->assertSame('Blog article blogArticle7 text', $blogArticle->getContent()[0]->getText());
 
-        $this->assertInstanceOf(Subject::class, $blogArticle->getSubjects()->toArray()[0]);
-        $this->assertSame('Subject 1 name', $blogArticle->getSubjects()->toArray()[0]->getName());
+        $this->assertInstanceOf(Subject::class, $blogArticle->getSubjects()[0]);
+        $this->assertSame('Subject 1 name', $blogArticle->getSubjects()[0]->getName());
 
         $this->mockSubjectCall('1');
 
         $this->assertSame('Subject 1 impact statement',
-            $blogArticle->getSubjects()->toArray()[0]->getImpactStatement());
+            $blogArticle->getSubjects()[0]->getImpactStatement());
     }
 
     /**
@@ -116,8 +148,8 @@ final class BlogArticlesTest extends ApiTestCase
 
         $this->mockBlogArticleCall(1);
 
-        $this->assertInstanceOf(Paragraph::class, $blogArticle->getContent()->toArray()[0]);
-        $this->assertSame('Blog article blogArticle1 text', $blogArticle->getContent()->toArray()[0]->getText());
+        $this->assertInstanceOf(Paragraph::class, $blogArticle->getContent()[0]);
+        $this->assertSame('Blog article blogArticle1 text', $blogArticle->getContent()[0]->getText());
     }
 
     /**

--- a/test/Client/CollectionsTest.php
+++ b/test/Client/CollectionsTest.php
@@ -2,6 +2,9 @@
 
 namespace test\eLife\ApiSdk\Client;
 
+use BadMethodCallException;
+use eLife\ApiClient\ApiClient\CollectionsClient;
+use eLife\ApiClient\MediaType;
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Client\Collections;
 use eLife\ApiSdk\Collection\Sequence;
@@ -78,6 +81,35 @@ final class CollectionsTest extends ApiTestCase
     /**
      * @test
      */
+    public function it_can_be_accessed_like_an_array()
+    {
+        $this->mockCollectionListCall(1, 1, 1);
+
+        $this->assertTrue(isset($this->collections[0]));
+        $this->assertSame('1', $this->collections[0]->getId());
+
+        $this->mockNotFound(
+            'collections?page=6&per-page=1&order=desc',
+            ['Accept' => new MediaType(CollectionsClient::TYPE_COLLECTION_LIST, 1)]
+        );
+
+        $this->assertFalse(isset($this->collections[5]));
+        $this->assertSame(null, $this->collections[5]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_an_immutable_array()
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        $this->collections[0] = 'foo';
+    }
+
+    /**
+     * @test
+     */
     public function it_gets_a_collection()
     {
         $this->mockCollectionCall('tropical-disease', true);
@@ -87,17 +119,17 @@ final class CollectionsTest extends ApiTestCase
         $this->assertInstanceOf(Collection::class, $collection);
         $this->assertSame('tropical-disease', $collection->getId());
 
-        $this->assertInstanceOf(BlogArticle::class, $collection->getContent()->toArray()[0]);
-        $this->assertSame('Media coverage: Slime can see', $collection->getContent()->toArray()[0]->getTitle());
+        $this->assertInstanceOf(BlogArticle::class, $collection->getContent()[0]);
+        $this->assertSame('Media coverage: Slime can see', $collection->getContent()[0]->getTitle());
 
-        $this->assertInstanceOf(Subject::class, $collection->getSubjects()->toArray()[0]);
-        $this->assertSame('Subject 1 name', $collection->getSubjects()->toArray()[0]->getName());
+        $this->assertInstanceOf(Subject::class, $collection->getSubjects()[0]);
+        $this->assertSame('Subject 1 name', $collection->getSubjects()[0]->getName());
 
         $this->mockSubjectCall('1');
         $this->mockSubjectCall('biophysics-structural-biology');
 
         $this->assertSame('Subject 1 impact statement',
-            $collection->getSubjects()->toArray()[0]->getImpactStatement());
+            $collection->getSubjects()[0]->getImpactStatement());
     }
 
     /**
@@ -117,8 +149,8 @@ final class CollectionsTest extends ApiTestCase
 
         $this->mockCollectionCall(1);
 
-        $this->assertInstanceOf(BlogArticle::class, $collection->getContent()->toArray()[0]);
-        $this->assertSame('Media coverage: Slime can see', $collection->getContent()->toArray()[0]->getTitle());
+        $this->assertInstanceOf(BlogArticle::class, $collection->getContent()[0]);
+        $this->assertSame('Media coverage: Slime can see', $collection->getContent()[0]->getTitle());
     }
 
     /**

--- a/test/Client/EventsTest.php
+++ b/test/Client/EventsTest.php
@@ -2,6 +2,9 @@
 
 namespace test\eLife\ApiSdk\Client;
 
+use BadMethodCallException;
+use eLife\ApiClient\ApiClient\EventsClient;
+use eLife\ApiClient\MediaType;
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Client\Events;
 use eLife\ApiSdk\Collection\Sequence;
@@ -77,6 +80,35 @@ final class EventsTest extends ApiTestCase
     /**
      * @test
      */
+    public function it_can_be_accessed_like_an_array()
+    {
+        $this->mockEventListCall(1, 1, 1);
+
+        $this->assertTrue(isset($this->events[0]));
+        $this->assertSame('event1', $this->events[0]->getId());
+
+        $this->mockNotFound(
+            'events?page=6&per-page=1&type=all&order=desc',
+            ['Accept' => new MediaType(EventsClient::TYPE_EVENT_LIST, 1)]
+        );
+
+        $this->assertFalse(isset($this->events[5]));
+        $this->assertSame(null, $this->events[5]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_an_immutable_array()
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        $this->events[0] = 'foo';
+    }
+
+    /**
+     * @test
+     */
     public function it_gets_an_event()
     {
         $this->mockEventCall(7);
@@ -86,8 +118,8 @@ final class EventsTest extends ApiTestCase
         $this->assertInstanceOf(Event::class, $event);
         $this->assertSame('event7', $event->getId());
 
-        $this->assertInstanceOf(Paragraph::class, $event->getContent()->toArray()[0]);
-        $this->assertSame('Event 7 text', $event->getContent()->toArray()[0]->getText());
+        $this->assertInstanceOf(Paragraph::class, $event->getContent()[0]);
+        $this->assertSame('Event 7 text', $event->getContent()[0]->getText());
     }
 
     /**
@@ -107,8 +139,8 @@ final class EventsTest extends ApiTestCase
 
         $this->mockEventCall(1);
 
-        $this->assertInstanceOf(Paragraph::class, $event->getContent()->toArray()[0]);
-        $this->assertSame('Event 1 text', $event->getContent()->toArray()[0]->getText());
+        $this->assertInstanceOf(Paragraph::class, $event->getContent()[0]);
+        $this->assertSame('Event 1 text', $event->getContent()[0]->getText());
     }
 
     /**

--- a/test/Client/InterviewsTest.php
+++ b/test/Client/InterviewsTest.php
@@ -2,6 +2,9 @@
 
 namespace test\eLife\ApiSdk\Client;
 
+use BadMethodCallException;
+use eLife\ApiClient\ApiClient\InterviewsClient;
+use eLife\ApiClient\MediaType;
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Client\Interviews;
 use eLife\ApiSdk\Collection\Sequence;
@@ -77,6 +80,35 @@ final class InterviewsTest extends ApiTestCase
     /**
      * @test
      */
+    public function it_can_be_accessed_like_an_array()
+    {
+        $this->mockInterviewListCall(1, 1, 1);
+
+        $this->assertTrue(isset($this->interviews[0]));
+        $this->assertSame('interview1', $this->interviews[0]->getId());
+
+        $this->mockNotFound(
+            'interviews?page=6&per-page=1&order=desc',
+            ['Accept' => new MediaType(InterviewsClient::TYPE_INTERVIEW_LIST, 1)]
+        );
+
+        $this->assertFalse(isset($this->interviews[5]));
+        $this->assertSame(null, $this->interviews[5]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_an_immutable_array()
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        $this->interviews[0] = 'foo';
+    }
+
+    /**
+     * @test
+     */
     public function it_gets_an_interview()
     {
         $this->mockInterviewCall('interview7');
@@ -86,8 +118,8 @@ final class InterviewsTest extends ApiTestCase
         $this->assertInstanceOf(Interview::class, $interview);
         $this->assertSame('interview7', $interview->getId());
 
-        $this->assertInstanceOf(Paragraph::class, $interview->getContent()->toArray()[0]);
-        $this->assertSame('Interview interview7 text', $interview->getContent()->toArray()[0]->getText());
+        $this->assertInstanceOf(Paragraph::class, $interview->getContent()[0]);
+        $this->assertSame('Interview interview7 text', $interview->getContent()[0]->getText());
     }
 
     /**
@@ -107,8 +139,8 @@ final class InterviewsTest extends ApiTestCase
 
         $this->mockInterviewCall('interview1');
 
-        $this->assertInstanceOf(Paragraph::class, $interview->getContent()->toArray()[0]);
-        $this->assertSame('Interview interview1 text', $interview->getContent()->toArray()[0]->getText());
+        $this->assertInstanceOf(Paragraph::class, $interview->getContent()[0]);
+        $this->assertSame('Interview interview1 text', $interview->getContent()[0]->getText());
     }
 
     /**

--- a/test/Client/LabsExperimentsTest.php
+++ b/test/Client/LabsExperimentsTest.php
@@ -2,6 +2,9 @@
 
 namespace test\eLife\ApiSdk\Client;
 
+use BadMethodCallException;
+use eLife\ApiClient\ApiClient\LabsClient;
+use eLife\ApiClient\MediaType;
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Client\LabsExperiments;
 use eLife\ApiSdk\Collection\Sequence;
@@ -77,6 +80,35 @@ final class LabsExperimentsTest extends ApiTestCase
     /**
      * @test
      */
+    public function it_can_be_accessed_like_an_array()
+    {
+        $this->mockLabsExperimentListCall(1, 1, 1);
+
+        $this->assertTrue(isset($this->labsExperiments[0]));
+        $this->assertSame(1, $this->labsExperiments[0]->getNumber());
+
+        $this->mockNotFound(
+            'labs-experiments?page=6&per-page=1&order=desc',
+            ['Accept' => new MediaType(LabsClient::TYPE_EXPERIMENT_LIST, 1)]
+        );
+
+        $this->assertFalse(isset($this->labsExperiments[5]));
+        $this->assertSame(null, $this->labsExperiments[5]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_an_immutable_array()
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        $this->labsExperiments[0] = 'foo';
+    }
+
+    /**
+     * @test
+     */
     public function it_gets_a_labs_experiment()
     {
         $this->mockLabsExperimentCall(7);
@@ -86,8 +118,8 @@ final class LabsExperimentsTest extends ApiTestCase
         $this->assertInstanceOf(LabsExperiment::class, $labsExperiment);
         $this->assertSame(7, $labsExperiment->getNumber());
 
-        $this->assertInstanceOf(Paragraph::class, $labsExperiment->getContent()->toArray()[0]);
-        $this->assertSame('Labs experiment 7 text', $labsExperiment->getContent()->toArray()[0]->getText());
+        $this->assertInstanceOf(Paragraph::class, $labsExperiment->getContent()[0]);
+        $this->assertSame('Labs experiment 7 text', $labsExperiment->getContent()[0]->getText());
     }
 
     /**
@@ -107,8 +139,8 @@ final class LabsExperimentsTest extends ApiTestCase
 
         $this->mockLabsExperimentCall(1);
 
-        $this->assertInstanceOf(Paragraph::class, $labsExperiment->getContent()->toArray()[0]);
-        $this->assertSame('Labs experiment 1 text', $labsExperiment->getContent()->toArray()[0]->getText());
+        $this->assertInstanceOf(Paragraph::class, $labsExperiment->getContent()[0]);
+        $this->assertSame('Labs experiment 1 text', $labsExperiment->getContent()[0]->getText());
     }
 
     /**

--- a/test/Client/MediumArticlesTest.php
+++ b/test/Client/MediumArticlesTest.php
@@ -2,7 +2,9 @@
 
 namespace test\eLife\ApiSdk\Client;
 
+use BadMethodCallException;
 use eLife\ApiClient\ApiClient\MediumClient;
+use eLife\ApiClient\MediaType;
 use eLife\ApiSdk\Client\MediumArticles;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\MediumArticle;
@@ -77,6 +79,35 @@ final class MediumArticlesTest extends ApiTestCase
             $this->assertInstanceOf(MediumArticle::class, $mediumArticle);
             $this->assertSame('Medium article '.($i + 1).' title', $mediumArticle->getTitle());
         }
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_accessed_like_an_array()
+    {
+        $this->mockMediumArticleListCall(1, 1, 1);
+
+        $this->assertTrue(isset($this->mediumArticles[0]));
+        $this->assertSame('Medium article 1 title', $this->mediumArticles[0]->getTitle());
+
+        $this->mockNotFound(
+            'medium-articles?page=6&per-page=1&order=desc',
+            ['Accept' => new MediaType(MediumClient::TYPE_MEDIUM_ARTICLE_LIST, 1)]
+        );
+
+        $this->assertFalse(isset($this->mediumArticles[5]));
+        $this->assertSame(null, $this->mediumArticles[5]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_an_immutable_array()
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        $this->mediumArticles[0] = 'foo';
     }
 
     /**

--- a/test/Client/PeopleTest.php
+++ b/test/Client/PeopleTest.php
@@ -2,6 +2,9 @@
 
 namespace test\eLife\ApiSdk\Client;
 
+use BadMethodCallException;
+use eLife\ApiClient\ApiClient\PeopleClient;
+use eLife\ApiClient\MediaType;
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Client\People;
 use eLife\ApiSdk\Collection\Sequence;
@@ -78,6 +81,35 @@ final class PeopleTest extends ApiTestCase
     /**
      * @test
      */
+    public function it_can_be_accessed_like_an_array()
+    {
+        $this->mockPersonListCall(1, 1, 1);
+
+        $this->assertTrue(isset($this->people[0]));
+        $this->assertSame('person1', $this->people[0]->getId());
+
+        $this->mockNotFound(
+            'people?page=6&per-page=1&order=desc',
+            ['Accept' => new MediaType(PeopleClient::TYPE_PERSON_LIST, 1)]
+        );
+
+        $this->assertFalse(isset($this->people[5]));
+        $this->assertSame(null, $this->people[5]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_an_immutable_array()
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        $this->people[0] = 'foo';
+    }
+
+    /**
+     * @test
+     */
     public function it_gets_a_person()
     {
         $this->mockPersonCall(7, true);
@@ -87,16 +119,16 @@ final class PeopleTest extends ApiTestCase
         $this->assertInstanceOf(Person::class, $person);
         $this->assertSame('person7', $person->getId());
 
-        $this->assertInstanceOf(Paragraph::class, $person->getProfile()->toArray()[0]);
-        $this->assertSame('person7 profile text', $person->getProfile()->toArray()[0]->getText());
+        $this->assertInstanceOf(Paragraph::class, $person->getProfile()[0]);
+        $this->assertSame('person7 profile text', $person->getProfile()[0]->getText());
 
-        $this->assertInstanceOf(Subject::class, $person->getResearch()->getExpertises()->toArray()[0]);
-        $this->assertSame('Subject 1 name', $person->getResearch()->getExpertises()->toArray()[0]->getName());
+        $this->assertInstanceOf(Subject::class, $person->getResearch()->getExpertises()[0]);
+        $this->assertSame('Subject 1 name', $person->getResearch()->getExpertises()[0]->getName());
 
         $this->mockSubjectCall(1);
 
         $this->assertSame('Subject subject1 impact statement',
-            $person->getResearch()->getExpertises()->toArray()[0]->getImpactStatement());
+            $person->getResearch()->getExpertises()[0]->getImpactStatement());
     }
 
     /**
@@ -116,8 +148,8 @@ final class PeopleTest extends ApiTestCase
 
         $this->mockPersonCall(1, true);
 
-        $this->assertInstanceOf(Paragraph::class, $person->getProfile()->toArray()[0]);
-        $this->assertSame('person1 profile text', $person->getProfile()->toArray()[0]->getText());
+        $this->assertInstanceOf(Paragraph::class, $person->getProfile()[0]);
+        $this->assertSame('person1 profile text', $person->getProfile()[0]->getText());
     }
 
     /**

--- a/test/Client/PodcastEpisodesTest.php
+++ b/test/Client/PodcastEpisodesTest.php
@@ -2,6 +2,9 @@
 
 namespace test\eLife\ApiSdk\Client;
 
+use BadMethodCallException;
+use eLife\ApiClient\ApiClient\PodcastClient;
+use eLife\ApiClient\MediaType;
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Client\PodcastEpisodes;
 use eLife\ApiSdk\Collection\Sequence;
@@ -78,6 +81,35 @@ final class PodcastEpisodesTest extends ApiTestCase
     /**
      * @test
      */
+    public function it_can_be_accessed_like_an_array()
+    {
+        $this->mockPodcastEpisodeListCall(1, 1, 1);
+
+        $this->assertTrue(isset($this->podcastEpisodes[0]));
+        $this->assertSame(1, $this->podcastEpisodes[0]->getNumber());
+
+        $this->mockNotFound(
+            'podcast-episodes?page=6&per-page=1&order=desc',
+            ['Accept' => new MediaType(PodcastClient::TYPE_PODCAST_EPISODE_LIST, 1)]
+        );
+
+        $this->assertFalse(isset($this->podcastEpisodes[5]));
+        $this->assertSame(null, $this->podcastEpisodes[5]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_an_immutable_array()
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        $this->podcastEpisodes[0] = 'foo';
+    }
+
+    /**
+     * @test
+     */
     public function it_gets_a_podcast_episode()
     {
         $this->mockPodcastEpisodeCall(7, true);
@@ -87,16 +119,16 @@ final class PodcastEpisodesTest extends ApiTestCase
         $this->assertInstanceOf(PodcastEpisode::class, $podcastEpisode);
         $this->assertSame(7, $podcastEpisode->getNumber());
 
-        $this->assertInstanceOf(PodcastEpisodeChapter::class, $podcastEpisode->getChapters()->toArray()[0]);
-        $this->assertSame('Chapter title', $podcastEpisode->getChapters()->toArray()[0]->getTitle());
+        $this->assertInstanceOf(PodcastEpisodeChapter::class, $podcastEpisode->getChapters()[0]);
+        $this->assertSame('Chapter title', $podcastEpisode->getChapters()[0]->getTitle());
 
-        $this->assertInstanceOf(Subject::class, $podcastEpisode->getSubjects()->toArray()[0]);
-        $this->assertSame('Subject 1 name', $podcastEpisode->getSubjects()->toArray()[0]->getName());
+        $this->assertInstanceOf(Subject::class, $podcastEpisode->getSubjects()[0]);
+        $this->assertSame('Subject 1 name', $podcastEpisode->getSubjects()[0]->getName());
 
         $this->mockSubjectCall('1');
 
         $this->assertSame('Subject 1 impact statement',
-            $podcastEpisode->getSubjects()->toArray()[0]->getImpactStatement());
+            $podcastEpisode->getSubjects()[0]->getImpactStatement());
     }
 
     /**
@@ -116,8 +148,8 @@ final class PodcastEpisodesTest extends ApiTestCase
 
         $this->mockPodcastEpisodeCall(1);
 
-        $this->assertInstanceOf(PodcastEpisodeChapter::class, $podcastEpisode->getChapters()->toArray()[0]);
-        $this->assertSame('Chapter title', $podcastEpisode->getChapters()->toArray()[0]->getTitle());
+        $this->assertInstanceOf(PodcastEpisodeChapter::class, $podcastEpisode->getChapters()[0]);
+        $this->assertSame('Chapter title', $podcastEpisode->getChapters()[0]->getTitle());
     }
 
     /**

--- a/test/Client/SearchTest.php
+++ b/test/Client/SearchTest.php
@@ -2,6 +2,9 @@
 
 namespace test\eLife\ApiSdk\Client;
 
+use BadMethodCallException;
+use eLife\ApiClient\ApiClient\SearchClient;
+use eLife\ApiClient\MediaType;
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Client\Search;
 use eLife\ApiSdk\Collection\Sequence;
@@ -74,12 +77,41 @@ class SearchTest extends ApiTestCase
     /**
      * @test
      */
+    public function it_can_be_accessed_like_an_array()
+    {
+        $this->mockSearchCall(1, 1, 1);
+
+        $this->assertTrue(isset($this->search[0]));
+        $this->assertInstanceOf(Model::class, $this->search[0]);
+
+        $this->mockNotFound(
+            'search?for=&page=6&per-page=1&sort=relevance&order=desc',
+            ['Accept' => new MediaType(SearchClient::TYPE_SEARCH, 1)]
+        );
+
+        $this->assertFalse(isset($this->search[5]));
+        $this->assertSame(null, $this->search[5]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_an_immutable_array()
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        $this->search[0] = 'foo';
+    }
+
+    /**
+     * @test
+     */
     public function it_reuses_already_known_models()
     {
         $this->mockCountCall(1);
         $this->mockFirstPageCall(1);
 
-        $existingModel = $this->search->toArray()[0];
+        $existingModel = $this->search[0];
 
         $models = $this->search->toArray();
 

--- a/test/Client/SubjectsTest.php
+++ b/test/Client/SubjectsTest.php
@@ -2,6 +2,9 @@
 
 namespace test\eLife\ApiSdk\Client;
 
+use BadMethodCallException;
+use eLife\ApiClient\ApiClient\SubjectsClient;
+use eLife\ApiClient\MediaType;
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Client\Subjects;
 use eLife\ApiSdk\Collection\Sequence;
@@ -71,6 +74,35 @@ final class SubjectsTest extends ApiTestCase
             $this->assertInstanceOf(Subject::class, $subject);
             $this->assertSame('subject'.($i + 1), $subject->getId());
         }
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_accessed_like_an_array()
+    {
+        $this->mockSubjectListCall(1, 1, 1);
+
+        $this->assertTrue(isset($this->subjects[0]));
+        $this->assertSame('subject1', $this->subjects[0]->getId());
+
+        $this->mockNotFound(
+            'subjects?page=6&per-page=1&order=desc',
+            ['Accept' => new MediaType(SubjectsClient::TYPE_SUBJECT_LIST, 1)]
+        );
+
+        $this->assertFalse(isset($this->subjects[5]));
+        $this->assertSame(null, $this->subjects[5]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_an_immutable_array()
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        $this->subjects[0] = 'foo';
     }
 
     /**

--- a/test/Collection/ArraySequenceTest.php
+++ b/test/Collection/ArraySequenceTest.php
@@ -2,6 +2,7 @@
 
 namespace test\eLife\ApiSdk\Collection;
 
+use BadMethodCallException;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\Sequence;
 use PHPUnit_Framework_TestCase;
@@ -51,6 +52,31 @@ final class ArraySequenceTest extends PHPUnit_Framework_TestCase
         $collection = new ArraySequence($array);
 
         $this->assertSame($array, $collection->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_accessed_like_an_array()
+    {
+        $collection = new ArraySequence([1, 2, 3, 4, 5]);
+
+        $this->assertTrue(isset($collection[0]));
+        $this->assertSame(1, $collection[0]);
+        $this->assertFalse(isset($collection[5]));
+        $this->assertSame(null, $collection[5]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_an_immutable_array()
+    {
+        $collection = new ArraySequence([1, 2, 3, 4, 5]);
+
+        $this->expectException(BadMethodCallException::class);
+
+        $collection[0] = 'foo';
     }
 
     /**

--- a/test/Collection/PromiseSequenceTest.php
+++ b/test/Collection/PromiseSequenceTest.php
@@ -3,6 +3,7 @@
 namespace test\eLife\ApiSdk\Collection;
 
 use ArrayObject;
+use BadMethodCallException;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
@@ -78,6 +79,31 @@ final class PromiseSequenceTest extends PHPUnit_Framework_TestCase
             'traversable' => [new ArrayObject(['foo']), ['foo']],
             'string' => ['foo', ['foo']],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_accessed_like_an_array()
+    {
+        $collection = new PromiseSequence(promise_for([1, 2, 3, 4, 5]));
+
+        $this->assertTrue(isset($collection[0]));
+        $this->assertSame(1, $collection[0]);
+        $this->assertFalse(isset($collection[5]));
+        $this->assertSame(null, $collection[5]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_an_immutable_array()
+    {
+        $collection = new PromiseSequence(promise_for([1, 2, 3, 4, 5]));
+
+        $this->expectException(BadMethodCallException::class);
+
+        $collection[0] = 'foo';
     }
 
     /**


### PR DESCRIPTION
This does make me think that the clients that are a 1:1 with a content type should be a (bi)map, so the array access is by their identifier not their position in the list (the others, eg `Search`, should be a sorted set). But, refactoring the collections (to hopefully use an external library, but I can't find one good enough) can be done later.