### PR TITLE
Don't store models in memory

### DIFF
--- a/project_tests.sh
+++ b/project_tests.sh
@@ -6,7 +6,7 @@ set -e
 if [ "$dependencies" = "lowest" ]; then
     composer1.0 update --prefer-lowest --no-interaction
     proofreader src/
-    proofreader --no-phpcpd test/
+    proofreader --no-phpcpd scripts/ test/
 else
     composer1.0 update --no-interaction
 fi

--- a/scripts/load_multiple_times_articles.php
+++ b/scripts/load_multiple_times_articles.php
@@ -1,0 +1,59 @@
+<?php
+
+
+include __DIR__.'/../vendor/autoload.php';
+
+$handler = GuzzleHttp\HandlerStack::create();
+$count = 0;
+$handler->push(GuzzleHttp\Middleware::mapRequest(function (GuzzleHttp\Psr7\Request $request) use (&$count) {
+    ++$count;
+    echo $request->getRequestTarget()."\n";
+
+    return $request;
+}));
+
+$guzzle = new GuzzleHttp\Client([
+  'handler' => $handler,
+  'base_uri' => 'http://prod--gateway.elifesciences.org/',
+]);
+
+$client = new eLife\ApiClient\HttpClient\BatchingHttpClient(
+    new eLife\ApiClient\HttpClient\Guzzle6HttpClient($guzzle),
+    100
+);
+$sdk = new eLife\ApiSdk\ApiSdk($client);
+
+// TEST.
+$articles = $sdk->articles();
+$total = $articles->count();
+$allArticlesObjectsHashesEverSeen = [];
+$allArticlesObjectsEverSeen = [];
+for ($i = 0; $i < 100; ++$i) {
+    $articleObjectsHashes = [];
+    $articleObjects = [];
+    $offset = rand(0, $total);
+    $limit = 100;
+    echo "Slicing $offset, $limit", PHP_EOL;
+    $countBefore = $count;
+    foreach ($articles->slice($offset, $limit) as $a) {
+        if ($a === null) {
+            continue;
+        }
+        // uncomment to force full loading
+        //$a->getCopyright();
+        $articleObjectsHashes[] = $hash = spl_object_hash($a);
+        $articleObjects[$hash] = $a;
+        $allArticlesObjectsEverSeen[$hash] = $a;
+        //echo $hash, " ", $a->getTitle(), PHP_EOL;
+    }
+    if ($intersection = array_intersect($articleObjectsHashes, $allArticlesObjectsHashesEverSeen)) {
+        echo 'Seeing again old objects...', PHP_EOL;
+        var_dump($intersection);
+        foreach ($intersection as $hash) {
+            var_dump($articleObjects[$hash]->getTitle());
+        }
+        throw new RuntimeException('We should only receive new objects');
+    }
+    $allArticlesObjectsHashesEverSeen = array_merge($allArticlesObjectsHashesEverSeen, $articleObjectsHashes);
+    echo 'Seen ', count($allArticlesObjectsHashesEverSeen), ' objects so far', PHP_EOL;
+}

--- a/src/Client/Collections.php
+++ b/src/Client/Collections.php
@@ -2,25 +2,21 @@
 
 namespace eLife\ApiSdk\Client;
 
-use ArrayObject;
 use eLife\ApiClient\ApiClient\CollectionsClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
-use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\Collection;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
-use function GuzzleHttp\Promise\promise_for;
 
 final class Collections implements Iterator, Sequence
 {
     use Client;
 
     private $count;
-    private $collections = [];
     private $descendingOrder = true;
     private $subjectsQuery = [];
     private $collectionsClient;
@@ -28,18 +24,13 @@ final class Collections implements Iterator, Sequence
 
     public function __construct(CollectionsClient $collectionsClient, DenormalizerInterface $denormalizer)
     {
-        $this->collections = new ArrayObject();
         $this->collectionsClient = $collectionsClient;
         $this->denormalizer = $denormalizer;
     }
 
     public function get(string $id) : PromiseInterface
     {
-        if (isset($this->collections[$id])) {
-            return $this->collections[$id];
-        }
-
-        return $this->collections[$id] = $this->collectionsClient
+        return $this->collectionsClient
             ->getCollection(
                 ['Accept' => new MediaType(CollectionsClient::TYPE_COLLECTION, 1)],
                 $id
@@ -86,19 +77,9 @@ final class Collections implements Iterator, Sequence
                 return $result;
             })
             ->then(function (Result $result) {
-                $collections = [];
-
-                foreach ($result['items'] as $collection) {
-                    if (isset($this->collections[$collection['id']])) {
-                        $collections[] = $this->collections[$collection['id']]->wait();
-                    } else {
-                        $collections[] = $collection = $this->denormalizer->denormalize($collection, Collection::class,
-                            null, ['snippet' => true]);
-                        $this->collections[$collection->getId()] = promise_for($collection);
-                    }
-                }
-
-                return new ArraySequence($collections);
+                return array_map(function (array $collection) {
+                    return $this->denormalizer->denormalize($collection, Collection::class, null, ['snippet' => true]);
+                }, $result['items']);
             })
         );
     }

