### PR TITLE
Endpoint for citation metrics by version DOI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "csa/guzzle-cache-middleware": "^1.0",
-        "elife/api": "2.31.3",
+        "elife/api": "^2.33",
         "elife/api-validator": "^1.0",
         "guzzlehttp/guzzle": "^6.0",
         "justinrainbow/json-schema": "^3.0 || ^4.0 || ^5.0",

--- a/spec/ApiClient/MetricsClientSpec.php
+++ b/spec/ApiClient/MetricsClientSpec.php
@@ -34,6 +34,19 @@ final class MetricsClientSpec extends ObjectBehavior
             ->shouldBeLike($response);
     }
 
+    public function it_gets_version_citations()
+    {
+        $request = new Request('GET', 'metrics/article/01234/citations/version/1',
+            ['X-Foo' => 'bar', 'Accept' => 'application/vnd.elife.metric-citations+json; version=2', 'User-Agent' => 'eLifeApiClient/'.Version::get()]);
+        $response = new FulfilledPromise(new ArrayResult(new MediaType('application/vnd.elife.metric-citations+json',
+            2), ['foo' => ['bar', 'baz']]));
+
+        $this->httpClient->send($request)->willReturn($response);
+
+        $this->versionCitations(['Accept' => 'application/vnd.elife.metric-citations+json; version=2'], 'article', '01234', 1)
+            ->shouldBeLike($response);
+    }
+
     public function it_gets_downloads()
     {
         $request = new Request('GET', 'metrics/article/01234/downloads?by=month&page=1&per-page=20&order=desc',

--- a/src/ApiClient/MetricsClient.php
+++ b/src/ApiClient/MetricsClient.php
@@ -17,6 +17,11 @@ class MetricsClient
         return $this->getRequest($this->createUri(['path' => "metrics/$type/$id/citations"]), $headers);
     }
 
+    public function versionCitations(array $headers, string $type, string $id, int $version) : PromiseInterface
+    {
+        return $this->getRequest($this->createUri(['path' => "metrics/$type/$id/citations/version/$version"]), $headers);
+    }
+
     public function downloads(
         array $headers,
         string $type,

--- a/src/Client/Metrics.php
+++ b/src/Client/Metrics.php
@@ -41,6 +41,26 @@ final class Metrics
             });
     }
 
+    public function versionCitations(Identifier $identifier, int $version) : PromiseInterface
+    {
+        return $this->metricsClient
+            ->versionCitations(
+                ['Accept' => (string) new MediaType(MetricsClient::TYPE_METRIC_CITATIONS, self::VERSION_METRIC_CITATIONS)],
+                $identifier->getType(),
+                $identifier->getId(),
+                $version
+            )
+            ->then(function (Result $result) {
+                $sources = [];
+
+                foreach ($result as $source) {
+                    $sources[] = new CitationsMetricSource($source['service'], $source['uri'], $source['citations']);
+                }
+
+                return new CitationsMetric(...$sources);
+            });
+    }
+
     public function totalPageViews(Identifier $identifier) : PromiseInterface
     {
         return $this->metricsClient

--- a/test/ApiTestCase.php
+++ b/test/ApiTestCase.php
@@ -767,6 +767,28 @@ abstract class ApiTestCase extends TestCase
         );
     }
 
+    final protected function mockMetricVersionCitationsCall(string $type, string $id, string $version)
+    {
+        $this->storage->save(
+            new Request(
+                'GET',
+                'http://api.elifesciences.org/metrics/'.$type.'/'.$id.'/citations/version/'.$version,
+                ['Accept' => (string) new MediaType(MetricsClient::TYPE_METRIC_CITATIONS, 1)]
+            ),
+            new Response(
+                200,
+                ['Content-Type' => (string) new MediaType(MetricsClient::TYPE_METRIC_CITATIONS, 1)],
+                json_encode([
+                    [
+                        'service' => 'Service',
+                        'uri' => 'http://www.example.com/',
+                        'citations' => (int) $id,
+                    ],
+                ])
+            )
+        );
+    }
+
     final protected function mockMetricDownloadsCall(string $type, string $id)
     {
         $this->storage->save(

--- a/test/Client/MetricsTest.php
+++ b/test/Client/MetricsTest.php
@@ -37,6 +37,18 @@ final class MetricsTest extends ApiTestCase
     /**
      * @test
      */
+    public function it_gets_version_citations()
+    {
+        $this->mockMetricVersionCitationsCall('article', '09560', 1);
+
+        $expected = new CitationsMetric(new CitationsMetricSource('Service', 'http://www.example.com/', 9560));
+
+        $this->assertEquals($expected, $this->metrics->versionCitations(Identifier::article('09560'), 1)->wait());
+    }
+
+    /**
+     * @test
+     */
     public function it_gets_total_page_views()
     {
         $this->mockMetricPageViewsCall('article', '09560');


### PR DESCRIPTION
This seems to work, though it's entirely possible I've missed a part or I have something wrong.

Note that both endpoints - metrics by concept DOI, or metrics by version DOI - return the same type of data in the response, and this is reflected in the code and tests for the new endpoint.

Re issue https://github.com/elifesciences/enhanced-preprints-issues/issues/1053