### PR TITLE
bumps symfony/serializer to also support ^4.2.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "elife/api-client": "^1.0@dev",
         "guzzlehttp/promises": "^1.0",
         "ocramius/package-versions": "^1.1",
-        "symfony/serializer": "^2.8.2 || ^3.0.2"
+        "symfony/serializer": "^2.8.2 || ^3.0.2 || ^4.2.12"
     },
     "require-dev": {
         "csa/guzzle-cache-middleware": "^1.0",


### PR DESCRIPTION
* this allows symfony 4.x versions to installed by dependents, like `journal` 
* re https://github.com/elifesciences/issues/issues/5265