### PR TITLE
ELPP-3304 Limited access on profiles API data

### DIFF
--- a/src/ApiSdk.php
+++ b/src/ApiSdk.php
@@ -44,6 +44,7 @@ use eLife\ApiSdk\Client\Profiles;
 use eLife\ApiSdk\Client\Recommendations;
 use eLife\ApiSdk\Client\Search;
 use eLife\ApiSdk\Client\Subjects;
+use eLife\ApiSdk\Serializer\AccessControlNormalizer;
 use eLife\ApiSdk\Serializer\AddressNormalizer;
 use eLife\ApiSdk\Serializer\AnnualReportNormalizer;
 use eLife\ApiSdk\Serializer\AppendixNormalizer;
@@ -165,6 +166,7 @@ final class ApiSdk
         $this->subjectsClient = new SubjectsClient($this->httpClient);
 
         $this->serializer = new NormalizerAwareSerializer([
+            new AccessControlNormalizer(),
             new AddressNormalizer(),
             new AnnualReportNormalizer(),
             new AppendixNormalizer(),

--- a/src/Model/AccessControl.php
+++ b/src/Model/AccessControl.php
@@ -13,7 +13,7 @@ final class AccessControl implements Model
      */
     public function __construct(
         $value,
-        string $access
+        string $access = 'public'
     ) {
         $this->value = $value;
         $this->access = $access;

--- a/src/Model/AccessControl.php
+++ b/src/Model/AccessControl.php
@@ -4,6 +4,9 @@ namespace eLife\ApiSdk\Model;
 
 final class AccessControl implements Model
 {
+    const ACCESS_PUBLIC = 'public';
+    const ACCESS_RESTRICTED = 'restricted';
+
     private $value;
     private $access;
 
@@ -14,7 +17,7 @@ final class AccessControl implements Model
      */
     public function __construct(
         $value,
-        string $access = 'public'
+        string $access = self::ACCESS_PUBLIC
     ) {
         $this->value = $value;
         $this->access = $access;

--- a/src/Model/AccessControl.php
+++ b/src/Model/AccessControl.php
@@ -9,6 +9,7 @@ final class AccessControl implements Model
 
     /**
      * @internal
+     *
      * @param mixed $value
      */
     public function __construct(

--- a/src/Model/AccessControl.php
+++ b/src/Model/AccessControl.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace eLife\ApiSdk\Model;
+
+final class AccessControl implements Model
+{
+    private $value;
+    private $access;
+
+    /**
+     * @internal
+     * @param mixed $value
+     */
+    public function __construct(
+        $value,
+        string $access
+    ) {
+        $this->value = $value;
+        $this->access = $access;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function getAccess() : string
+    {
+        return $this->access;
+    }
+}

--- a/src/Model/AccessControl.php
+++ b/src/Model/AccessControl.php
@@ -2,7 +2,7 @@
 
 namespace eLife\ApiSdk\Model;
 
-final class AccessControl implements Model
+final class AccessControl
 {
     const ACCESS_PUBLIC = 'public';
     const ACCESS_RESTRICTED = 'restricted';

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -42,7 +42,7 @@ final class Profile implements Model, HasId, HasIdentifier
     }
 
     /**
-     * @return Sequence|AccessControl[]|Place
+     * @return Sequence|AccessControl[]
      */
     public function getAffiliations() : Sequence
     {
@@ -50,7 +50,7 @@ final class Profile implements Model, HasId, HasIdentifier
     }
 
     /**
-     * @return Sequence|AccessControl[]|string
+     * @return Sequence|AccessControl[]
      */
     public function getEmailAddresses() : Sequence
     {

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -42,7 +42,7 @@ final class Profile implements Model, HasId, HasIdentifier
     }
 
     /**
-     * @return Sequence|Place[]
+     * @return Sequence|AccessControl[]|Place
      */
     public function getAffiliations() : Sequence
     {
@@ -50,7 +50,7 @@ final class Profile implements Model, HasId, HasIdentifier
     }
 
     /**
-     * @return Sequence|string[]
+     * @return Sequence|AccessControl[]|string
      */
     public function getEmailAddresses() : Sequence
     {

--- a/src/Serializer/AccessControlNormalizer.php
+++ b/src/Serializer/AccessControlNormalizer.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace eLife\ApiSdk\Serializer;
+
+use eLife\ApiSdk\Model\Address;
+use eLife\ApiSdk\Model\AccessControl;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class AccessControlNormalizer implements NormalizerInterface, DenormalizerInterface
+{
+    public function denormalize($data, $class, $format = null, array $context = []) : AccessControl
+    {
+        return new AccessControl(
+            $data['value'],
+            $data['access']
+        );
+    }
+
+    public function supportsDenormalization($data, $type, $format = null) : bool
+    {
+        return AccessControl::class === $type;
+    }
+
+    /**
+     * @param AccessControl $object
+     */
+    public function normalize($object, $format = null, array $context = []) : array
+    {
+        return [
+            'value' => $object->getValue(),
+            'access' => $object->getAccess(),
+        ];
+    }
+
+    public function supportsNormalization($data, $format = null) : bool
+    {
+        return $data instanceof AccessControl;
+    }
+}

--- a/src/Serializer/AccessControlNormalizer.php
+++ b/src/Serializer/AccessControlNormalizer.php
@@ -35,14 +35,8 @@ final class AccessControlNormalizer implements NormalizerInterface, Denormalizer
      */
     public function normalize($object, $format = null, array $context = []) : array
     {
-        $value = $object->getValue();
-        if ($context['class'] ?? false) {
-            unset($context['class']);
-            $value = $this->normalizer->normalize($value, $format, $context);
-        }
-
         return [
-            'value' => $value,
+            'value' => $this->normalizer->normalize($object->getValue(), $format, $context),
             'access' => $object->getAccess(),
         ];
     }

--- a/src/Serializer/AccessControlNormalizer.php
+++ b/src/Serializer/AccessControlNormalizer.php
@@ -2,7 +2,6 @@
 
 namespace eLife\ApiSdk\Serializer;
 
-use eLife\ApiSdk\Model\Address;
 use eLife\ApiSdk\Model\AccessControl;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -19,6 +18,7 @@ final class AccessControlNormalizer implements NormalizerInterface, Denormalizer
             unset($context['class']);
             $data['value'] = $this->denormalizer->denormalize($data['value'], $class, $format, $context);
         }
+
         return new AccessControl(
             $data['value'],
             $data['access']
@@ -40,6 +40,7 @@ final class AccessControlNormalizer implements NormalizerInterface, Denormalizer
             unset($context['class']);
             $value = $this->normalizer->normalize($value, $format, $context);
         }
+
         return [
             'value' => $value,
             'access' => $object->getAccess(),

--- a/src/Serializer/AccessControlNormalizer.php
+++ b/src/Serializer/AccessControlNormalizer.php
@@ -7,10 +7,18 @@ use eLife\ApiSdk\Model\AccessControl;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
-final class AccessControlNormalizer implements NormalizerInterface, DenormalizerInterface
+final class AccessControlNormalizer implements NormalizerInterface, DenormalizerInterface, NormalizerAwareInterface, DenormalizerAwareInterface
 {
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+
     public function denormalize($data, $class, $format = null, array $context = []) : AccessControl
     {
+        if ($context['class'] ?? false) {
+            $class = $context['class'];
+            unset($context['class']);
+            $data['value'] = $this->denormalizer->denormalize($data['value'], $class, $format, $context);
+        }
         return new AccessControl(
             $data['value'],
             $data['access']
@@ -27,8 +35,13 @@ final class AccessControlNormalizer implements NormalizerInterface, Denormalizer
      */
     public function normalize($object, $format = null, array $context = []) : array
     {
+        $value = $object->getValue();
+        if ($context['class'] ?? false) {
+            unset($context['class']);
+            $value = $this->normalizer->normalize($value, $format, $context);
+        }
         return [
-            'value' => $object->getValue(),
+            'value' => $value,
             'access' => $object->getAccess(),
         ];
     }

--- a/src/Serializer/ProfileNormalizer.php
+++ b/src/Serializer/ProfileNormalizer.php
@@ -65,7 +65,7 @@ final class ProfileNormalizer implements NormalizerInterface, DenormalizerInterf
             return $this->denormalizer->denormalize($maybeAccessControl, AccessControl::class, $format, $context + ['class' => Place::class]);
         });
 
-        $data['emailAddresses'] = $data['emailAddresses']->map(function(/*array*/ $maybeAccessControl) use ($format, $context) {
+        $data['emailAddresses'] = $data['emailAddresses']->map(function (/*array*/ $maybeAccessControl) use ($format, $context) {
             unset($context['snippet']);
 
             $maybeAccessControl = $this->wrapInAccessControl($maybeAccessControl);
@@ -102,7 +102,7 @@ final class ProfileNormalizer implements NormalizerInterface, DenormalizerInterf
                 })->toArray();
             }
             if ($object->getEmailAddresses()->notEmpty()) {
-                $data['emailAddresses'] = $object->getEmailAddresses()->map(function(AccessControl $accessControl) use ($format, $context) {
+                $data['emailAddresses'] = $object->getEmailAddresses()->map(function (AccessControl $accessControl) use ($format, $context) {
                     return $this->normalizer->normalize($accessControl, $format, $context);
                 })->toArray();
             }
@@ -118,7 +118,7 @@ final class ProfileNormalizer implements NormalizerInterface, DenormalizerInterf
 
     /**
      * Backward compatibility with emailAddresses
-     * and affiliations without access control
+     * and affiliations without access control.
      *
      * Remove after https://github.com/elifesciences/api-raml/pull/204 is merged
      */

--- a/src/Serializer/ProfileNormalizer.php
+++ b/src/Serializer/ProfileNormalizer.php
@@ -127,7 +127,7 @@ final class ProfileNormalizer implements NormalizerInterface, DenormalizerInterf
         if (empty($maybeAccessControl['access'])) {
             return [
                 'value' => $maybeAccessControl,
-                'access' => 'public',
+                'access' => AccessControl::ACCESS_PUBLIC,
             ];
         }
 

--- a/src/Serializer/ProfileNormalizer.php
+++ b/src/Serializer/ProfileNormalizer.php
@@ -119,6 +119,8 @@ final class ProfileNormalizer implements NormalizerInterface, DenormalizerInterf
     /**
      * Backward compatibility with emailAddresses
      * and affiliations without access control
+     *
+     * Remove after https://github.com/elifesciences/api-raml/pull/204 is merged
      */
     private function wrapInAccessControl($maybeAccessControl)
     {

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -2015,11 +2015,21 @@ abstract class ApiTestCase extends TestCase
             'orcid' => '0000-0002-1825-0097',
             'affiliations' => [
                 [
-                    'name' => ['affiliation'],
+                    'value' => [
+                        'name' => ['affiliation'],
+                    ],
+                    'access' => 'public',
                 ],
             ],
             'emailAddresses' => [
-                'foo@example.com',
+                [
+                    'value' => 'foo@example.com',
+                    'access' => 'public',
+                ],
+                [
+                    'value' => 'secret@example.com',
+                    'access' => 'restricted',
+                ]
             ],
         ];
 

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -914,7 +914,7 @@ abstract class ApiTestCase extends TestCase
 
     /**
      * @param string|int $numberOrId
-     * @param bool $idOld  deprecated, remove after https://github.com/elifesciences/api-raml/pull/204 is merged
+     * @param bool       $idOld      deprecated, remove after https://github.com/elifesciences/api-raml/pull/204 is merged
      */
     final protected function mockProfileCall($numberOrId, bool $complete = false, bool $isSnippet = false, bool $isOld = false)
     {
@@ -2016,7 +2016,7 @@ abstract class ApiTestCase extends TestCase
     }
 
     /**
-     * @param bool $idOld  deprecated, remove after https://github.com/elifesciences/api-raml/pull/204 is merged
+     * @param bool $idOld deprecated, remove after https://github.com/elifesciences/api-raml/pull/204 is merged
      */
     private function createProfileJson(string $id, bool $isSnippet = false, bool $complete = false, bool $isOld = false) : array
     {
@@ -2043,7 +2043,7 @@ abstract class ApiTestCase extends TestCase
                 [
                     'value' => 'secret@example.com',
                     'access' => 'restricted',
-                ]
+                ],
             ],
         ];
 

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -53,6 +53,12 @@ abstract class ApiTestCase extends TestCase
         $this->httpClient = null;
     }
 
+    final public function disableValidationOfResponses()
+    {
+        $this->storage = new InMemoryStorageAdapter();
+        $this->addMockMiddleware();
+    }
+
     final protected function getHttpClient() : HttpClient
     {
         if (null === $this->httpClient) {
@@ -63,17 +69,21 @@ abstract class ApiTestCase extends TestCase
             );
 
             $this->storage = new ValidatingStorageAdapter($storage, $validator);
-
-            $stack = HandlerStack::create();
-            $stack->push(new MockMiddleware($this->storage, 'replay'));
-
-            $this->httpClient = new Guzzle6HttpClient(new Client([
-                'base_uri' => 'http://api.elifesciences.org',
-                'handler' => $stack,
-            ]));
+            $this->addMockMiddleware();
         }
 
         return $this->httpClient;
+    }
+
+    private function addMockMiddleware()
+    {
+        $stack = HandlerStack::create();
+        $stack->push(new MockMiddleware($this->storage, 'replay'));
+
+        $this->httpClient = new Guzzle6HttpClient(new Client([
+            'base_uri' => 'http://api.elifesciences.org',
+            'handler' => $stack,
+        ]));
     }
 
     final protected function mockNotFound(string $uri, array $headers)
@@ -904,8 +914,9 @@ abstract class ApiTestCase extends TestCase
 
     /**
      * @param string|int $numberOrId
+     * @param bool $idOld  deprecated, remove after https://github.com/elifesciences/api-raml/pull/204 is merged
      */
-    final protected function mockProfileCall($numberOrId, bool $complete = false, bool $isSnippet = false)
+    final protected function mockProfileCall($numberOrId, bool $complete = false, bool $isSnippet = false, bool $isOld = false)
     {
         if (is_integer($numberOrId)) {
             $id = "profile{$numberOrId}";
@@ -921,7 +932,7 @@ abstract class ApiTestCase extends TestCase
             new Response(
                 200,
                 ['Content-Type' => new MediaType(ProfilesClient::TYPE_PROFILE, 1)],
-                json_encode($this->createProfileJson($id, $isSnippet, $complete))
+                json_encode($this->createProfileJson($id, $isSnippet, $complete, $isOld))
             )
         );
     }
@@ -2004,7 +2015,10 @@ abstract class ApiTestCase extends TestCase
         return $package;
     }
 
-    private function createProfileJson(string $id, bool $isSnippet = false, bool $complete = false) : array
+    /**
+     * @param bool $idOld  deprecated, remove after https://github.com/elifesciences/api-raml/pull/204 is merged
+     */
+    private function createProfileJson(string $id, bool $isSnippet = false, bool $complete = false, bool $isOld = false) : array
     {
         $profile = [
             'id' => $id,
@@ -2032,6 +2046,18 @@ abstract class ApiTestCase extends TestCase
                 ]
             ],
         ];
+
+        if ($isOld) {
+            $profile['affiliations'] = [
+                [
+                    'name' => ['affiliation'],
+                ],
+            ];
+            $profile['emailAddresses'] = [
+                'foo@example.com',
+                'secret@example.com',
+            ];
+        }
 
         if (!$complete) {
             unset($profile['orcid']);

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -8,6 +8,7 @@ use DateTimeZone;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\EmptySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
+use eLife\ApiSdk\Model\AccessControl;
 use eLife\ApiSdk\Model\Address;
 use eLife\ApiSdk\Model\Appendix;
 use eLife\ApiSdk\Model\ArticlePoA;
@@ -59,6 +60,12 @@ final class Builder
     {
         if (self::$defaults === null) {
             self::$defaults = [
+                AccessControl::class => function () {
+                    return [
+                        'value' => 'sample',
+                        'access' => 'public',
+                    ];
+                },
                 Address::class => function () {
                     return [
                         'formatted' => new ArraySequence(['foo', 'bar']),

--- a/test/Builder.php
+++ b/test/Builder.php
@@ -63,7 +63,7 @@ final class Builder
                 AccessControl::class => function () {
                     return [
                         'value' => 'sample',
-                        'access' => 'public',
+                        'access' => AccessControl::ACCESS_PUBLIC,
                     ];
                 },
                 Address::class => function () {

--- a/test/Model/AccessControlTest.php
+++ b/test/Model/AccessControlTest.php
@@ -3,7 +3,6 @@
 namespace test\eLife\ApiSdk\Model;
 
 use eLife\ApiSdk\Model\AccessControl;
-use eLife\ApiSdk\Model\Model;
 use PHPUnit_Framework_TestCase;
 use test\eLife\ApiSdk\Builder;
 

--- a/test/Model/AccessControlTest.php
+++ b/test/Model/AccessControlTest.php
@@ -12,18 +12,6 @@ final class AccessControlTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_is_a_model()
-    {
-        $accessControl = Builder::for(AccessControl::class)
-            ->withValue('value1')
-            ->__invoke();
-
-        $this->assertInstanceOf(Model::class, $accessControl);
-    }
-
-    /**
-     * @test
-     */
     public function it_has_a_value()
     {
         $accessControl = Builder::for(AccessControl::class)

--- a/test/Model/AccessControlTest.php
+++ b/test/Model/AccessControlTest.php
@@ -27,9 +27,9 @@ final class AccessControlTest extends PHPUnit_Framework_TestCase
     public function it_has_an_access()
     {
         $accessControl = Builder::for(AccessControl::class)
-            ->withAccess('public')
+            ->withAccess(AccessControl::ACCESS_PUBLIC)
             ->__invoke();
 
-        $this->assertSame('public', $accessControl->getAccess());
+        $this->assertSame(AccessControl::ACCESS_PUBLIC, $accessControl->getAccess());
     }
 }

--- a/test/Model/AccessControlTest.php
+++ b/test/Model/AccessControlTest.php
@@ -5,7 +5,6 @@ namespace test\eLife\ApiSdk\Model;
 use eLife\ApiSdk\Model\AccessControl;
 use eLife\ApiSdk\Model\Model;
 use PHPUnit_Framework_TestCase;
-use stdClass;
 use test\eLife\ApiSdk\Builder;
 
 final class AccessControlTest extends PHPUnit_Framework_TestCase

--- a/test/Model/AccessControlTest.php
+++ b/test/Model/AccessControlTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace test\eLife\ApiSdk\Model;
+
+use eLife\ApiSdk\Model\AccessControl;
+use eLife\ApiSdk\Model\Model;
+use PHPUnit_Framework_TestCase;
+use stdClass;
+use test\eLife\ApiSdk\Builder;
+
+final class AccessControlTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_is_a_model()
+    {
+        $accessControl = Builder::for(AccessControl::class)
+            ->withValue('value1')
+            ->__invoke();
+
+        $this->assertInstanceOf(Model::class, $accessControl);
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_value()
+    {
+        $accessControl = Builder::for(AccessControl::class)
+            ->withValue('value1')
+            ->__invoke();
+
+        $this->assertSame('value1', $accessControl->getValue());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_an_access()
+    {
+        $accessControl = Builder::for(AccessControl::class)
+            ->withValue('value1')
+            ->withAccess('public')
+            ->__invoke();
+
+        $this->assertSame('public', $accessControl->getAccess());
+    }
+}

--- a/test/Model/AccessControlTest.php
+++ b/test/Model/AccessControlTest.php
@@ -27,7 +27,6 @@ final class AccessControlTest extends PHPUnit_Framework_TestCase
     public function it_has_an_access()
     {
         $accessControl = Builder::for(AccessControl::class)
-            ->withValue('value1')
             ->withAccess('public')
             ->__invoke();
 

--- a/test/Model/ProfileTest.php
+++ b/test/Model/ProfileTest.php
@@ -89,7 +89,7 @@ final class ProfileTest extends PHPUnit_Framework_TestCase
     {
         $with = Builder::for(Profile::class)
             ->withEmailAddresses($emailAddresses = new ArraySequence([
-                new AccessControl('foo@example.com')
+                new AccessControl('foo@example.com'),
             ]))
             ->__invoke();
 

--- a/test/Model/ProfileTest.php
+++ b/test/Model/ProfileTest.php
@@ -3,6 +3,7 @@
 namespace test\eLife\ApiSdk\Model;
 
 use eLife\ApiSdk\Collection\ArraySequence;
+use eLife\ApiSdk\Model\AccessControl;
 use eLife\ApiSdk\Model\HasId;
 use eLife\ApiSdk\Model\HasIdentifier;
 use eLife\ApiSdk\Model\Identifier;
@@ -87,7 +88,9 @@ final class ProfileTest extends PHPUnit_Framework_TestCase
     public function it_may_have_email_addresses()
     {
         $with = Builder::for(Profile::class)
-            ->withEmailAddresses($emailAddresses = new ArraySequence(['foo@example.com']))
+            ->withEmailAddresses($emailAddresses = new ArraySequence([
+                new AccessControl('foo@example.com')
+            ]))
             ->__invoke();
 
         $withOut = Builder::for(Profile::class)

--- a/test/Serializer/AccessControlNormalizerTest.php
+++ b/test/Serializer/AccessControlNormalizerTest.php
@@ -105,7 +105,7 @@ final class AccessControlNormalizerTest extends TestCase
     {
         return [
             'restricted place' => [
-                new AccessControl(new Place(['place']), 'restricted'),
+                new AccessControl(new Place(['place']), AccessControl::ACCESS_RESTRICTED),
                 [
                     'value' => [
                         'name' => ['place'],
@@ -115,7 +115,7 @@ final class AccessControlNormalizerTest extends TestCase
                 ['class' => Place::class],
             ],
             'public string' => [
-                $accessControl = new AccessControl('sample'),
+                $accessControl = new AccessControl('sample', AccessControl::ACCESS_PUBLIC),
                 [
                     'value' => 'sample',
                     'access' => 'public',

--- a/test/Serializer/AccessControlNormalizerTest.php
+++ b/test/Serializer/AccessControlNormalizerTest.php
@@ -2,10 +2,8 @@
 
 namespace test\eLife\ApiSdk\Serializer;
 
-use eLife\ApiSdk\Model\Address;
 use eLife\ApiSdk\Model\AccessControl;
-use eLife\ApiSdk\Serializer\AddressNormalizer;
-use eLife\ApiSdk\Serializer\NormalizerAwareSerializer;
+use eLife\ApiSdk\Model\Address;
 use eLife\ApiSdk\Serializer\AccessControlNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;

--- a/test/Serializer/AccessControlNormalizerTest.php
+++ b/test/Serializer/AccessControlNormalizerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace test\eLife\ApiSdk\Serializer;
+
+use eLife\ApiSdk\Model\Address;
+use eLife\ApiSdk\Model\AccessControl;
+use eLife\ApiSdk\Serializer\AddressNormalizer;
+use eLife\ApiSdk\Serializer\NormalizerAwareSerializer;
+use eLife\ApiSdk\Serializer\AccessControlNormalizer;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use test\eLife\ApiSdk\Builder;
+use test\eLife\ApiSdk\TestCase;
+
+final class AccessControlNormalizerTest extends TestCase
+{
+    /** @var AccessControlNormalizer */
+    private $normalizer;
+
+    /**
+     * @before
+     */
+    protected function setUpNormalizer()
+    {
+        $this->normalizer = new AccessControlNormalizer();
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_a_normalizer()
+    {
+        $this->assertInstanceOf(NormalizerInterface::class, $this->normalizer);
+    }
+
+    /**
+     * @test
+     * @dataProvider canNormalizeProvider
+     */
+    public function it_can_normalize_access_controls($data, $format, bool $expected)
+    {
+        $this->assertSame($expected, $this->normalizer->supportsNormalization($data, $format));
+    }
+
+    public function canNormalizeProvider() : array
+    {
+        $accessControl = new AccessControl('sample');
+
+        return [
+            'access control' => [$accessControl, null, true],
+            'not an access control' => [$this, null, false],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider normalizeProvider
+     */
+    public function it_normalize_access_controls(AccessControl $accessControl, array $expected)
+    {
+        $this->assertSame($expected, $this->normalizer->normalize($accessControl));
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_a_denormalizer()
+    {
+        $this->assertInstanceOf(DenormalizerInterface::class, $this->normalizer);
+    }
+
+    /**
+     * @test
+     * @dataProvider canDenormalizeProvider
+     */
+    public function it_can_denormalize_access_controls($data, $format, array $context, bool $expected)
+    {
+        $this->assertSame($expected, $this->normalizer->supportsDenormalization($data, $format, $context));
+    }
+
+    public function canDenormalizeProvider() : array
+    {
+        return [
+            'access control' => [[], AccessControl::class, [], true],
+            'not an access control' => [[], get_class($this), [], false],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider normalizeProvider
+     */
+    public function it_denormalize_access_controls(AccessControl $expected, array $json)
+    {
+        $actual = $this->normalizer->denormalize($json, AccessControl::class);
+
+        $this->assertObjectsAreEqual($expected, $actual);
+    }
+
+    public function normalizeProvider() : array
+    {
+        $address = Builder::for(Address::class)->sample('simple');
+
+        return [
+            'complete' => [
+                new AccessControl('sample', 'restricted'),
+                [
+                    'value' => 'sample',
+                    'access' => 'restricted',
+                ],
+            ],
+            'minimum' => [
+                $accessControl = new AccessControl('sample'),
+                [
+                    'value' => 'sample',
+                    'access' => 'public',
+                ],
+            ],
+        ];
+    }
+}

--- a/test/Serializer/ProfileNormalizerTest.php
+++ b/test/Serializer/ProfileNormalizerTest.php
@@ -116,7 +116,8 @@ final class ProfileNormalizerTest extends ApiTestCase
     }
 
     /**
-     * Remove after https://github.com/elifesciences/api-raml/pull/204 is merged
+     * Remove after https://github.com/elifesciences/api-raml/pull/204 is merged.
+     *
      * @test
      * @dataProvider normalizeProviderBackwardCompatibility
      */
@@ -138,7 +139,7 @@ final class ProfileNormalizerTest extends ApiTestCase
                     new PersonDetails('Profile 1 preferred', 'Profile 1 index', '0000-0002-1825-0097'),
                     new ArraySequence([
                         new AccessControl(new Place(['affiliation'])),
-                    ]), 
+                    ]),
                     new ArraySequence([
                         new AccessControl('foo@example.com', 'public'),
                         new AccessControl('secret@example.com', 'restricted'),
@@ -185,7 +186,7 @@ final class ProfileNormalizerTest extends ApiTestCase
             ],
             'complete snippet' => [
                 new Profile(
-                    'profile1', 
+                    'profile1',
                     new PersonDetails('Profile 1 preferred', 'Profile 1 index', '0000-0002-1825-0097'),
                     new ArraySequence([
                         new AccessControl(new Place(['affiliation'])),
@@ -234,7 +235,7 @@ final class ProfileNormalizerTest extends ApiTestCase
                     new PersonDetails('Profile 1 preferred', 'Profile 1 index', '0000-0002-1825-0097'),
                     new ArraySequence([
                         new AccessControl(new Place(['affiliation'])),
-                    ]), 
+                    ]),
                     new ArraySequence([
                         new AccessControl('foo@example.com'),
                         new AccessControl('secret@example.com'),
@@ -261,7 +262,7 @@ final class ProfileNormalizerTest extends ApiTestCase
             ],
             'complete snippet' => [
                 new Profile(
-                    'profile1', 
+                    'profile1',
                     new PersonDetails('Profile 1 preferred', 'Profile 1 index', '0000-0002-1825-0097'),
                     new ArraySequence([
                         new AccessControl(new Place(['affiliation'])),

--- a/test/Serializer/ProfileNormalizerTest.php
+++ b/test/Serializer/ProfileNormalizerTest.php
@@ -6,6 +6,7 @@ use eLife\ApiClient\ApiClient\ProfilesClient;
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\EmptySequence;
+use eLife\ApiSdk\Model\AccessControl;
 use eLife\ApiSdk\Model\PersonDetails;
 use eLife\ApiSdk\Model\Place;
 use eLife\ApiSdk\Model\Profile;
@@ -118,8 +119,17 @@ final class ProfileNormalizerTest extends ApiTestCase
     {
         return [
             'complete' => [
-                new Profile('profile1', new PersonDetails('Profile 1 preferred', 'Profile 1 index', '0000-0002-1825-0097'),
-                    new ArraySequence([new Place(['affiliation'])]), new ArraySequence(['foo@example.com'])),
+                new Profile(
+                    'profile1',
+                    new PersonDetails('Profile 1 preferred', 'Profile 1 index', '0000-0002-1825-0097'),
+                    new ArraySequence([
+                        new AccessControl(new Place(['affiliation'])),
+                    ]), 
+                    new ArraySequence([
+                        new AccessControl('foo@example.com', 'public'),
+                        new AccessControl('secret@example.com', 'restricted'),
+                    ])
+                ),
                 [],
                 [
                     'name' => [
@@ -130,11 +140,21 @@ final class ProfileNormalizerTest extends ApiTestCase
                     'id' => 'profile1',
                     'affiliations' => [
                         [
-                            'name' => ['affiliation'],
+                            'value' => [
+                                'name' => ['affiliation'],
+                            ],
+                            'access' => 'public',
                         ],
                     ],
                     'emailAddresses' => [
-                        'foo@example.com',
+                        [
+                            'value' => 'foo@example.com',
+                            'access' => 'public',
+                        ],
+                        [
+                            'value' => 'secret@example.com',
+                            'access' => 'restricted',
+                        ],
                     ],
                 ],
             ],
@@ -150,8 +170,17 @@ final class ProfileNormalizerTest extends ApiTestCase
                 ],
             ],
             'complete snippet' => [
-                new Profile('profile1', new PersonDetails('Profile 1 preferred', 'Profile 1 index', '0000-0002-1825-0097'),
-                    new ArraySequence([new Place(['affiliation'])]), new ArraySequence(['foo@example.com'])),
+                new Profile(
+                    'profile1', 
+                    new PersonDetails('Profile 1 preferred', 'Profile 1 index', '0000-0002-1825-0097'),
+                    new ArraySequence([
+                        new AccessControl(new Place(['affiliation'])),
+                    ]),
+                    new ArraySequence([
+                        new AccessControl('foo@example.com'),
+                        new AccessControl('secret@example.com', 'restricted'),
+                    ])
+                ),
                 ['snippet' => true],
                 [
                     'name' => [

--- a/test/Serializer/ProfileNormalizerTest.php
+++ b/test/Serializer/ProfileNormalizerTest.php
@@ -116,6 +116,7 @@ final class ProfileNormalizerTest extends ApiTestCase
     }
 
     /**
+     * Remove after https://github.com/elifesciences/api-raml/pull/204 is merged
      * @test
      * @dataProvider normalizeProviderBackwardCompatibility
      */
@@ -224,7 +225,7 @@ final class ProfileNormalizerTest extends ApiTestCase
         ];
     }
 
-    public function normalizeProviderBackwardCompatibility() : array
+    public static function normalizeProviderBackwardCompatibility() : array
     {
         return [
             'complete' => [
@@ -258,31 +259,34 @@ final class ProfileNormalizerTest extends ApiTestCase
                     ],
                 ],
             ],
-            //'complete snippet' => [
-            //    new Profile(
-            //        'profile1', 
-            //        new PersonDetails('Profile 1 preferred', 'Profile 1 index', '0000-0002-1825-0097'),
-            //        new ArraySequence([
-            //            new AccessControl(new Place(['affiliation'])),
-            //        ]),
-            //        new ArraySequence([
-            //            new AccessControl('foo@example.com'),
-            //            new AccessControl('secret@example.com', 'restricted'),
-            //        ])
-            //    ),
-            //    ['snippet' => true],
-            //    [
-            //        'name' => [
-            //            'preferred' => 'Profile 1 preferred',
-            //            'index' => 'Profile 1 index',
-            //        ],
-            //        'orcid' => '0000-0002-1825-0097',
-            //        'id' => 'profile1',
-            //    ],
-            //    function (ApiTestCase $test) {
-            //        $test->mockProfileCall(1, true);
-            //    },
-            //],
+            'complete snippet' => [
+                new Profile(
+                    'profile1', 
+                    new PersonDetails('Profile 1 preferred', 'Profile 1 index', '0000-0002-1825-0097'),
+                    new ArraySequence([
+                        new AccessControl(new Place(['affiliation'])),
+                    ]),
+                    new ArraySequence([
+                        new AccessControl('foo@example.com', 'public'),
+                        // note if it was in the old response, we have to assume it's public
+                        new AccessControl('secret@example.com', 'public'),
+                    ])
+                ),
+                ['snippet' => true],
+                [
+                    'name' => [
+                        'preferred' => 'Profile 1 preferred',
+                        'index' => 'Profile 1 index',
+                    ],
+                    'orcid' => '0000-0002-1825-0097',
+                    'id' => 'profile1',
+                ],
+                function (ApiTestCase $test) {
+                    $test->disableValidationOfResponses();
+                    $test->setUpNormalizer();
+                    $test->mockProfileCall(1, $complete = true, $isSnippet = false, $isOld = true);
+                },
+            ],
         ];
     }
 }

--- a/test/Serializer/ProfileNormalizerTest.php
+++ b/test/Serializer/ProfileNormalizerTest.php
@@ -141,8 +141,8 @@ final class ProfileNormalizerTest extends ApiTestCase
                         new AccessControl(new Place(['affiliation'])),
                     ]),
                     new ArraySequence([
-                        new AccessControl('foo@example.com', 'public'),
-                        new AccessControl('secret@example.com', 'restricted'),
+                        new AccessControl('foo@example.com', AccessControl::ACCESS_PUBLIC),
+                        new AccessControl('secret@example.com', AccessControl::ACCESS_RESTRICTED),
                     ])
                 ),
                 [],
@@ -268,9 +268,9 @@ final class ProfileNormalizerTest extends ApiTestCase
                         new AccessControl(new Place(['affiliation'])),
                     ]),
                     new ArraySequence([
-                        new AccessControl('foo@example.com', 'public'),
+                        new AccessControl('foo@example.com', AccessControl::ACCESS_PUBLIC),
                         // note if it was in the old response, we have to assume it's public
-                        new AccessControl('secret@example.com', 'public'),
+                        new AccessControl('secret@example.com', AccessControl::ACCESS_PUBLIC),
                     ])
                 ),
                 ['snippet' => true],

--- a/test/Serializer/ProfileNormalizerTest.php
+++ b/test/Serializer/ProfileNormalizerTest.php
@@ -115,6 +115,19 @@ final class ProfileNormalizerTest extends ApiTestCase
         $this->assertObjectsAreEqual($expected, $actual);
     }
 
+    /**
+     * @test
+     * @dataProvider normalizeProviderBackwardCompatibility
+     */
+    public function it_denormalize_profiles_from_api_responses_without_access_control(
+        Profile $expected,
+        array $context,
+        array $json,
+        callable $extra = null
+    ) {
+        $this->it_denormalize_profiles($expected, $context, $json, $extra);
+    }
+
     public function normalizeProvider() : array
     {
         return [
@@ -208,6 +221,68 @@ final class ProfileNormalizerTest extends ApiTestCase
                     $test->mockProfileCall(1);
                 },
             ],
+        ];
+    }
+
+    public function normalizeProviderBackwardCompatibility() : array
+    {
+        return [
+            'complete' => [
+                new Profile(
+                    'profile1',
+                    new PersonDetails('Profile 1 preferred', 'Profile 1 index', '0000-0002-1825-0097'),
+                    new ArraySequence([
+                        new AccessControl(new Place(['affiliation'])),
+                    ]), 
+                    new ArraySequence([
+                        new AccessControl('foo@example.com'),
+                        new AccessControl('secret@example.com'),
+                    ])
+                ),
+                [],
+                [
+                    'name' => [
+                        'preferred' => 'Profile 1 preferred',
+                        'index' => 'Profile 1 index',
+                    ],
+                    'orcid' => '0000-0002-1825-0097',
+                    'id' => 'profile1',
+                    'affiliations' => [
+                        [
+                            'name' => ['affiliation'],
+                        ],
+                    ],
+                    'emailAddresses' => [
+                        'foo@example.com',
+                        'secret@example.com',
+                    ],
+                ],
+            ],
+            //'complete snippet' => [
+            //    new Profile(
+            //        'profile1', 
+            //        new PersonDetails('Profile 1 preferred', 'Profile 1 index', '0000-0002-1825-0097'),
+            //        new ArraySequence([
+            //            new AccessControl(new Place(['affiliation'])),
+            //        ]),
+            //        new ArraySequence([
+            //            new AccessControl('foo@example.com'),
+            //            new AccessControl('secret@example.com', 'restricted'),
+            //        ])
+            //    ),
+            //    ['snippet' => true],
+            //    [
+            //        'name' => [
+            //            'preferred' => 'Profile 1 preferred',
+            //            'index' => 'Profile 1 index',
+            //        ],
+            //        'orcid' => '0000-0002-1825-0097',
+            //        'id' => 'profile1',
+            //    ],
+            //    function (ApiTestCase $test) {
+            //        $test->mockProfileCall(1, true);
+            //    },
+            //],
         ];
     }
 }


### PR DESCRIPTION
An `AccessControl` class is introduced (better name?) to wrap arbitrary objects that need access control. Its `Normalizer` accepts a `class` context key determining whether to denormalize into an object what is wrapped.

`emailAddresses` and `affiliations` are affected, the latter using the `class` context key.

Backward compatibility is provided for current responses, that are wrapped into a public `AccessControl` (which fits with the public data they represented so far).

Needs https://github.com/elifesciences/api-raml/pull/204 to build, but even switching the composer branch would fail because of the lack of `dist/` recompilation. So I just do:
```
cd vendor/elife/api
git fetch
git checkout composer/profile-access-level
npm install
node compile.js
```