### PR TITLE
Remove knowledge of promises from Sequence

### DIFF
--- a/src/ArrayFromIterator.php
+++ b/src/ArrayFromIterator.php
@@ -6,7 +6,6 @@ use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use GuzzleHttp\Promise\Promise;
-use GuzzleHttp\Promise\PromiseInterface;
 
 trait ArrayFromIterator
 {

--- a/src/ArrayFromIterator.php
+++ b/src/ArrayFromIterator.php
@@ -20,7 +20,7 @@ trait ArrayFromIterator
         return $this->all()->filter($callback);
     }
 
-    final public function reduce(callable $callback, $initial = null) : PromiseInterface
+    final public function reduce(callable $callback, $initial = null)
     {
         return $this->all()->reduce($callback, $initial);
     }

--- a/src/Collection/ArraySequence.php
+++ b/src/Collection/ArraySequence.php
@@ -6,10 +6,8 @@ use ArrayIterator;
 use eLife\ApiSdk\CanBeCounted;
 use eLife\ApiSdk\Collection;
 use eLife\ApiSdk\ImmutableArrayAccess;
-use GuzzleHttp\Promise\PromiseInterface;
 use IteratorAggregate;
 use Traversable;
-use function GuzzleHttp\Promise\promise_for;
 
 final class ArraySequence implements IteratorAggregate, Sequence
 {
@@ -53,9 +51,9 @@ final class ArraySequence implements IteratorAggregate, Sequence
         return new self(array_filter($this->array, $callback));
     }
 
-    public function reduce(callable $callback, $initial = null) : PromiseInterface
+    public function reduce(callable $callback, $initial = null)
     {
-        return promise_for(array_reduce($this->array, $callback, $initial));
+        return array_reduce($this->array, $callback, $initial);
     }
 
     public function sort(callable $callback) : Sequence

--- a/src/Collection/PromiseSequence.php
+++ b/src/Collection/PromiseSequence.php
@@ -74,11 +74,9 @@ final class PromiseSequence implements IteratorAggregate, Sequence, PromiseInter
         );
     }
 
-    public function reduce(callable $callback, $initial = null) : PromiseInterface
+    public function reduce(callable $callback, $initial = null)
     {
-        return $this->then(function (Sequence $collection) use ($callback, $initial) {
-            return $collection->reduce($callback, $initial);
-        });
+        return $this->wait()->reduce($callback, $initial);
     }
 
     public function sort(callable $callback) : Sequence

--- a/src/Collection/Sequence.php
+++ b/src/Collection/Sequence.php
@@ -4,7 +4,6 @@ namespace eLife\ApiSdk\Collection;
 
 use ArrayAccess;
 use eLife\ApiSdk\Collection;
-use GuzzleHttp\Promise\PromiseInterface;
 
 interface Sequence extends Collection, ArrayAccess
 {
@@ -17,7 +16,7 @@ interface Sequence extends Collection, ArrayAccess
      */
     public function filter(callable $callback) : Collection;
 
-    public function reduce(callable $callback, $initial = null) : PromiseInterface;
+    public function reduce(callable $callback, $initial = null);
 
     public function sort(callable $callback) : Sequence;
 

--- a/test/Client/AnnualReportsTest.php
+++ b/test/Client/AnnualReportsTest.php
@@ -232,7 +232,7 @@ final class AnnualReportsTest extends ApiTestCase
             return $carry + $annualReport->getYear();
         };
 
