### PR TITLE
Rename annotation parents to ancestors

### DIFF
--- a/src/Model/Annotation.php
+++ b/src/Model/Annotation.php
@@ -9,7 +9,7 @@ final class Annotation implements Model, HasContent, HasId, HasIdentifier, HasCr
 {
     private $id;
     private $access;
-    private $parents;
+    private $ancestors;
     private $document;
     private $highlight;
     private $created;
@@ -23,7 +23,7 @@ final class Annotation implements Model, HasContent, HasId, HasIdentifier, HasCr
         string $id,
         string $access,
         AnnotationDocument $document,
-        Sequence $parents,
+        Sequence $ancestors,
         string $highlight = null,
         DateTimeImmutable $created,
         DateTimeImmutable $updated = null,
@@ -32,7 +32,7 @@ final class Annotation implements Model, HasContent, HasId, HasIdentifier, HasCr
         $this->id = $id;
         $this->access = $access;
         $this->document = $document;
-        $this->parents = $parents;
+        $this->ancestors = $ancestors;
         $this->highlight = $highlight;
         $this->created = $created;
         $this->updated = $updated;
@@ -57,9 +57,9 @@ final class Annotation implements Model, HasContent, HasId, HasIdentifier, HasCr
     /**
      * @return Sequence|string[]
      */
-    public function getParents() : Sequence
+    public function getAncestors() : Sequence
     {
-        return $this->parents;
+        return $this->ancestors;
     }
 
     public function getDocument() : AnnotationDocument

--- a/src/Serializer/AnnotationNormalizer.php
+++ b/src/Serializer/AnnotationNormalizer.php
@@ -30,7 +30,7 @@ final class AnnotationNormalizer implements NormalizerInterface, DenormalizerInt
             $data['id'],
             $data['access'],
             $data['document'],
-            new ArraySequence($data['parents'] ?? []),
+            new ArraySequence($data['ancestors'] ?? []),
             $data['highlight'] ?? null,
             DateTimeImmutable::createFromFormat(DATE_ATOM, $data['created']),
             !empty($data['updated']) ? DateTimeImmutable::createFromFormat(DATE_ATOM, $data['updated']) : null,
@@ -63,8 +63,8 @@ final class AnnotationNormalizer implements NormalizerInterface, DenormalizerInt
             $data['updated'] = $object->getUpdatedDate()->format(ApiSdk::DATE_FORMAT);
         }
 
-        if ($object->getParents()->notEmpty()) {
-            $data['parents'] = $object->getParents()->toArray();
+        if ($object->getAncestors()->notEmpty()) {
+            $data['ancestors'] = $object->getAncestors()->toArray();
         }
 
         if ($object->getContent()->notEmpty()) {

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -1191,7 +1191,7 @@ abstract class ApiTestCase extends TestCase
         ];
 
         if ($complete) {
-            $annotation['parents'] = ['foo'];
+            $annotation['ancestors'] = ['foo'];
             $annotation['updated'] = '2000-01-01T00:00:00Z';
             $annotation['content'] = [
                 [

--- a/test/Model/AnnotationTest.php
+++ b/test/Model/AnnotationTest.php
@@ -101,9 +101,9 @@ final class AnnotationTest extends PHPUnit_Framework_TestCase
             new PromiseSequence(rejection_for('Annotation content should not be unwrapped'))
         );
 
-        $this->assertSame($ancestors, $with->getancestors()->toArray());
-        $this->assertTrue($withOut->getancestors()->isEmpty());
-        $this->assertEmpty($withOut->getancestors()->toArray());
+        $this->assertSame($ancestors, $with->getAncestors()->toArray());
+        $this->assertTrue($withOut->getAncestors()->isEmpty());
+        $this->assertEmpty($withOut->getAncestors()->toArray());
     }
 
     /**

--- a/test/Model/AnnotationTest.php
+++ b/test/Model/AnnotationTest.php
@@ -27,7 +27,7 @@ final class AnnotationTest extends PHPUnit_Framework_TestCase
      */
     public function it_is_a_model()
     {
-        $annotation = new Annotation('id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation parents should not be unwrapped')), 'Highlighted text', new DateTimeImmutable('now', new DateTimeZone('Z')), null,
+        $annotation = new Annotation('id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation ancestors should not be unwrapped')), 'Highlighted text', new DateTimeImmutable('now', new DateTimeZone('Z')), null,
             new PromiseSequence(rejection_for('Annotation content should not be unwrapped'))
         );
 
