### PR TITLE
Trying to iterate over articles with one invalid one contained in the page

### DIFF
--- a/src/Client/Articles.php
+++ b/src/Client/Articles.php
@@ -117,8 +117,12 @@ final class Articles implements Iterator, Sequence
                 $articles = [];
 
                 foreach ($result['items'] as $article) {
+                    // *** temporary hack for invalid articles
+                    // we resolve them as null, and let the client applications
+                    // skip them rather than exploding when encountering them
                     if (isset($article['-invalid'])) {
                         $articles[] = null;
+                    // *** end of temporary hack
                     } elseif (isset($this->articles[$article['id']])) {
                         $articles[] = $this->articles[$article['id']]->wait();
                     } else {

--- a/src/Client/Articles.php
+++ b/src/Client/Articles.php
@@ -118,9 +118,8 @@ final class Articles implements Iterator, Sequence
 
                 foreach ($result['items'] as $article) {
                     if (isset($article['-invalid'])) {
-                        continue;
-                    }
-                    if (isset($this->articles[$article['id']])) {
+                        $articles[] = null;
+                    } elseif (isset($this->articles[$article['id']])) {
                         $articles[] = $this->articles[$article['id']]->wait();
                     } else {
                         $articles[] = $article = $this->denormalizer->denormalize($article, ArticleVersion::class, null,

--- a/src/Client/Articles.php
+++ b/src/Client/Articles.php
@@ -117,6 +117,9 @@ final class Articles implements Iterator, Sequence
                 $articles = [];
 
                 foreach ($result['items'] as $article) {
+                    if (isset($article['-invalid'])) {
+                        continue;
+                    }
                     if (isset($this->articles[$article['id']])) {
                         $articles[] = $this->articles[$article['id']]->wait();
                     } else {

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -199,6 +199,43 @@ abstract class ApiTestCase extends TestCase
         );
     }
 
+    final protected function mockArticleListCallWithAnInvalidArticle(
+        int $page = 1,
+        int $perPage = 100,
+        int $total = 200
+    ) {
+        $articles = array_map(function (int $id) {
+            $body = $this->createArticlePoAJson('article'.$id, true);
+            if ($id == 42) {
+                $body = [
+                    "-invalid" => true,
+                    "published" => "2016-12-13T00:00:00Z",
+                    "status" => "vor",
+                    "version" => 1,
+                    "versionDate" => "2016-12-13T00:00:00Z",
+                ];
+            }
+            return $body;
+
+        }, $this->generateIdList($page, $perPage, $total));
+
+        $this->storage->save(
+            new Request(
+                'GET',
+                'http://api.elifesciences.org/articles?page='.$page.'&per-page='.$perPage.'&order=desc',
+                ['Accept' => new MediaType(ArticlesClient::TYPE_ARTICLE_LIST, 1)]
+            ),
+            new Response(
+                200,
+                ['Content-Type' => new MediaType(ArticlesClient::TYPE_ARTICLE_LIST, 1)],
+                json_encode([
+                    'total' => $total,
+                    'items' => $articles,
+                ])
+            )
+        );
+    }
+
     final protected function mockBlogArticleListCall(
         int $page,
         int $perPage,

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -208,15 +208,15 @@ abstract class ApiTestCase extends TestCase
             $body = $this->createArticlePoAJson('article'.$id, true);
             if ($id == 42) {
                 $body = [
-                    "-invalid" => true,
-                    "published" => "2016-12-13T00:00:00Z",
-                    "status" => "vor",
-                    "version" => 1,
-                    "versionDate" => "2016-12-13T00:00:00Z",
+                    '-invalid' => true,
+                    'published' => '2016-12-13T00:00:00Z',
+                    'status' => 'vor',
+                    'version' => 1,
+                    'versionDate' => '2016-12-13T00:00:00Z',
                 ];
             }
-            return $body;
 
+            return $body;
         }, $this->generateIdList($page, $perPage, $total));
 
         $this->storage->save(

--- a/test/Client/ArticlesTest.php
+++ b/test/Client/ArticlesTest.php
@@ -361,8 +361,14 @@ final class ArticlesTest extends ApiTestCase
         $this->mockArticleListCall(1, 1, 100);
         $this->mockArticleListCallWithAnInvalidArticle(1, 100, 100);
 
+        $count = $nullsCount = 0;
         foreach ($this->articles as $article) {
-
+            $count++; 
+            if ($article === null) {
+                $nullsCount++;
+            }
         }
+        $this->assertEquals(100, $count);
+        $this->assertEquals(1, $nullsCount);
     }
 }

--- a/test/Client/ArticlesTest.php
+++ b/test/Client/ArticlesTest.php
@@ -352,4 +352,17 @@ final class ArticlesTest extends ApiTestCase
 
         $this->articles->reverse()->toArray();
     }
+
+    /**
+     * @test
+     */
+    public function it_silently_skips_articles_marked_as_invalid_to_allow_bulk_imports_to_work()
+    {
+        $this->mockArticleListCall(1, 1, 100);
+        $this->mockArticleListCallWithAnInvalidArticle(1, 100, 100);
+
+        foreach ($this->articles as $article) {
+
+        }
+    }
 }

--- a/test/Client/ArticlesTest.php
+++ b/test/Client/ArticlesTest.php
@@ -363,9 +363,9 @@ final class ArticlesTest extends ApiTestCase
 
         $count = $nullsCount = 0;
         foreach ($this->articles as $article) {
-            $count++; 
+            ++$count;
             if ($article === null) {
-                $nullsCount++;
+                ++$nullsCount;
             }
         }
         $this->assertEquals(100, $count);


### PR DESCRIPTION
This is a workaround for the ~35 articles that are invalid in the list.

Currently when loaded in pages of 100 elements, each of them makes the whole page fail when being denormalized, resulting in ~2000 of the ~3200 articles not being accessible.

After the workaround is inserted, the iteration returns null in place of invalid articles. A smart application can then skip the nulls (or error out anyway).

The article is recognized as invalid because Lax returns a small snippet in place of it, marked with the `-invalid` field. This snippet can be used by other applications depending on those APIs like elife-bot.