-        $this->assertSame(10170, $this->annualReports->reduce($reduce, 100)->wait());
+        $this->assertSame(10170, $this->annualReports->reduce($reduce, 100));
     }
 
     /**

--- a/test/Client/ArticlesTest.php
+++ b/test/Client/ArticlesTest.php
@@ -290,7 +290,7 @@ final class ArticlesTest extends ApiTestCase
             return $carry + substr($article->getId(), -1);
         };
 
-        $this->assertSame(115, $this->articles->reduce($reduce, 100)->wait());
+        $this->assertSame(115, $this->articles->reduce($reduce, 100));
     }
 
     /**

--- a/test/Client/BlogArticlesTest.php
+++ b/test/Client/BlogArticlesTest.php
@@ -290,7 +290,7 @@ final class BlogArticlesTest extends ApiTestCase
             return $carry + substr($blogArticle->getId(), -1);
         };
 
-        $this->assertSame(115, $this->blogArticles->reduce($reduce, 100)->wait());
+        $this->assertSame(115, $this->blogArticles->reduce($reduce, 100));
     }
 
     /**

--- a/test/Client/CollectionsTest.php
+++ b/test/Client/CollectionsTest.php
@@ -294,7 +294,7 @@ final class CollectionsTest extends ApiTestCase
             return $carry + $podcastEpisode->getId();
         };
 
-        $this->assertSame(115, $this->collections->reduce($reduce, 100)->wait());
+        $this->assertSame(115, $this->collections->reduce($reduce, 100));
     }
 
     /**

--- a/test/Client/EventsTest.php
+++ b/test/Client/EventsTest.php
@@ -281,7 +281,7 @@ final class EventsTest extends ApiTestCase
             return $carry + substr($event->getId(), -1);
         };
 
-        $this->assertSame(115, $this->events->reduce($reduce, 100)->wait());
+        $this->assertSame(115, $this->events->reduce($reduce, 100));
     }
 
     /**

--- a/test/Client/InterviewsTest.php
+++ b/test/Client/InterviewsTest.php
@@ -236,7 +236,7 @@ final class InterviewsTest extends ApiTestCase
             return $carry + substr($interview->getId(), -1);
         };
 
-        $this->assertSame(115, $this->interviews->reduce($reduce, 100)->wait());
+        $this->assertSame(115, $this->interviews->reduce($reduce, 100));
     }
 
     /**

--- a/test/Client/LabsExperimentsTest.php
+++ b/test/Client/LabsExperimentsTest.php
@@ -236,7 +236,7 @@ final class LabsExperimentsTest extends ApiTestCase
             return $carry + $labsExperiment->getNumber();
         };
 
-        $this->assertSame(115, $this->labsExperiments->reduce($reduce, 100)->wait());
+        $this->assertSame(115, $this->labsExperiments->reduce($reduce, 100));
     }
 
     /**

--- a/test/Client/MediumArticlesTest.php
+++ b/test/Client/MediumArticlesTest.php
@@ -204,7 +204,7 @@ final class MediumArticlesTest extends ApiTestCase
             return $carry + substr($mediumArticle->getUri(), -1);
         };
 
-        $this->assertSame(115, $this->mediumArticles->reduce($reduce, 100)->wait());
+        $this->assertSame(115, $this->mediumArticles->reduce($reduce, 100));
     }
 
     /**

--- a/test/Client/PeopleTest.php
+++ b/test/Client/PeopleTest.php
@@ -335,7 +335,7 @@ final class PeopleTest extends ApiTestCase
             return $carry + substr($person->getId(), -1);
         };
 
-        $this->assertSame(115, $this->people->reduce($reduce, 100)->wait());
+        $this->assertSame(115, $this->people->reduce($reduce, 100));
     }
 
     /**

--- a/test/Client/PodcastEpisodesTest.php
+++ b/test/Client/PodcastEpisodesTest.php
@@ -291,7 +291,7 @@ final class PodcastEpisodesTest extends ApiTestCase
             return $carry + $podcastEpisode->getNumber();
         };
 
-        $this->assertSame(115, $this->podcastEpisodes->reduce($reduce, 100)->wait());
+        $this->assertSame(115, $this->podcastEpisodes->reduce($reduce, 100));
     }
 
     /**

--- a/test/Client/SearchTest.php
+++ b/test/Client/SearchTest.php
@@ -295,7 +295,7 @@ class SearchTest extends ApiTestCase
             return $carry + 1;
         };
 
-        $this->assertSame(105, $this->search->reduce($reduce, 100)->wait());
+        $this->assertSame(105, $this->search->reduce($reduce, 100));
     }
 
     /**

--- a/test/Client/SubjectsTest.php
+++ b/test/Client/SubjectsTest.php
@@ -227,7 +227,7 @@ final class SubjectsTest extends ApiTestCase
             return $carry + substr($subject->getId(), -1);
         };
 
-        $this->assertSame(115, $this->subjects->reduce($reduce, 100)->wait());
+        $this->assertSame(115, $this->subjects->reduce($reduce, 100));
     }
 
     /**

--- a/test/Collection/ArraySequenceTest.php
+++ b/test/Collection/ArraySequenceTest.php
@@ -139,7 +139,7 @@ final class ArraySequenceTest extends PHPUnit_Framework_TestCase
             return $carry + $number;
         };
 
-        $this->assertSame(115, $collection->reduce($reduce, 100)->wait());
+        $this->assertSame(115, $collection->reduce($reduce, 100));
     }
 
     /**

--- a/test/Collection/PromiseSequenceTest.php
+++ b/test/Collection/PromiseSequenceTest.php
@@ -181,7 +181,7 @@ final class PromiseSequenceTest extends PHPUnit_Framework_TestCase
             return $carry + $number;
         };
 
-        $this->assertSame(115, $collection->reduce($reduce, 100)->wait());
+        $this->assertSame(115, $collection->reduce($reduce, 100));
     }
 
     /**


### PR DESCRIPTION
This means that `PromiseSequence::reduce()` will now resolve the promise, but I think that's ok.