### PR TITLE
Allow filter callback to be null

### DIFF
--- a/src/ArrayFromIterator.php
+++ b/src/ArrayFromIterator.php
@@ -15,7 +15,7 @@ trait ArrayFromIterator
         return $this->all()->map($callback);
     }
 
-    final public function filter(callable $callback) : Collection
+    final public function filter(callable $callback = null) : Collection
     {
         return $this->all()->filter($callback);
     }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -7,7 +7,7 @@ use Traversable;
 
 interface Collection extends Countable, Traversable
 {
-    public function filter(callable $callback) : Collection;
+    public function filter(callable $callback = null) : Collection;
 
     public function isEmpty() : bool;
 

--- a/src/Collection/ArraySequence.php
+++ b/src/Collection/ArraySequence.php
@@ -50,6 +50,10 @@ final class ArraySequence implements IteratorAggregate, Sequence
 
     public function filter(callable $callback = null) : Collection
     {
+        if (null === $callback) {
+            return new self(array_filter($this->array));
+        }
+
         return new self(array_filter($this->array, $callback));
     }
 

--- a/src/Collection/ArraySequence.php
+++ b/src/Collection/ArraySequence.php
@@ -48,7 +48,7 @@ final class ArraySequence implements IteratorAggregate, Sequence
         return new self(array_map($callback, $this->array));
     }
 
-    public function filter(callable $callback) : Collection
+    public function filter(callable $callback = null) : Collection
     {
         return new self(array_filter($this->array, $callback));
     }

--- a/src/Collection/PromiseSequence.php
+++ b/src/Collection/PromiseSequence.php
@@ -65,7 +65,7 @@ final class PromiseSequence implements IteratorAggregate, Sequence, PromiseInter
         );
     }
 
-    public function filter(callable $callback) : Collection
+    public function filter(callable $callback = null) : Collection
     {
         return new self(
             $this->then(function (Sequence $collection) use ($callback) {

--- a/src/Collection/Sequence.php
+++ b/src/Collection/Sequence.php
@@ -15,7 +15,7 @@ interface Sequence extends Collection, ArrayAccess
     /**
      * @return Sequence
      */
-    public function filter(callable $callback) : Collection;
+    public function filter(callable $callback = null) : Collection;
 
     public function reduce(callable $callback, $initial = null) : PromiseInterface;
 

--- a/test/Collection/ArraySequenceTest.php
+++ b/test/Collection/ArraySequenceTest.php
@@ -119,6 +119,16 @@ final class ArraySequenceTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_be_filtered()
     {
+        $collection = new ArraySequence([1, null, 2, 3, false, 4, 5]);
+
+        $this->assertSame([1, 2, 3, 4, 5], $collection->filter()->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_filtered_with_a_callback()
+    {
         $collection = new ArraySequence([1, 2, 3, 4, 5]);
 
         $filter = function (int $number) {


### PR DESCRIPTION
This then matches `array_filter()`.