--- a/src/Client/Covers.php
+++ b/src/Client/Covers.php
@@ -66,9 +66,9 @@ final class Covers implements Iterator, Sequence
                 return $result;
             })
             ->then(function (Result $result) {
-                return new ArraySequence(array_map(function (array $cover) {
+                return array_map(function (array $cover) {
                     return $this->denormalizer->denormalize($cover, Cover::class);
-                }, $result['items']));
+                }, $result['items']);
             }));
     }
 

--- a/src/Client/LabsExperiments.php
+++ b/src/Client/LabsExperiments.php
@@ -2,43 +2,34 @@
 
 namespace eLife\ApiSdk\Client;
 
-use ArrayObject;
 use eLife\ApiClient\ApiClient\LabsClient;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
-use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
 use eLife\ApiSdk\Model\LabsExperiment;
 use GuzzleHttp\Promise\PromiseInterface;
 use Iterator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
-use function GuzzleHttp\Promise\promise_for;
 
 final class LabsExperiments implements Iterator, Sequence
 {
     use Client;
 
     private $count;
-    private $experiments;
     private $descendingOrder = true;
     private $labsClient;
     private $denormalizer;
 
     public function __construct(LabsClient $labsClient, DenormalizerInterface $denormalizer)
     {
-        $this->experiments = new ArrayObject();
         $this->labsClient = $labsClient;
         $this->denormalizer = $denormalizer;
     }
 
     public function get(int $number) : PromiseInterface
     {
-        if (isset($this->experiments[$number])) {
-            return $this->experiments[$number];
-        }
-
-        return $this->experiments[$number] = $this->labsClient
+        return $this->labsClient
             ->getExperiment(
                 ['Accept' => new MediaType(LabsClient::TYPE_EXPERIMENT, 1)],
                 $number
@@ -71,19 +62,9 @@ final class LabsExperiments implements Iterator, Sequence
                 return $result;
             })
             ->then(function (Result $result) {
-                $experiments = [];
-
-                foreach ($result['items'] as $experiment) {
-                    if (isset($this->experiments[$experiment['number']])) {
-                        $experiments[] = $this->experiments[$experiment['number']]->wait();
-                    } else {
-                        $experiments[] = $experiment = $this->denormalizer->denormalize($experiment,
-                            LabsExperiment::class, null, ['snippet' => true]);
-                        $this->experiments[$experiment->getNumber()] = promise_for($experiment);
-                    }
-                }
-
-                return new ArraySequence($experiments);
+                return array_map(function (array $experiment) {
+                    return $this->denormalizer->denormalize($experiment, LabsExperiment::class, null, ['snippet' => true]);
+                }, $result['items']);
             })
         );
     }

