### PR TITLE
Only have a single Accept header on article requests

### DIFF
--- a/src/Client/Articles.php
+++ b/src/Client/Articles.php
@@ -49,10 +49,10 @@ final class Articles implements Iterator, Sequence
             return $this->articlesClient
                 ->getArticleLatestVersion(
                     [
-                        'Accept' => [
+                        'Accept' => implode(', ', [
                             new MediaType(ArticlesClient::TYPE_ARTICLE_POA, 2),
                             new MediaType(ArticlesClient::TYPE_ARTICLE_VOR, 2),
-                        ],
+                        ]),
                     ],
                     $id
                 )
@@ -64,10 +64,10 @@ final class Articles implements Iterator, Sequence
         return $this->articlesClient
             ->getArticleVersion(
                 [
-                    'Accept' => [
+                    'Accept' => implode(', ', [
                         new MediaType(ArticlesClient::TYPE_ARTICLE_POA, 2),
                         new MediaType(ArticlesClient::TYPE_ARTICLE_VOR, 2),
-                    ],
+                    ]),
                 ],
                 $id,
                 $version

--- a/src/Serializer/ArticleVersionNormalizer.php
+++ b/src/Serializer/ArticleVersionNormalizer.php
@@ -49,10 +49,10 @@ abstract class ArticleVersionNormalizer implements NormalizerInterface, Denormal
 
                 return $articlesClient->getArticleVersion(
                     [
-                        'Accept' => [
+                        'Accept' => implode(', ', [
                             new MediaType(ArticlesClient::TYPE_ARTICLE_POA, 2),
                             new MediaType(ArticlesClient::TYPE_ARTICLE_VOR, 2),
-                        ],
+                        ]),
                     ],
                     $id,
                     $version

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -252,10 +252,10 @@ abstract class ApiTestCase extends TestCase
                 'GET',
                 'http://api.elifesciences.org/articles/'.$id.($version ? '/versions/'.$version : ''),
                 [
-                    'Accept' => [
+                    'Accept' => implode(', ', [
                         new MediaType(ArticlesClient::TYPE_ARTICLE_POA, 2),
                         new MediaType(ArticlesClient::TYPE_ARTICLE_VOR, 2),
-                    ],
+                    ]),
                 ]
             ),
             $response


### PR DESCRIPTION
Article requests have multiple `Accept` values due to PoAs and VoRs. These were being sent as multiple `Accept` headers:

```
Accept: application/vnd.elife.article-poa+json; version=2
Accept: application/vnd.elife.article-vor+json; version=2
```

rather a single one:

```
Accept: application/vnd.elife.article-poa+json; version=2, application/vnd.elife.article-vor+json; version=2
```

This is valid HTTP, but its only down that servers "MAY combine multiple header fields with the same field name into one 'field-name: field-value' pair, [...] separated by a comma"

It seems like the real article API (ie Lax) understands multiple `Accept` headers, but PHP (in `$_SERVER`) doesn't. https://github.com/elifesciences/api-dummy/pull/114 changed the API Dummy so that it wouldn't just return the real item at the latest version if the type couldn't be negotiated, so for VoRs it only sees the PoA `Accept` value (as it happens to come first) and fails (so pointing a Journal at the API Dummy and viewing a VoR page fails).