@@ -39,7 +39,7 @@ final class AnnotationTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_an_identifier()
     {
-        $annotation = new Annotation($id = 'id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation parents should not be unwrapped')), null, new DateTimeImmutable('now', new DateTimeZone('Z')), null,
+        $annotation = new Annotation($id = 'id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation ancestors should not be unwrapped')), null, new DateTimeImmutable('now', new DateTimeZone('Z')), null,
             new PromiseSequence(rejection_for('Annotation content should not be unwrapped'))
         );
 
@@ -52,7 +52,7 @@ final class AnnotationTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_an_id()
     {
-        $annotation = new Annotation($id = 'id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation parents should not be unwrapped')), null, new DateTimeImmutable('now', new DateTimeZone('Z')), null,
+        $annotation = new Annotation($id = 'id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation ancestors should not be unwrapped')), null, new DateTimeImmutable('now', new DateTimeZone('Z')), null,
             new PromiseSequence(rejection_for('Annotation content should not be unwrapped'))
         );
 
@@ -65,7 +65,7 @@ final class AnnotationTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_an_access_level()
     {
-        $annotation = new Annotation('id', $access = 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation parents should not be unwrapped')), null, new DateTimeImmutable('now', new DateTimeZone('Z')), null,
+        $annotation = new Annotation('id', $access = 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation ancestors should not be unwrapped')), null, new DateTimeImmutable('now', new DateTimeZone('Z')), null,
             new PromiseSequence(rejection_for('Annotation content should not be unwrapped'))
         );
 
@@ -77,7 +77,7 @@ final class AnnotationTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_a_document()
     {
-        $annotation = new Annotation('id', 'public', $document = new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation parents should not be unwrapped')), null, new DateTimeImmutable('now', new DateTimeZone('Z')), null,
+        $annotation = new Annotation('id', 'public', $document = new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation ancestors should not be unwrapped')), null, new DateTimeImmutable('now', new DateTimeZone('Z')), null,
             new PromiseSequence(rejection_for('Annotation content should not be unwrapped'))
         );
 
@@ -87,23 +87,23 @@ final class AnnotationTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_may_have_parents()
+    public function it_may_have_ancestors()
     {
-        $parents = [
+        $ancestors = [
             'id2',
             'id3',
         ];
 
-        $with = new Annotation('id1', 'public', new AnnotationDocument('title', 'http://example.com'), new ArraySequence($parents), null, new DateTimeImmutable('now', new DateTimeZone('Z')), null,
+        $with = new Annotation('id1', 'public', new AnnotationDocument('title', 'http://example.com'), new ArraySequence($ancestors), null, new DateTimeImmutable('now', new DateTimeZone('Z')), null,
             new PromiseSequence(rejection_for('Annotation content should not be unwrapped'))
         );
         $withOut = new Annotation('id1', 'public', new AnnotationDocument('title', 'http://example.com'), new EmptySequence(), null, new DateTimeImmutable('now', new DateTimeZone('Z')), null,
             new PromiseSequence(rejection_for('Annotation content should not be unwrapped'))
         );
 
-        $this->assertSame($parents, $with->getParents()->toArray());
-        $this->assertTrue($withOut->getParents()->isEmpty());
-        $this->assertEmpty($withOut->getParents()->toArray());
+        $this->assertSame($ancestors, $with->getancestors()->toArray());
+        $this->assertTrue($withOut->getancestors()->isEmpty());
+        $this->assertEmpty($withOut->getancestors()->toArray());
     }
 
     /**
@@ -111,7 +111,7 @@ final class AnnotationTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_a_created_date()
     {
-        $annotation = new Annotation('id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation parents should not be unwrapped')), null, $date = new DateTimeImmutable('now', new DateTimeZone('Z')), null,
+        $annotation = new Annotation('id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation ancestors should not be unwrapped')), null, $date = new DateTimeImmutable('now', new DateTimeZone('Z')), null,
             new PromiseSequence(rejection_for('Annotation content should not be unwrapped'))
         );
 
@@ -124,10 +124,10 @@ final class AnnotationTest extends PHPUnit_Framework_TestCase
      */
     public function it_may_have_an_updated_date()
     {
-        $with = new Annotation('id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation parents should not be unwrapped')), null, new DateTimeImmutable('now', new DateTimeZone('Z')), $date = new DateTimeImmutable('now', new DateTimeZone('Z')),
+        $with = new Annotation('id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation ancestors should not be unwrapped')), null, new DateTimeImmutable('now', new DateTimeZone('Z')), $date = new DateTimeImmutable('now', new DateTimeZone('Z')),
             new PromiseSequence(rejection_for('Annotation content should not be unwrapped'))
         );
-        $withOut = new Annotation('id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation parents should not be unwrapped')), null, new DateTimeImmutable('now', new DateTimeZone('Z')), null,
+        $withOut = new Annotation('id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation ancestors should not be unwrapped')), null, new DateTimeImmutable('now', new DateTimeZone('Z')), null,
             new PromiseSequence(rejection_for('Annotation content should not be unwrapped'))
         );
 
@@ -141,10 +141,10 @@ final class AnnotationTest extends PHPUnit_Framework_TestCase
      */
     public function it_may_have_a_highlight()
     {
-        $with = new Annotation('id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation parents should not be unwrapped')), $highlight = 'Highlighted text', new DateTimeImmutable('now', new DateTimeZone('Z')), null,
+        $with = new Annotation('id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation ancestors should not be unwrapped')), $highlight = 'Highlighted text', new DateTimeImmutable('now', new DateTimeZone('Z')), null,
             new PromiseSequence(rejection_for('Annotation content should not be unwrapped'))
         );
