### PR TITLE
removes '/test' from .gitattributes file.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,3 @@
 /build export-ignore
 /Jenkinsfile* export-ignore
 /scripts export-ignore
-/test export-ignore

--- a/src/Serializer/PressPackageNormalizer.php
+++ b/src/Serializer/PressPackageNormalizer.php
@@ -71,7 +71,7 @@ final class PressPackageNormalizer implements NormalizerInterface, DenormalizerI
 
             $data['image']['social'] = $article
                 ->then(function (Result $article) {
-                    return $article['image']['social'];
+                    return $article['image']['social'] ?? null;
                 });
         } else {
             $data['content'] = new ArraySequence($data['content']);


### PR DESCRIPTION
the 'search' project is referencing the api-sdk tests for some reason here:
https://github.com/elifesciences/search/blob/41ccd96bc3d4fee097c8d70f3b065ddf6f5a02ff/tests/bootstrap#L10-L24

Scott Aubrey narrowed the culprit to the test files not being present in the zipfile download from Github, however I'm not sure if that is the actual problem or not. It could be Composer decided to download the zip from github rather than do a git clone, I can't find information to either effect.

Ticket here: https://github.com/elifesciences/search/blob/41ccd96bc3d4fee097c8d70f3b065ddf6f5a02ff/tests/bootstrap#L10-L24