### PR TITLE
Allow sort callback to be optional

### DIFF
--- a/src/ArrayFromIterator.php
+++ b/src/ArrayFromIterator.php
@@ -25,7 +25,7 @@ trait ArrayFromIterator
         return $this->all()->reduce($callback, $initial);
     }
 
-    final public function sort(callable $callback) : Sequence
+    final public function sort(callable $callback = null) : Sequence
     {
         return $this->all()->sort($callback);
     }

--- a/src/Collection/ArraySequence.php
+++ b/src/Collection/ArraySequence.php
@@ -58,11 +58,15 @@ final class ArraySequence implements IteratorAggregate, Sequence
         return promise_for(array_reduce($this->array, $callback, $initial));
     }
 
-    public function sort(callable $callback) : Sequence
+    public function sort(callable $callback = null) : Sequence
     {
         $clone = clone $this;
 
-        usort($clone->array, $callback);
+        if (null === $callback) {
+            sort($clone->array);
+        } else {
+            usort($clone->array, $callback);
+        }
 
         return $clone;
     }

--- a/src/Collection/PromiseSequence.php
+++ b/src/Collection/PromiseSequence.php
@@ -81,7 +81,7 @@ final class PromiseSequence implements IteratorAggregate, Sequence, PromiseInter
         });
     }
 
-    public function sort(callable $callback) : Sequence
+    public function sort(callable $callback = null) : Sequence
     {
         return new self(
             $this->then(function (Sequence $collection) use ($callback) {

--- a/src/Collection/Sequence.php
+++ b/src/Collection/Sequence.php
@@ -19,7 +19,7 @@ interface Sequence extends Collection, ArrayAccess
 
     public function reduce(callable $callback, $initial = null) : PromiseInterface;
 
-    public function sort(callable $callback) : Sequence;
+    public function sort(callable $callback = null) : Sequence;
 
     public function reverse() : Sequence;
 }

--- a/test/Collection/ArraySequenceTest.php
+++ b/test/Collection/ArraySequenceTest.php
@@ -147,6 +147,16 @@ final class ArraySequenceTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_be_sorted()
     {
+        $collection = new ArraySequence([5, 4, 3, 2, 1]);
+
+        $this->assertSame([1, 2, 3, 4, 5], $collection->sort()->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_sorted_with_a_callback()
+    {
         $collection = new ArraySequence([1, 2, 3, 4, 5]);
 
         $sort = function (int $a, int $b) {


### PR DESCRIPTION
It will do a regular sort if not set. Sorting objects etc will still require a callback to produce something meaningful, but this might be useful elsewhere.