-        $withOut = new Annotation('id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation parents should not be unwrapped')), null, new DateTimeImmutable('now', new DateTimeZone('Z')), null,
+        $withOut = new Annotation('id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation ancestors should not be unwrapped')), null, new DateTimeImmutable('now', new DateTimeZone('Z')), null,
             new PromiseSequence(rejection_for('Annotation content should not be unwrapped'))
         );
 
@@ -162,10 +162,10 @@ final class AnnotationTest extends PHPUnit_Framework_TestCase
             new Block\YouTube('foo', 300, 200),
         ];
 
-        $with = new Annotation('id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation parents should not be unwrapped')), null, new DateTimeImmutable('now', new DateTimeZone('Z')), null,
+        $with = new Annotation('id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation ancestors should not be unwrapped')), null, new DateTimeImmutable('now', new DateTimeZone('Z')), null,
             new ArraySequence($content)
         );
-        $withOut = new Annotation('id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation parents should not be unwrapped')), null, new DateTimeImmutable('now', new DateTimeZone('Z')), null,
+        $withOut = new Annotation('id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation ancestors should not be unwrapped')), null, new DateTimeImmutable('now', new DateTimeZone('Z')), null,
             new EmptySequence()
         );
 

--- a/test/Serializer/AnnotationNormalizerTest.php
+++ b/test/Serializer/AnnotationNormalizerTest.php
@@ -53,7 +53,7 @@ final class AnnotationNormalizerTest extends ApiTestCase
 
     public function canNormalizeProvider() : array
     {
-        $annotation = new Annotation('id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation parents should not be unwrapped')), 'Highlighted text', new DateTimeImmutable('now', new DateTimeZone('Z')), null,
+        $annotation = new Annotation('id', 'public', new AnnotationDocument('title', 'http://example.com'), new PromiseSequence(rejection_for('Annotation ancestors should not be unwrapped')), 'Highlighted text', new DateTimeImmutable('now', new DateTimeZone('Z')), null,
             new PromiseSequence(rejection_for('Annotation content should not be unwrapped'))
         );
 
@@ -134,7 +134,7 @@ final class AnnotationNormalizerTest extends ApiTestCase
                         'title' => 'Document title',
                         'uri' => 'http://example.com',
                     ],
-                    'parents' => [
+                    'ancestors' => [
                         'id2',
                     ],
                     'highlight' => 'Highlighted text',
@@ -159,7 +159,7 @@ final class AnnotationNormalizerTest extends ApiTestCase
                         'title' => 'Document title',
                         'uri' => 'http://example.com',
                     ],
-                    'parents' => [
+                    'ancestors' => [
                         'id2',
                     ],
                     'created' => $created->format(ApiSdk::DATE_FORMAT),
@@ -183,7 +183,7 @@ final class AnnotationNormalizerTest extends ApiTestCase
                         'title' => 'Document title',
                         'uri' => 'http://example.com',
                     ],
-                    'parents' => [
+                    'ancestors' => [
                         'id2',
                     ],
                     'highlight' => 'Highlighted text',


### PR DESCRIPTION
Haven't provided a BC layer on `Annotation::getParents()` since it's an experimental API (and is only used in one place).