--- a/src/Serializer/IdentityMap.php
+++ b/src/Serializer/IdentityMap.php
@@ -12,9 +12,13 @@ final class IdentityMap
 {
     private $contents = [];
 
-    public function reset($id) : self
+    public function reset($id = null) : self
     {
-        $this->contents[$id] = null;
+        if ($id) {
+            $this->contents[$id] = null;
+        } else {
+            $this->contents = [];
+        }
 
         return $this;
     }

--- a/src/Serializer/LabsExperimentNormalizer.php
+++ b/src/Serializer/LabsExperimentNormalizer.php
@@ -13,7 +13,6 @@ use eLife\ApiSdk\Model\Block;
 use eLife\ApiSdk\Model\Image;
 use eLife\ApiSdk\Model\LabsExperiment;
 use eLife\ApiSdk\Model\Model;
-use eLife\ApiSdk\Promise\CallbackPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
@@ -21,7 +20,6 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-use function GuzzleHttp\Promise\all;
 use function GuzzleHttp\Promise\promise_for;
 
 final class LabsExperimentNormalizer implements NormalizerInterface, DenormalizerInterface, NormalizerAwareInterface, DenormalizerAwareInterface
@@ -29,19 +27,27 @@ final class LabsExperimentNormalizer implements NormalizerInterface, Denormalize
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
 
-    private $labsClient;
-    private $found = [];
-    private $globalCallback;
+    private $snippetDenormalizer;
 
     public function __construct(LabsClient $labsClient)
     {
-        $this->labsClient = $labsClient;
+        $this->snippetDenormalizer = new SnippetDenormalizer(
+            function (array $event) : int {
+                return $event['number'];
+            },
+            function (int $number) use ($labsClient) : PromiseInterface {
+                return $labsClient->getExperiment(
+                    ['Accept' => new MediaType(LabsClient::TYPE_EXPERIMENT, 1)],
+                    $number
+                );
+            }
+        );
     }
 
     public function denormalize($data, $class, $format = null, array $context = []) : LabsExperiment
     {
         if (!empty($context['snippet'])) {
-            $experiment = $this->denormalizeSnippet($data);
+            $experiment = $this->snippetDenormalizer->denormalizeSnippet($data);
 
             $data['content'] = new PromiseSequence($experiment
                 ->then(function (Result $experiment) {
@@ -79,37 +85,6 @@ final class LabsExperimentNormalizer implements NormalizerInterface, Denormalize
             $data['image']['thumbnail'],
             $data['content']
         );
-    }
-
-    private function denormalizeSnippet(array $experiment) : PromiseInterface
-    {
-        if (isset($this->found[$experiment['number']])) {
-            return $this->found[$experiment['number']];
-        }
-
-        $this->found[$experiment['number']] = null;
-
-        if (empty($this->globalCallback)) {
-            $this->globalCallback = new CallbackPromise(function () {
-                foreach ($this->found as $number => $experiment) {
-                    if (null === $experiment) {
-                        $this->found[$number] = $this->labsClient->getExperiment(
-                            ['Accept' => new MediaType(LabsClient::TYPE_EXPERIMENT, 1)],
-                            $number
-                        );
-                    }
-                }
-
-                $this->globalCallback = null;
-
-                return all($this->found)->wait();
-            });
-        }
-
-        return $this->globalCallback
-            ->then(function (array $experiments) use ($experiment) {
-                return $experiments[$experiment['number']];
-            });
     }
 
     public function supportsDenormalization($data, $type, $format = null) : bool

--- a/src/Serializer/SnippetDenormalizer.php
+++ b/src/Serializer/SnippetDenormalizer.php
@@ -7,21 +7,21 @@ use GuzzleHttp\Promise\PromiseInterface;
 
 final class SnippetDenormalizer
 {
-    private $id;
-    private $fetcher;
+    private $determineId;
+    private $fetchComplete;
     private $identityMap;
     private $globalCallback;
 
-    public function __construct(callable $id, callable $fetcher)
+    public function __construct(callable $determineId, callable $fetchComplete)
     {
-        $this->id = $id;
-        $this->fetcher = $fetcher;
+        $this->determineId = $determineId;
+        $this->fetchComplete = $fetchComplete;
         $this->identityMap = new IdentityMap();
     }
 
     public function denormalizeSnippet(array $item) : PromiseInterface
     {
-        $id = call_user_func($this->id, $item);
+        $id = call_user_func($this->determineId, $item);
 
         if ($this->identityMap->has($id)) {
             return $this->identityMap->get($id);
@@ -31,7 +31,7 @@ final class SnippetDenormalizer
 
         if (empty($this->globalCallback)) {
             $this->globalCallback = new CallbackPromise(function () {
-                $this->identityMap->fillMissingWith($this->fetcher);
+                $this->identityMap->fillMissingWith($this->fetchComplete);
 
                 $this->globalCallback = null;
 

--- a/src/Serializer/SnippetDenormalizer.php
+++ b/src/Serializer/SnippetDenormalizer.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace eLife\ApiSdk\Serializer;
+
+use eLife\ApiSdk\Promise\CallbackPromise;
+use GuzzleHttp\Promise\PromiseInterface;
+
+final class SnippetDenormalizer
+{
+    private $id;
+    private $fetcher;
+    private $identityMap;
+    private $globalCallback;
+
+    public function __construct(callable $id, callable $fetcher)
+    {
+        $this->id = $id;
+        $this->fetcher = $fetcher;
+        $this->identityMap = new IdentityMap();
+    }
+
+    public function denormalizeSnippet(array $item) : PromiseInterface
+    {
+        $id = call_user_func($this->id, $item);
+
+        if ($this->identityMap->has($id)) {
+            return $this->identityMap->get($id);
+        }
+
+        $this->identityMap->reset($id);
+
+        if (empty($this->globalCallback)) {
+            $this->globalCallback = new CallbackPromise(function () {
+                $this->identityMap->fillMissingWith($this->fetcher);
+
+                $this->globalCallback = null;
+
+                $settled = $this->identityMap->waitForAll();
+
+                $this->identityMap->reset();
+
+                return $settled;
+            });
+        }
+
+        return $this->globalCallback
+            ->then(function (array $items) use ($id) {
+                return $items[$id];
+            });
+    }
+}

--- a/test/Client/AnnualReportsTest.php
+++ b/test/Client/AnnualReportsTest.php
@@ -125,22 +125,6 @@ final class AnnualReportsTest extends ApiTestCase
 
     /**
      * @test
-     */
-    public function it_reuses_already_known_annual_reports()
-    {
-        $this->mockAnnualReportListCall(1, 1, 10);
-        $this->mockAnnualReportListCall(1, 100, 10);
-
-        $this->annualReports->toArray();
-
-        $annualReport = $this->annualReports->get(2012)->wait();
-
-        $this->assertInstanceOf(AnnualReport::class, $annualReport);
-        $this->assertSame(2012, $annualReport->getYear());
-    }
-
-    /**
-     * @test
      * @dataProvider sliceProvider
      */
     public function it_can_be_sliced(int $offset, int $length = null, array $expected, array $calls)

--- a/test/Client/ArticlesTest.php
+++ b/test/Client/ArticlesTest.php
@@ -136,27 +136,6 @@ final class ArticlesTest extends ApiTestCase
     /**
      * @test
      */
-    public function it_reuses_already_known_articles()
-    {
-        $this->mockArticleListCall(1, 1, 1, true, [], true);
-        $this->mockArticleListCall(1, 100, 1, true, [], true);
-
-        $this->articles->toArray();
-
-        $article = $this->articles->get('article1')->wait();
-
-        $this->assertInstanceOf(ArticleVersion::class, $article);
-        $this->assertSame('article1', $article->getId());
-
-        $this->mockArticleCall('article1', false, true, 1);
-
-        $this->assertInstanceOf(Section::class, $article->getContent()[0]);
-        $this->assertSame('Article article1 section title', $article->getContent()[0]->getTitle());
-    }
-
-    /**
-     * @test
-     */
     public function it_gets_an_article_history()
     {
         $this->mockArticleHistoryCall('article7', true);
@@ -182,19 +161,6 @@ final class ArticlesTest extends ApiTestCase
             $this->assertInstanceOf(Subject::class, $articleVersion->getSubjects()[0]);
             $this->assertSame('Subject 1 name', $articleVersion->getSubjects()[0]->getName());
         }
-    }
-
-    /**
-     * @test.
-     */
-    public function it_reuses_already_known_article_histories()
-    {
-        $this->mockArticleHistoryCall('article7', true);
-
-        $articleHistory1 = $this->articles->getHistory('article7')->wait();
-        $articleHistory2 = $this->articles->getHistory('article7')->wait();
-
-        $this->assertSame($articleHistory1, $articleHistory2);
     }
 
     /**

--- a/test/Client/BlogArticlesTest.php
+++ b/test/Client/BlogArticlesTest.php
@@ -134,27 +134,6 @@ final class BlogArticlesTest extends ApiTestCase
     /**
      * @test
      */
-    public function it_reuses_already_known_blog_articles()
-    {
-        $this->mockBlogArticleListCall(1, 1, 1);
-        $this->mockBlogArticleListCall(1, 100, 1);
-
-        $this->blogArticles->toArray();
-
-        $blogArticle = $this->blogArticles->get('blog-article-1')->wait();
-
-        $this->assertInstanceOf(BlogArticle::class, $blogArticle);
-        $this->assertSame('blog-article-1', $blogArticle->getId());
-
-        $this->mockBlogArticleCall(1);
-
-        $this->assertInstanceOf(Paragraph::class, $blogArticle->getContent()[0]);
-        $this->assertSame('Blog article blog-article-1 text', $blogArticle->getContent()[0]->getText());
-    }
-
-    /**
-     * @test
-     */
     public function it_can_be_filtered_by_subject()
     {
         $this->mockBlogArticleListCall(1, 1, 5, true, ['subject']);

--- a/test/Client/CollectionsTest.php
+++ b/test/Client/CollectionsTest.php
@@ -135,27 +135,6 @@ final class CollectionsTest extends ApiTestCase
     /**
      * @test
      */
-    public function it_reuses_already_known_collections()
-    {
-        $this->mockCollectionListCall(1, 1, 1);
-        $this->mockCollectionListCall(1, 100, 1);
-
-        $this->collections->toArray();
-
-        $collection = $this->collections->get(1)->wait();
-
-        $this->assertInstanceOf(Collection::class, $collection);
-        $this->assertSame('1', $collection->getId());
-
-        $this->mockCollectionCall(1);
-
-        $this->assertInstanceOf(BlogArticle::class, $collection->getContent()[0]);
-        $this->assertSame('Media coverage: Slime can see', $collection->getContent()[0]->getTitle());
-    }
-
-    /**
-     * @test
-     */
     public function it_can_be_filtered_by_subject()
     {
         $this->mockCollectionListCall(1, 1, 5, true, ['subject']);

--- a/test/Client/EventsTest.php
+++ b/test/Client/EventsTest.php
@@ -125,27 +125,6 @@ final class EventsTest extends ApiTestCase
     /**
      * @test
      */
-    public function it_reuses_already_known_events()
-    {
-        $this->mockEventListCall(1, 1, 1);
-        $this->mockEventListCall(1, 100, 1);
-
-        $this->events->toArray();
-
-        $event = $this->events->get('event1')->wait();
-
-        $this->assertInstanceOf(Event::class, $event);
-        $this->assertSame('event1', $event->getId());
-
-        $this->mockEventCall(1);
-
-        $this->assertInstanceOf(Paragraph::class, $event->getContent()[0]);
-        $this->assertSame('Event 1 text', $event->getContent()[0]->getText());
-    }
-
-    /**
-     * @test
-     */
     public function it_can_be_filtered_by_type()
     {
         $this->mockEventListCall(1, 1, 5, true, 'open');

--- a/test/Client/InterviewsTest.php
+++ b/test/Client/InterviewsTest.php
@@ -124,27 +124,6 @@ final class InterviewsTest extends ApiTestCase
 
     /**
      * @test
-     */
-    public function it_reuses_already_known_interviews()
-    {
-        $this->mockInterviewListCall(1, 1, 1);
-        $this->mockInterviewListCall(1, 100, 1);
-
-        $this->interviews->toArray();
-
-        $interview = $this->interviews->get('interview1')->wait();
-
-        $this->assertInstanceOf(Interview::class, $interview);
-        $this->assertSame('interview1', $interview->getId());
-
-        $this->mockInterviewCall('interview1');
-
-        $this->assertInstanceOf(Paragraph::class, $interview->getContent()[0]);
-        $this->assertSame('Interview interview1 text', $interview->getContent()[0]->getText());
-    }
-
-    /**
-     * @test
      * @dataProvider sliceProvider
      */
     public function it_can_be_sliced(int $offset, int $length = null, array $expected, array $calls)

--- a/test/Client/LabsExperimentsTest.php
+++ b/test/Client/LabsExperimentsTest.php
@@ -124,27 +124,6 @@ final class LabsExperimentsTest extends ApiTestCase
 
     /**
      * @test
-     */
-    public function it_reuses_already_known_labs_experiments()
-    {
-        $this->mockLabsExperimentListCall(1, 1, 1);
-        $this->mockLabsExperimentListCall(1, 100, 1);
-
-        $this->labsExperiments->toArray();
-
-        $labsExperiment = $this->labsExperiments->get(1)->wait();
-
-        $this->assertInstanceOf(LabsExperiment::class, $labsExperiment);
-        $this->assertSame(1, $labsExperiment->getNumber());
-
-        $this->mockLabsExperimentCall(1);
-
-        $this->assertInstanceOf(Paragraph::class, $labsExperiment->getContent()[0]);
-        $this->assertSame('Labs experiment 1 text', $labsExperiment->getContent()[0]->getText());
-    }
-
-    /**
-     * @test
      * @dataProvider sliceProvider
      */
     public function it_can_be_sliced(int $offset, int $length = null, array $expected, array $calls)

--- a/test/Client/PeopleTest.php
+++ b/test/Client/PeopleTest.php
@@ -134,27 +134,6 @@ final class PeopleTest extends ApiTestCase
     /**
      * @test
      */
-    public function it_reuses_already_known_people()
-    {
-        $this->mockPersonListCall(1, 1, 1);
-        $this->mockPersonListCall(1, 100, 1);
-
-        $this->people->toArray();
-
-        $person = $this->people->get('person1')->wait();
-
-        $this->assertInstanceOf(Person::class, $person);
-        $this->assertSame('person1', $person->getId());
-
-        $this->mockPersonCall(1, true);
-
-        $this->assertInstanceOf(Paragraph::class, $person->getProfile()[0]);
-        $this->assertSame('person1 profile text', $person->getProfile()[0]->getText());
-    }
-
-    /**
-     * @test
-     */
     public function it_can_be_filtered_by_subject()
     {
         $this->mockPersonListCall(1, 1, 5, true, ['subject']);

--- a/test/Client/PodcastEpisodesTest.php
+++ b/test/Client/PodcastEpisodesTest.php
@@ -134,27 +134,6 @@ final class PodcastEpisodesTest extends ApiTestCase
     /**
      * @test
      */
-    public function it_reuses_already_known_podcast_episodes()
-    {
-        $this->mockPodcastEpisodeListCall(1, 1, 1);
-        $this->mockPodcastEpisodeListCall(1, 100, 1);
-
-        $this->podcastEpisodes->toArray();
-
-        $podcastEpisode = $this->podcastEpisodes->get(1)->wait();
-
-        $this->assertInstanceOf(PodcastEpisode::class, $podcastEpisode);
-        $this->assertSame(1, $podcastEpisode->getNumber());
-
-        $this->mockPodcastEpisodeCall(1);
-
-        $this->assertInstanceOf(PodcastEpisodeChapter::class, $podcastEpisode->getChapters()[0]);
-        $this->assertSame('Chapter title', $podcastEpisode->getChapters()[0]->getTitle());
-    }
-
-    /**
-     * @test
-     */
     public function it_can_be_filtered_by_subject()
     {
         $this->mockPodcastEpisodeListCall(1, 1, 5, true, ['subject']);

--- a/test/Client/SearchTest.php
+++ b/test/Client/SearchTest.php
@@ -106,25 +106,6 @@ class SearchTest extends ApiTestCase
     /**
      * @test
      */
-    public function it_reuses_already_known_models()
-    {
-        $this->mockCountCall(1);
-        $this->mockFirstPageCall(1);
-
-        $existingModel = $this->search[0];
-
-        $models = $this->search->toArray();
-
-        $this->assertInstanceOf(Model::class, $models[0]);
-
-        $this->mockArticleCall(1);
-        $this->assertSame($existingModel, $models[0]);
-        $this->assertSame('Article 1 title', $models[0]->getTitle());
-    }
-
-    /**
-     * @test
-     */
     public function it_can_be_filtered_by_query()
     {
         $this->mockCountCall(5, 'bacteria');
@@ -318,21 +299,6 @@ class SearchTest extends ApiTestCase
         $this->mockFirstPageCall(10, $query = '', $descendingOrder = false);
 
         $this->assertSame(10, $this->traverseAndSanityCheck($this->search->reverse()));
-    }
-
-    /**
-     * @test
-     */
-    public function it_reuses_models_when_reversed_or_in_general_resliced()
-    {
-        $this->mockCountCall(10, $query = '');
-        $this->mockFirstPageCall(10, $query = '', $descendingOrder = true);
-        $models = $this->search->toArray();
-
-        $this->mockFirstPageCall(10, $query = '', $descendingOrder = false);
-        foreach ($this->search->reverse() as $item) {
-            $this->assertTrue(array_search($item, $models, $strict = true) !== false, 'Search item not found in previous items objects set');
-        }
     }
 
     /**

--- a/test/Client/SubjectsTest.php
+++ b/test/Client/SubjectsTest.php
@@ -120,22 +120,6 @@ final class SubjectsTest extends ApiTestCase
 
     /**
      * @test
-     */
-    public function it_reuses_already_known_subjects()
-    {
-        $this->mockSubjectListCall(1, 1, 10);
-        $this->mockSubjectListCall(1, 100, 10);
-
-        $this->subjects->toArray();
-
-        $subject = $this->subjects->get('subject7')->wait();
-
-        $this->assertInstanceOf(Subject::class, $subject);
-        $this->assertSame('subject7', $subject->getId());
-    }
-
-    /**
-     * @test
      * @dataProvider sliceProvider
      */
     public function it_can_be_sliced(int $offset, int $length = null, array $expected, array $calls)

--- a/test/Serializer/SnippetDenormalizerTest.php
+++ b/test/Serializer/SnippetDenormalizerTest.php
@@ -3,9 +3,9 @@
 namespace test\eLife\ApiSdk\Serializer;
 
 use eLife\ApiSdk\Serializer\SnippetDenormalizer;
-use function GuzzleHttp\Promise\promise_for;
 use GuzzleHttp\Promise\PromiseInterface;
 use PHPUnit_Framework_TestCase;
+use function GuzzleHttp\Promise\promise_for;
 
 final class SnippetDenormalizerTest extends PHPUnit_Framework_TestCase
 {
@@ -23,7 +23,7 @@ final class SnippetDenormalizerTest extends PHPUnit_Framework_TestCase
             function (int $id) use (&$settled) : PromiseInterface {
                 return promise_for(['id' => $id, 'name' => 'Item '.$id])
                     ->then(function (array $item) use (&$settled) {
-                        $settled++;
+                        ++$settled;
 
                         return $item;
                     });

--- a/test/Serializer/SnippetDenormalizerTest.php
+++ b/test/Serializer/SnippetDenormalizerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace test\eLife\ApiSdk\Serializer;
+
+use eLife\ApiSdk\Serializer\SnippetDenormalizer;
+use function GuzzleHttp\Promise\promise_for;
+use GuzzleHttp\Promise\PromiseInterface;
+use PHPUnit_Framework_TestCase;
+
+final class SnippetDenormalizerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_denormalizes_snippets()
+    {
+        $settled = 0;
+
+        $snippetDenormalizer = new SnippetDenormalizer(
+            function (array $item) : int {
+                return $item['id'];
+            },
+            function (int $id) use (&$settled) : PromiseInterface {
+                return promise_for(['id' => $id, 'name' => 'Item '.$id])
+                    ->then(function (array $item) use (&$settled) {
+                        $settled++;
+
+                        return $item;
+                    });
+            }
+        );
+
+        $item1 = $snippetDenormalizer->denormalizeSnippet(['id' => 1]);
+        $item2 = $snippetDenormalizer->denormalizeSnippet(['id' => 2]);
+
+        $this->assertSame(0, $settled);
+
+        $this->assertSame(['id' => 1, 'name' => 'Item 1'], $item1->wait());
+
+        $this->assertSame(2, $settled);
+
+        $this->assertSame(['id' => 2, 'name' => 'Item 2'], $item2->wait());
+    }
+}


### PR DESCRIPTION
Currently the SDK acts like an ORM and stores models in memory, so if you request it again it doesn't have to make another HTTP request. However, this inflates memory usage, but worse is a problem for long-running requests, as the models never update (unlike an ORM, we don't know if the objects have changed since they're remote).

So, this (should) stop models from being tracked by the SDK, allowing them to be garbaged-collected/re-requested.

I would like to investigate adding something similar back in the future, but it must be optional/customisable. In the meantime, HTTP caching could be used to reduce the number of requests a bit.

This is going to need a bit more manual examination, but appears to work.

/cc @giorgiosironi @stephenwf